### PR TITLE
[feat] Swagger 및 Spring Security 기반 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,17 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // Swagger (springdoc-openapi) - Spring Boot 4 계열
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
+
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/halo/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/halo/global/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.umc.halo.global.config;
 
+import com.umc.halo.global.security.JwtAccessDeniedHandler;
 import com.umc.halo.global.security.JwtAuthFilter;
+import com.umc.halo.global.security.JwtAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +18,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     // 인증 없이 접근 가능한 경로(Public)
     private static final String[] PUBLIC_URIS = {
@@ -47,11 +51,13 @@ public class SecurityConfig {
                         // 그 외 전부 인증 필요(Private)
                         .anyRequest().authenticated()
                 )
-                // JWT 인증 필터를 스프링 기본 인증 필터 앞에 등록
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
-        // 인증/인가 실패 응답통일(EntryPoint/AccessDeniedHandler) 등록
-        //   → #1 머지 후 추가 예정
+        // 인증/인가 실패 시 공통 응답 포맷으로 반환
+                .exceptionHandling(ex -> ex
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+        )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/umc/halo/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/halo/global/config/SecurityConfig.java
@@ -1,0 +1,58 @@
+package com.umc.halo.global.config;
+
+import com.umc.halo.global.security.JwtAuthFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
+
+    // 인증 없이 접근 가능한 경로(Public)
+    private static final String[] PUBLIC_URIS = {
+            // Swagger
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            // 인증(소셜 로그인 / 토큰 재발급)
+            "/api/v1/auth/**",
+            // 온보딩 (로그인 전 guest_uuid 기반)
+            "/api/v1/onboarding/**"
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // 토큰(JWT) 기반이라 세션 안 씀
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 폼 로그인/기본 인증 안 씀 (소셜 로그인 전용)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // 토큰 기반이라 csrf 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                // 경로별 접근 제어
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PUBLIC_URIS).permitAll()
+                        // 약관 목록 조회(GET /api/v1/terms)는 Public
+                        .requestMatchers(HttpMethod.GET, "/api/v1/terms").permitAll()
+                        // 그 외 전부 인증 필요(Private)
+                        .anyRequest().authenticated()
+                )
+                // JWT 인증 필터를 스프링 기본 인증 필터 앞에 등록
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        // 인증/인가 실패 응답통일(EntryPoint/AccessDeniedHandler) 등록
+        //   → #1 머지 후 추가 예정
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/umc/halo/global/config/SwaggerConfig.java
+++ b/src/main/java/com/umc/halo/global/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.umc.halo.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI haloOpenAPI() {
+        Info info = new Info()
+                .title("HALO API")
+                .description("HALO 서버 API 문서")
+                .version("v1");
+
+        // JWT Bearer 인증 스키마 (Swagger UI의 Authorize 버튼에서 accessToken 입력용)
+        String jwtSchemeName = "JWT";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .info(info)
+                .addServersItem(new Server().url("/"))
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/com/umc/halo/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAccessDeniedHandler.java
@@ -17,14 +17,6 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
-        GeneralErrorCode errorCode = GeneralErrorCode.FORBIDDEN;
-        response.setStatus(errorCode.getStatus().value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-
-        String body = String.format(
-                "{\"isSuccess\": false, \"code\": \"%s\", \"message\": \"%s\", \"result\": null}",
-                errorCode.getCode(), errorCode.getMessage());
-        response.getWriter().write(body);
+        SecurityResponseWriter.write(response, GeneralErrorCode.FORBIDDEN);
     }
 }

--- a/src/main/java/com/umc/halo/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.umc.halo.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        GeneralErrorCode errorCode = GeneralErrorCode.FORBIDDEN;
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(
+                objectMapper.writeValueAsString(ApiResponse.onFailure(errorCode, null)));
+    }
+}

--- a/src/main/java/com/umc/halo/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAccessDeniedHandler.java
@@ -1,11 +1,8 @@
 package com.umc.halo.global.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.halo.global.apiPayload.ApiResponse;
 import com.umc.halo.global.apiPayload.code.GeneralErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -15,10 +12,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 @Component
-@RequiredArgsConstructor
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
-
-    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
@@ -27,7 +21,10 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         response.setStatus(errorCode.getStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.getWriter().write(
-                objectMapper.writeValueAsString(ApiResponse.onFailure(errorCode, null)));
+
+        String body = String.format(
+                "{\"isSuccess\": false, \"code\": \"%s\", \"message\": \"%s\", \"result\": null}",
+                errorCode.getCode(), errorCode.getMessage());
+        response.getWriter().write(body);
     }
 }

