### PR TITLE
[feat] ERD 기반 전체 도메인 엔티티 설정

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/chapter/entity/Chapter.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/entity/Chapter.java
@@ -1,0 +1,38 @@
+package com.umc.halo.domain.content.chapter.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chapter")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chapter {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chapter_id")
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(name = "image_url", length = 255, nullable = false)
+    private String imageUrl;
+
+    @Column(length = 255)
+    private String guid;
+
+    @Column(name = "short_description", length = 255, nullable = false)
+    private String shortDescription;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/content/chapter/entity/ChapterQuestion.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/entity/ChapterQuestion.java
@@ -1,0 +1,33 @@
+package com.umc.halo.domain.content.chapter.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chapter_question")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChapterQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chapter_question_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chapter_id", nullable = false)
+    private Chapter chapter;
+
+    @Column(name = "question_order", nullable = false)
+    private Integer questionOrder;
+
+    @Column(length = 255, nullable = false)
+    private String question;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/content/scenecard/entity/SceneCard.java
+++ b/src/main/java/com/umc/halo/domain/content/scenecard/entity/SceneCard.java
@@ -1,0 +1,31 @@
+package com.umc.halo.domain.content.scenecard.entity;
+
+import com.umc.halo.domain.content.chapter.entity.Chapter;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "scene_card")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SceneCard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "scene_card_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chapter_id", nullable = false)
+    private Chapter chapter;
+
+    @Column(name = "image_url", length = 255, nullable = false)
+    private String imageUrl;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/Storybook.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/Storybook.java
@@ -1,0 +1,49 @@
+package com.umc.halo.domain.content.storybook.entity;
+
+import com.umc.halo.domain.tag.entity.Tag;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "storybook")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Storybook {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "storybook_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(name = "theme_order", nullable = false)
+    private Integer themeOrder;
+
+    @Column(name = "short_description", length = 255, nullable = false)
+    private String shortDescription;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(length = 255)
+    private String summary;
+
+    @Column(name = "image_url", length = 255, nullable = false)
+    private String imageUrl;
+
+    @Column(name = "character_image_url", length = 255)
+    private String characterImageUrl;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookChapter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookChapter.java
@@ -1,0 +1,35 @@
+package com.umc.halo.domain.content.storybook.entity;
+
+import com.umc.halo.domain.content.chapter.entity.Chapter;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "storybook_chapter")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StorybookChapter {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "storybook_chapter_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storybook_id", nullable = false)
+    private Storybook storybook;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chapter_id", nullable = false)
+    private Chapter chapter;
+
+    @Column(name = "chapter_order", nullable = false)
+    private Integer chapterOrder;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -1,0 +1,49 @@
+package com.umc.halo.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(name = "guest_uuid", length = 36)
+    private String guestUuid;
+
+    @Column(length = 10)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @Column(name = "provider_id", length = 255)
+    private String providerId;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "age_group")
+    private AgeGroup ageGroup;
+
+    @Column(name = "onboarding_completed", nullable = false)
+    private Boolean onboardingCompleted = false;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum Provider { GOOGLE, KAKAO }
+    public enum Gender { MALE, FEMALE }
+    public enum AgeGroup { TEENS, TWENTIES, THIRTIES, FORTIES, FIFTIES_PLUS }
+}

--- a/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
@@ -1,0 +1,53 @@
+package com.umc.halo.domain.notification.entity;
+
+import com.umc.halo.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "anniversary")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Anniversary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "anniversary_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(length = 20, nullable = false)
+    private String title;
+
+    @Column(name = "anniversary_date", nullable = false)
+    private LocalDate anniversaryDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Target target;
+
+    @Column(name = "is_repeated", nullable = false)
+    private Boolean isRepeated = true;
+
+    @Column(name = "seven_days_alarm_enabled", nullable = false)
+    private Boolean sevenDaysAlarmEnabled = true;
+
+    @Column(name = "day_alarm_enabled", nullable = false)
+    private Boolean dayAlarmEnabled = true;
+
+    @Column(length = 255)
+    private String memo;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum Target { MOTHER, FATHER, FAMILY }
+}