--- a/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
@@ -41,9 +41,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             Long memberId = jwtUtil.getMemberId(token);
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(
-                            memberId,               // principal = memberId (#3 머지 후 수정예정!)
+                            memberId,               // principal = memberId (현재는 memberId만 사용 (MemberRepository 생기면 회원 조회로 수정 예정)
                             null,
-                            Collections.emptyList() // 권한 목록 (#1 머지 후 수정예정!)
+                            Collections.emptyList() // 권한 목록 (role 구분 없어 현재 비움)
                     );
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
@@ -1,0 +1,54 @@
+package com.umc.halo.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        // 토큰이 없거나 Bearer 형식이 아니면: 인증 세팅 없이 다음 필터로 넘김
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.substring(7); // "Bearer " 제거
+
+        // 유효한 토큰이면 인증 객체를 만들어 SecurityContext에 저장
+        if (jwtUtil.isValid(token)) {
+            Long memberId = jwtUtil.getMemberId(token);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            memberId,               // principal = memberId (#3 머지 후 수정예정!)
+                            null,
+                            Collections.emptyList() // 권한 목록 (#1 머지 후 수정예정!)
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        // 토큰이 유효하지 않아도 여기선 에러 응답 안 만듦 → Private면 뒤에서 차단됨
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/umc/halo/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAuthenticationEntryPoint.java
@@ -17,14 +17,6 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
-        GeneralErrorCode errorCode = GeneralErrorCode.UNAUTHORIZED;
-        response.setStatus(errorCode.getStatus().value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-
-        String body = String.format(
-                "{\"isSuccess\": false, \"code\": \"%s\", \"message\": \"%s\", \"result\": null}",
-                errorCode.getCode(), errorCode.getMessage());
-        response.getWriter().write(body);
+        SecurityResponseWriter.write(response, GeneralErrorCode.UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/umc/halo/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.umc.halo.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        GeneralErrorCode errorCode = GeneralErrorCode.UNAUTHORIZED;
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(
+                objectMapper.writeValueAsString(ApiResponse.onFailure(errorCode, null)));
+    }
+}

--- a/src/main/java/com/umc/halo/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAuthenticationEntryPoint.java
@@ -1,11 +1,8 @@
 package com.umc.halo.global.security;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.halo.global.apiPayload.ApiResponse;
 import com.umc.halo.global.apiPayload.code.GeneralErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -15,10 +12,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 @Component
-@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
-
-    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
@@ -27,7 +21,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setStatus(errorCode.getStatus().value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.getWriter().write(
-                objectMapper.writeValueAsString(ApiResponse.onFailure(errorCode, null)));
+
+        String body = String.format(
+                "{\"isSuccess\": false, \"code\": \"%s\", \"message\": \"%s\", \"result\": null}",
+                errorCode.getCode(), errorCode.getMessage());
+        response.getWriter().write(body);
     }
 }

--- a/src/main/java/com/umc/halo/global/security/JwtUtil.java
+++ b/src/main/java/com/umc/halo/global/security/JwtUtil.java
@@ -1,0 +1,63 @@
+package com.umc.halo.global.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final Duration accessExpiration;
+
+    public JwtUtil(
+            @Value("${jwt.token.secretKey}") String secret,
+            @Value("${jwt.token.expiration.access}") Long accessExpiration
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessExpiration = Duration.ofMillis(accessExpiration);
+    }
+
+    // accessToken 생성: subject(sub)에 memberId를 담음
+    public String createAccessToken(Long memberId) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(accessExpiration)))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // 토큰에서 memberId 추출
+    public Long getMemberId(String token) {
+        return Long.valueOf(getClaims(token).getSubject());
+    }
+
+    // 토큰 유효성(서명·만료) 검증
+    public boolean isValid(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/umc/halo/global/security/SecurityResponseWriter.java
+++ b/src/main/java/com/umc/halo/global/security/SecurityResponseWriter.java
@@ -1,0 +1,28 @@
+package com.umc.halo.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+// 인증/인가 실패 응답을 공통 포맷(ApiResponse)으로 작성
+public final class SecurityResponseWriter {
+
+    // Spring 빈 주입 대신 로컬 static 인스턴스 사용
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private SecurityResponseWriter() {}
+
+    public static void write(HttpServletResponse response, GeneralErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+
+        ApiResponse<Void> body = ApiResponse.onFailure(errorCode, null);
+        response.getWriter().write(OBJECT_MAPPER.writeValueAsString(body));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,3 +23,9 @@ logging:
     root: info
     org.hibernate.SQL: !!str debug
     org.hibernate.orm.jdbc.bind: trace
+
+jwt:
+  token:
+    secretKey: ${JWT_SECRET_KEY}
+    expiration:
+      access: 3600000   # 1시간 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,6 @@ logging:
   level:
     root: info
     org.hibernate.SQL: !!str debug
-    org.hibernate.orm.jdbc.bind: trace
 
 jwt:
   token:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,4 +28,4 @@ jwt:
   token:
     secretKey: ${JWT_SECRET_KEY}
     expiration:
-      access: 3600000   # 1시간 
+      access: 3600000   # 1시간


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- Swagger와 Spring Security 셋팅하였습니다.

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- **의존성 추가**: Swagger, Spring Security, JWT
- **SwaggerConfig**: API 문서 + JWT 인증 버튼(Authorize)
- **SecurityConfig**: 토큰 기반 설정 + Public/Private 경로 구분 + 인증 실패 응답 통일
- **JWT**: 토큰 검증 유틸(JwtUtil) + 인증 필터(JwtAuthFilter)

[Public] 로그인 / 토큰 재발급 / 온보딩 / 약관 목록 / Swagger
[Private] 로그아웃 / 탈퇴 / 내 정보 / 관계 정보 / 약관 동의

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
-  서버 정상 기동 및 로컬 DB 연동 확인
- Swagger UI 정상 표시 확인: `localhost:8080/swagger-ui/index.html` (HALO API v1 / Authorize 버튼 노출)

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #5
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- JWT 인증 필터는 현재 토큰의 memberId만 사용. 회원 조회는 MemberRepository 생성 후 반영 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swagger UI(OpenAPI)로 API 문서를 제공하며, Bearer JWT 인증 설정 후 웹에서 바로 테스트할 수 있습니다.
  * JWT 기반 인증/보안이 적용되어 보호된 기능은 토큰 기반으로만 접근할 수 있게 변경되었습니다.
* **Bug Fixes**
  * 인증/인가 실패 시 표준화된 JSON 오류 응답으로 일관되게 반환됩니다.
  * Swagger, 인증 관련 및 온보딩 등 일부 경로는 인증 없이도 접근 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->