--- a/src/main/java/com/umc/halo/domain/notification/entity/CommonAnniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/CommonAnniversary.java
@@ -1,0 +1,41 @@
+package com.umc.halo.domain.notification.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "common_anniversary")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommonAnniversary {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "common_anniversary_id")
+    private Long id;
+
+    @Column(length = 20, nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private Integer month;
+
+    @Column(nullable = false)
+    private Integer day;
+
+    @Column(name = "is_lunar", nullable = false)
+    private Boolean isLunar = false;
+
+    @Column(name = "seven_days_alarm_enabled", nullable = false)
+    private Boolean sevenDaysAlarmEnabled = true;
+
+    @Column(name = "day_alarm_enabled", nullable = false)
+    private Boolean dayAlarmEnabled = true;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
@@ -1,0 +1,46 @@
+package com.umc.halo.domain.notification.entity;
+
+import com.umc.halo.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "notification_type", nullable = false)
+    private NotificationType notificationType;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(length = 255, nullable = false)
+    private String message;
+
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt;
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum NotificationType { ANNIVERSARY_D7, ANNIVERSARY_DDAY, TODAY_CHAPTER, RETENTION }
+}

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberChapter.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberChapter.java
@@ -1,0 +1,66 @@
+package com.umc.halo.domain.record.entity;
+
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.content.storybook.entity.StorybookChapter;
+import com.umc.halo.domain.content.scenecard.entity.SceneCard;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member_chapter")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberChapter {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_chapter_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storybook_chapter_id", nullable = false)
+    private StorybookChapter storybookChapter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scene_card_id")
+    private SceneCard sceneCard;
+
+    @Enumerated(EnumType.STRING)
+    private Emotion emotion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cover_type", nullable = false)
+    private CoverType coverType;
+
+    @Column(name = "image_url", length = 255)
+    private String imageUrl;
+
+    @Column(name = "image_key", length = 255)
+    private String imageKey;
+
+    @Column(name = "completed_date")
+    private LocalDate completedDate;
+
+    @Column(columnDefinition = "TEXT")
+    private String summary;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Status status;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum Emotion { CURIOUS, WARM, TOUCHED, AWKWARD, CLOSER }
+    public enum CoverType { SCENE_CARD, IMAGE }
+    public enum Status { DRAFT, COMPLETED }
+}

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberChapterAnswer.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberChapterAnswer.java
@@ -1,0 +1,35 @@
+package com.umc.halo.domain.record.entity;
+
+import com.umc.halo.domain.content.chapter.entity.ChapterQuestion;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member_chapter_answer")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberChapterAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_chapter_answer_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_chapter_id", nullable = false)
+    private MemberChapter memberChapter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chapter_question_id", nullable = false)
+    private ChapterQuestion chapterQuestion;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String answer;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
@@ -1,0 +1,40 @@
+package com.umc.halo.domain.record.entity;
+
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.content.storybook.entity.Storybook;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member_storybook")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberStorybook {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_storybook_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storybook_id", nullable = false)
+    private Storybook storybook;
+
+    @Column(name = "last_chapter_order", nullable = false)
+    private Integer lastChapterOrder;
+
+    @Column(name = "last_completed_date")
+    private LocalDate lastCompletedDate;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/setting/entity/Bgm.java
+++ b/src/main/java/com/umc/halo/domain/setting/entity/Bgm.java
@@ -1,0 +1,32 @@
+package com.umc.halo.domain.setting.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "bgm")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bgm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bgm_id")
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(name = "audio_url", length = 255, nullable = false)
+    private String audioUrl;
+
+    @Column(name = "image_url", length = 255)
+    private String imageUrl;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/setting/entity/MemberSetting.java
+++ b/src/main/java/com/umc/halo/domain/setting/entity/MemberSetting.java
@@ -1,0 +1,54 @@
+package com.umc.halo.domain.setting.entity;
+
+import com.umc.halo.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "member_setting")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_setting_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bgm_id")
+    private Bgm bgm;
+
+    @Column(name = "bgm_enabled", nullable = false)
+    private Boolean bgmEnabled = true;
+
+    @Column(name = "bgm_volume", nullable = false)
+    private Integer bgmVolume = 100;
+
+    @Column(name = "regular_notification_enabled", nullable = false)
+    private Boolean regularNotificationEnabled = true;
+
+    @Column(name = "regular_notification_time")
+    private LocalTime regularNotificationTime;
+
+    @Column(name = "today_chapter_notification_enabled", nullable = false)
+    private Boolean todayChapterNotificationEnabled = true;
+
+    @Column(name = "retention_notification_enabled", nullable = false)
+    private Boolean retentionNotificationEnabled = true;
+
+    @Column(name = "anniversary_notification_enabled", nullable = false)
+    private Boolean anniversaryNotificationEnabled = true;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/tag/entity/MemberTag.java
+++ b/src/main/java/com/umc/halo/domain/tag/entity/MemberTag.java
@@ -1,0 +1,32 @@
+package com.umc.halo.domain.tag.entity;
+
+import com.umc.halo.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member_tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id", nullable = false)
+    private Tag tag;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/tag/entity/Tag.java
+++ b/src/main/java/com/umc/halo/domain/tag/entity/Tag.java
@@ -1,0 +1,39 @@
+package com.umc.halo.domain.tag.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "tag_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @Column(length = 20, nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private Subtitle subtitle;
+
+    @Column(length = 255)
+    private String description;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public enum Category { PARENT_TENDENCY, CURRENT_RELATIONSHIP, DESIRED_DIRECTION, COMMUNICATION_LEVEL }
+    public enum Subtitle { /* 세부값 확정되면 채우기 */ }
+}

--- a/src/main/java/com/umc/halo/domain/term/entity/MemberTerm.java
+++ b/src/main/java/com/umc/halo/domain/term/entity/MemberTerm.java
@@ -1,0 +1,35 @@
+package com.umc.halo.domain.term.entity;
+
+import com.umc.halo.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member_term")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTerm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_term_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id", nullable = false)
+    private Term term;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "is_agreed", nullable = false)
+    private Boolean isAgreed = true;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/halo/domain/term/entity/Term.java
+++ b/src/main/java/com/umc/halo/domain/term/entity/Term.java
@@ -1,0 +1,35 @@
+package com.umc.halo.domain.term.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "term")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Term {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "term_id")
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(name = "short_description", length = 100, nullable = false)
+    private String shortDescription;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(name = "is_required", nullable = false)
+    private Boolean isRequired = true;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
* 현재 ERD 기준으로 전체 도메인 엔티티를 설정합니다.
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
* member, term, member_term 엔티티
* tag, member_tag 엔티티
* storybook, storybook_chapter 엔티티
* chapter, chapter_question 엔티티
* scene_card 엔티티
* member_storybook, member_chapter, member_chapter_answer 엔티티
* notification, anniversary, common_anniversary 엔티티
* member_setting, bgm 엔티티
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
* 엔티티 설정 단계로, API 구현 시 함께 확인 예정
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [ ] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #3
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for chapters, chapter questions, scene cards, storybooks, tags, terms, background music, notifications, anniversaries, and member-specific settings.
  * Introduced member progress and record tracking for storybooks and chapters, including answers, completion state, and saved content.
  * Added member profile and preference data such as provider, gender, age group, onboarding status, and notification/music settings.
  * Added reusable content for anniversaries, notifications, and term agreements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->