### PR TITLE
[feat] 로컬 시드 데이터 생성

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/chapter/entity/Chapter.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/entity/Chapter.java
@@ -8,6 +8,8 @@ import lombok.*;
 @Table(name = "chapter")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Chapter extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/content/chapter/entity/ChapterQuestion.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/entity/ChapterQuestion.java
@@ -1,6 +1,6 @@
 package com.umc.halo.domain.content.chapter.entity;
 
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,6 +8,8 @@ import lombok.*;
 @Table(name = "chapter_question")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChapterQuestion extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/content/chapter/entity/SceneCard.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/entity/SceneCard.java
@@ -1,6 +1,6 @@
 package com.umc.halo.domain.content.chapter.entity;
 
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,6 +8,8 @@ import lombok.*;
 @Table(name = "scene_card")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SceneCard extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/content/chapter/entity/SceneCard.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/entity/SceneCard.java
@@ -1,6 +1,5 @@
-package com.umc.halo.domain.content.scenecard.entity;
+package com.umc.halo.domain.content.chapter.entity;
 
-import com.umc.halo.domain.content.chapter.entity.Chapter;
 import com.umc.halo.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/umc/halo/domain/content/chapter/repository/ChapterQuestionRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/repository/ChapterQuestionRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.content.chapter.repository;
+
+import com.umc.halo.domain.content.chapter.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface ChapterQuestionRepository extends JpaRepository<ChapterQuestion, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/content/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/repository/ChapterRepository.java
@@ -4,6 +4,9 @@ import com.umc.halo.domain.content.chapter.entity.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
 
+import java.util.*;
+
 @Repository
 public interface ChapterRepository extends JpaRepository<Chapter, Long> {
+    List<Chapter> findAllByOrderByIdAsc();
 }

--- a/src/main/java/com/umc/halo/domain/content/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/repository/ChapterRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.content.chapter.repository;
+
+import com.umc.halo.domain.content.chapter.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface ChapterRepository extends JpaRepository<Chapter, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/content/chapter/repository/SceneCardRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/repository/SceneCardRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.content.chapter.repository;
+
+import com.umc.halo.domain.content.chapter.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface SceneCardRepository extends JpaRepository<SceneCard, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/Storybook.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/Storybook.java
@@ -8,6 +8,8 @@ import lombok.*;
 @Table(name = "storybook")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Storybook extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookChapter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookChapter.java
@@ -1,7 +1,7 @@
 package com.umc.halo.domain.content.storybook.entity;
 
-import com.umc.halo.domain.content.chapter.entity.Chapter;
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.domain.content.chapter.entity.*;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,6 +9,8 @@ import lombok.*;
 @Table(name = "storybook_chapter")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class StorybookChapter extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
@@ -10,6 +10,8 @@ import lombok.*;
 @Table(name = "storybook_character")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class StorybookCharacter extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookChapterRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookChapterRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.content.storybook.repository;
+
+import com.umc.halo.domain.content.storybook.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface StorybookChapterRepository extends JpaRepository<StorybookChapter, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookCharacterRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookCharacterRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.content.storybook.repository;
+
+import com.umc.halo.domain.content.storybook.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface StorybookCharacterRepository extends JpaRepository<StorybookCharacter, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.content.storybook.repository;
+
+import com.umc.halo.domain.content.storybook.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface StorybookRepository extends JpaRepository<Storybook, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -1,7 +1,7 @@
 package com.umc.halo.domain.member.entity;
 
 import com.umc.halo.domain.member.enums.*;
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -16,7 +16,7 @@ import lombok.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Member extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.member.repository;
+
+import com.umc.halo.domain.member.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
@@ -1,18 +1,19 @@
 package com.umc.halo.domain.notification.entity;
 
-import com.umc.halo.domain.member.entity.Member;
-import com.umc.halo.domain.notification.enums.Target;
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.domain.notification.enums.*;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
-import java.time.LocalDate;
+
+import java.time.*;
 
 @Entity
 @Table(name = "anniversary")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Anniversary extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/notification/entity/CommonAnniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/CommonAnniversary.java
@@ -1,6 +1,6 @@
 package com.umc.halo.domain.notification.entity;
 
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,6 +8,8 @@ import lombok.*;
 @Table(name = "common_anniversary")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommonAnniversary extends BaseEntity {
 
     @Id
@@ -25,11 +27,14 @@ public class CommonAnniversary extends BaseEntity {
     private Integer day;
 
     @Column(name = "is_lunar", nullable = false)
+    @Builder.Default
     private Boolean isLunar = false;
 
     @Column(name = "seven_days_alarm_enabled", nullable = false)
+    @Builder.Default
     private Boolean sevenDaysAlarmEnabled = true;
 
     @Column(name = "day_alarm_enabled", nullable = false)
+    @Builder.Default
     private Boolean dayAlarmEnabled = true;
 }

--- a/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
@@ -1,7 +1,7 @@
 package com.umc.halo.domain.notification.entity;
 
 import com.umc.halo.domain.member.entity.*;
-import com.umc.halo.domain.notification.enums.NotificationType;
+import com.umc.halo.domain.notification.enums.*;
 import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,7 +13,7 @@ import java.time.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Notification extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/notification/repository/AnniversaryRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/AnniversaryRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.notification.repository;
+
+import com.umc.halo.domain.notification.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface AnniversaryRepository extends JpaRepository<Anniversary, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/notification/repository/CommonAnniversaryRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/CommonAnniversaryRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.notification.repository;
+
+import com.umc.halo.domain.notification.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface CommonAnniversaryRepository extends JpaRepository<CommonAnniversary, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.notification.repository;
+
+import com.umc.halo.domain.notification.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberChapter.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberChapter.java
@@ -1,6 +1,6 @@
 package com.umc.halo.domain.record.entity;
 
-import com.umc.halo.domain.content.scenecard.entity.*;
+import com.umc.halo.domain.content.chapter.entity.*;
 import com.umc.halo.domain.content.storybook.entity.*;
 import com.umc.halo.domain.member.entity.*;
 import com.umc.halo.domain.record.enums.*;

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberChapter.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberChapter.java
@@ -15,6 +15,8 @@ import java.time.*;
 @Table(name = "member_chapter")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberChapter extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberChapterAnswer.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberChapterAnswer.java
@@ -1,7 +1,7 @@
 package com.umc.halo.domain.record.entity;
 
-import com.umc.halo.domain.content.chapter.entity.ChapterQuestion;
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.domain.content.chapter.entity.*;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,6 +9,8 @@ import lombok.*;
 @Table(name = "member_chapter_answer")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberChapterAnswer extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
@@ -13,6 +13,8 @@ import java.time.*;
 @Table(name = "member_storybook")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberStorybook extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberChapterAnswerRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberChapterAnswerRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.record.repository;
+
+import com.umc.halo.domain.record.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface MemberChapterAnswerRepository extends JpaRepository<MemberChapterAnswer, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberChapterRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberChapterRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.record.repository;
+
+import com.umc.halo.domain.record.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface MemberChapterRepository extends JpaRepository<MemberChapter, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberStorybookRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberStorybookRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.record.repository;
+
+import com.umc.halo.domain.record.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface MemberStorybookRepository extends JpaRepository<MemberStorybook, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/setting/entity/Bgm.java
+++ b/src/main/java/com/umc/halo/domain/setting/entity/Bgm.java
@@ -1,6 +1,6 @@
 package com.umc.halo.domain.setting.entity;
 
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,6 +8,8 @@ import lombok.*;
 @Table(name = "bgm")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Bgm extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/setting/repository/BgmRepository.java
+++ b/src/main/java/com/umc/halo/domain/setting/repository/BgmRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.setting.repository;
+
+import com.umc.halo.domain.setting.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface BgmRepository extends JpaRepository<Bgm, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/setting/repository/MemberSettingRepository.java
+++ b/src/main/java/com/umc/halo/domain/setting/repository/MemberSettingRepository.java
@@ -1,0 +1,10 @@
+package com.umc.halo.domain.setting.repository;
+
+import com.umc.halo.domain.setting.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface MemberSettingRepository extends JpaRepository<MemberSetting, Long> {
+
+}

--- a/src/main/java/com/umc/halo/domain/tag/entity/MemberTag.java
+++ b/src/main/java/com/umc/halo/domain/tag/entity/MemberTag.java
@@ -1,7 +1,7 @@
 package com.umc.halo.domain.tag.entity;
 
-import com.umc.halo.domain.member.entity.Member;
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,7 +13,7 @@ import lombok.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberTag extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/tag/entity/StorybookTag.java
+++ b/src/main/java/com/umc/halo/domain/tag/entity/StorybookTag.java
@@ -17,6 +17,8 @@ import lombok.*;
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class StorybookTag extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/tag/entity/Tag.java
+++ b/src/main/java/com/umc/halo/domain/tag/entity/Tag.java
@@ -1,7 +1,7 @@
 package com.umc.halo.domain.tag.entity;
 
 import com.umc.halo.domain.tag.enums.*;
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,6 +9,8 @@ import lombok.*;
 @Table(name = "tag")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Tag extends BaseEntity {
 
     @Id

--- a/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
+++ b/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.tag.repository;
+
+import com.umc.halo.domain.tag.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface MemberTagRepository extends JpaRepository<MemberTag, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/tag/repository/StorybookTagRepository.java
+++ b/src/main/java/com/umc/halo/domain/tag/repository/StorybookTagRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.tag.repository;
+
+import com.umc.halo.domain.tag.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface StorybookTagRepository extends JpaRepository<StorybookTag, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/tag/repository/TagRepository.java
+++ b/src/main/java/com/umc/halo/domain/tag/repository/TagRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.tag.repository;
+
+import com.umc.halo.domain.tag.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/com/umc/halo/domain/term/entity/MemberTerm.java
+++ b/src/main/java/com/umc/halo/domain/term/entity/MemberTerm.java
@@ -1,7 +1,7 @@
 package com.umc.halo.domain.term.entity;
 
-import com.umc.halo.domain.member.entity.Member;
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,6 +9,8 @@ import lombok.*;
 @Table(name = "member_term")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberTerm extends BaseEntity {
 
     @Id
@@ -25,5 +27,6 @@ public class MemberTerm extends BaseEntity {
     private Member member;
 
     @Column(name = "is_agreed", nullable = false)
+    @Builder.Default
     private Boolean isAgreed = false;
 }

--- a/src/main/java/com/umc/halo/domain/term/entity/Term.java
+++ b/src/main/java/com/umc/halo/domain/term/entity/Term.java
@@ -1,6 +1,6 @@
 package com.umc.halo.domain.term.entity;
 
-import com.umc.halo.global.entity.BaseEntity;
+import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,6 +8,8 @@ import lombok.*;
 @Table(name = "term")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Term extends BaseEntity {
 
     @Id
@@ -25,5 +27,6 @@ public class Term extends BaseEntity {
     private String description;
 
     @Column(name = "is_required", nullable = false)
+    @Builder.Default
     private Boolean isRequired = true;
 }

--- a/src/main/java/com/umc/halo/domain/term/repository/MemberTermRepository.java
+++ b/src/main/java/com/umc/halo/domain/term/repository/MemberTermRepository.java
@@ -1,0 +1,10 @@
+package com.umc.halo.domain.term.repository;
+
+import com.umc.halo.domain.term.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
+
+}

--- a/src/main/java/com/umc/halo/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/umc/halo/domain/term/repository/TermRepository.java
@@ -1,0 +1,9 @@
+package com.umc.halo.domain.term.repository;
+
+import com.umc.halo.domain.term.entity.*;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.stereotype.*;
+
+@Repository
+public interface TermRepository extends JpaRepository<Term, Long> {
+}

--- a/src/main/java/com/umc/halo/global/seed/ChapterSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/ChapterSeeder.java
@@ -1,0 +1,150 @@
+package com.umc.halo.global.seed;
+
+import com.umc.halo.domain.content.chapter.entity.*;
+import com.umc.halo.domain.content.chapter.repository.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ChapterSeeder {
+    private final ChapterRepository chapterRepository;
+    private final ChapterQuestionRepository chapterQuestionRepository;
+    private final SceneCardRepository sceneCardRepository;
+
+    @Transactional
+    public List<Chapter> seedChapter() {
+        List<Chapter> chapters = List.of(
+                Chapter.builder()
+                        .title("나와 같은 나이였던 시절")
+                        .imageUrl("https://example.com/chapter1.png")
+                        .guid("부모님이 지금 내 나이였을 땐 어떤 하루를 보냈을까요? 사진 한 장을 보며 가볍게 물어봐요.")
+                        .shortDescription("부모님이 지금의 내 나이였을 때의 하루")
+                        .description("부모님을 한 사람으로 바라보는 첫 장입니다. 지금의 내 나이였을 때 부모님은 어떤 하루를 살고 있었는지 돌아봅니다.")
+                        .imageDescription("부모님이 내 나이였던 시절을 보여주는 사진이나 장면카드로 남겨보세요.")
+                        .build(),
+                Chapter.builder()
+                        .title("소년과 소녀의 꿈")
+                        .imageUrl("https://example.com/chapter2.png")
+                        .guid("어릴 적 부모님은 어떤 꿈을 꾸셨을까요? 좋아했던 놀이부터 천천히 들어보면 어떨까요?")
+                        .shortDescription("목차 예시2")
+                        .description("부모님에게도 작고 선명했던 어린 시절의 꿈이 있었습니다. 무엇을 좋아하고 어떤 사람이 되고 싶었는지 들어봅니다.")
+                        .imageDescription("부모님의 어린 시절 꿈을 보여주는 사진이나 장면카드로 남겨보세요.")
+                        .build(),
+                Chapter.builder()
+                        .title("빛나던 청춘의 한 페이지")
+                        .imageUrl("https://example.com/chapter3.png")
+                        .guid("부모님의 젊은 날이 담긴 사진을 함께 골라볼까요? 사진 속 표정과 이야기를 천천히 들어봐요.")
+                        .shortDescription("목차 예시3")
+                        .description("부모님의 젊은 날이 담긴 사진 속으로 들어가보는 장입니다. 사진 속 장소와 사람들을 통해 내가 몰랐던 부모님의 표정을 발견합니다.")
+                        .imageDescription("부모님의 청춘이 가장 선명하게 보이는 사진이나 장면카드로 남겨보세요.")
+                        .build(),
+                Chapter.builder()
+                        .title("첫 출근과 첫 월급")
+                        .imageUrl("https://example.com/chapter4.png")
+                        .guid("처음 일하러 가던 날, 어떤 마음이셨을까요? 첫 월급 이야기도 살짝 물어보면 좋겠어요.")
+                        .shortDescription("목차 예시4")
+                        .description("부모님이 처음 사회에 나섰던 순간을 돌아봅니다. 첫 출근의 마음과 첫 월급의 기억을 통해 부모님의 시작점을 기록합니다.")
+                        .imageDescription("부모님의 첫 시작을 보여주는 사진이나 장면카드로 남겨보세요.")
+                        .build(),
+                Chapter.builder()
+                        .title("두 사람의 서막")
+                        .imageUrl("https://example.com/chapter5.png")
+                        .guid("부모님은 처음 어떻게 만나셨을까요? 첫인상부터 조심스럽게 물어보며 가족의 시작을 떠올려봐요.")
+                        .shortDescription("목차 예시5")
+                        .description("부모님이 서로를 만나 가족이 시작되기 전의 이야기를 들어봅니다. 첫 만남과 첫인상을 통해 우리 가족의 첫 장면을 떠올립니다.")
+                        .imageDescription("두 분의 시작을 보여주는 사진이나 장면카드로 남겨보세요.")
+                        .build(),
+                Chapter.builder()
+                        .title("가장 용기 냈던 순간")
+                        .imageUrl("https://example.com/chapter6.png")
+                        .guid("부모님이 살면서 가장 용기 냈던 선택은 무엇이었을까요? 그때의 마음을 천천히 들어봐요.")
+                        .shortDescription("목차 예시6")
+                        .description("부모님이 삶에서 큰 결정을 내렸던 순간을 돌아봅니다. 그때의 고민과 선택을 들으며 부모님의 용기를 이해해봅니다.")
+                        .imageDescription("부모님이 용기 냈던 선택을 떠올리게 하는 사진이나 장면카드로 남겨보세요.")
+                        .build(),
+                Chapter.builder()
+                        .title("잊지 못할 사람들")
+                        .imageUrl("https://example.com/chapter7.png")
+                        .guid("부모님 마음속에 오래 남아 있는 사람은 누구일까요? 어떤 사람이었는지 함께 떠올려보세요!")
+                        .shortDescription("목차 예시7")
+                        .description("부모님 마음속에 오래 남아 있는 사람을 만나보는 장입니다. 그 사람이 어떤 의미였는지 들으며 부모님의 관계와 시간을 알아갑니다.")
+                        .imageDescription("부모님 마음에 오래 남은 사람을 보여주는 사진이나 장면카드로 남겨보세요.")
+                        .build(),
+                Chapter.builder()
+                        .title("부모가 되기 전의 밤")
+                        .imageUrl("https://example.com/chapter8.png")
+                        .guid("내가 태어나기 전, 부모님은 어떤 마음으로 기다리고 계셨을까요? 조심스럽게 물어봐요.")
+                        .shortDescription("목차 예시8")
+                        .description("내가 태어나기 전 부모님의 마음을 조심스럽게 들어봅니다. 기다림과 걱정, 설렘이 섞여 있던 시간을 기록합니다.")
+                        .imageDescription("부모가 되기 전후의 마음을 보여주는 사진이나 장면카드로 남겨보세요.")
+                        .build(),
+                Chapter.builder()
+                        .title("잠시 접어두었던 것들")
+                        .imageUrl("https://example.com/chapter9.png")
+                        .guid("부모님이 예전에 좋아했지만 잠시 미뤄둔 것이 있을까요? 다시 해보고 싶은지도 살짝 물어봐요.")
+                        .shortDescription("목차 예시9")
+                        .description("부모님이 가족을 위해 잠시 미뤄두었던 것들을 떠올려봅니다. 내려놓았던 꿈이나 취미를 통해 부모님의 또 다른 모습을 발견합니다.")
+                        .imageDescription("부모님이 잠시 내려놓았던 것을 보여주는 사진이나 장면카드로 남겨보세요.")
+                        .build(),
+                Chapter.builder()
+                        .title("다시 쓰는 당신의 프로필")
+                        .imageUrl("https://example.com/chapter10.png")
+                        .guid("앞의 이야기를 떠올리며 부모님을 한 사람으로 소개해볼까요? 새롭게 알게 된 마음도 함께 남겨봐요.")
+                        .shortDescription("목차 예시10")
+                        .description("앞의 기록을 바탕으로 부모님을 다시 소개하는 마지막 장입니다. 누구의 부모가 아닌 한 사람으로서의 부모님을 정리합니다.")
+                        .imageDescription("지금의 부모님을 보여주는 사진이나 장면카드로 남겨보세요.")
+                        .build()
+
+        );
+        List<Chapter> savedChapters = chapterRepository.saveAll(chapters);
+        log.info("Chapters {}건 시딩 완료", savedChapters.size());
+
+        return savedChapters;
+    }
+
+    @Transactional
+    public List<ChapterQuestion> seedChapterQuestion(Chapter chapter) {
+        List<ChapterQuestion> chapterQuestions = IntStream.range(1, 4)
+                .mapToObj(i -> ChapterQuestion.builder()
+                        .chapter(chapter)
+                        .question(chapter.getTitle() + "에 대한 질문" + i)
+                        .questionOrder(i)
+                        .build())
+                .toList();
+        List<ChapterQuestion> savedChapterQuestions = chapterQuestionRepository.saveAll(chapterQuestions);
+        log.info("Chapters {}건 시딩 완료", savedChapterQuestions.size());
+
+        return savedChapterQuestions;
+    }
+
+    @Transactional
+    public List<SceneCard> seedSceneCard(Chapter chapter) {
+        List<SceneCard> sceneCards = IntStream.range(1, 5)
+                .mapToObj(i -> SceneCard.builder()
+                        .chapter(chapter)
+                        .imageUrl("https://example.com/scene" + i + ".png")
+                        .build())
+                .toList();
+        List<SceneCard> savedSceneCards = sceneCardRepository.saveAll(sceneCards);
+        log.info("SceneCards {}건 시딩 완료", savedSceneCards.size());
+
+        return savedSceneCards;
+    }
+
+    @Transactional
+    public void seed() {
+        List<Chapter> chapters = seedChapter();
+        chapters.forEach(chapter -> {
+            seedChapterQuestion(chapter);
+            seedSceneCard(chapter);
+        });
+    }
+}
+

--- a/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
@@ -16,6 +16,7 @@ public class LocalDataSeeder implements CommandLineRunner {
     private final ChapterSeeder chapterSeeder;
     private final StorybookSeeder storybookSeeder;
     private final TagSeeder tagSeeder;
+    private final RecordSeeder recordSeeder;
 
     @Override
     public void run(String... args) throws Exception {
@@ -26,6 +27,7 @@ public class LocalDataSeeder implements CommandLineRunner {
         chapterSeeder.seed();
         storybookSeeder.seed();
         tagSeeder.seed();
+        recordSeeder.seed();
 
     }
 

--- a/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
@@ -1,0 +1,26 @@
+package com.umc.halo.global.seed;
+
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.boot.*;
+import org.springframework.context.annotation.*;
+import org.springframework.stereotype.*;
+
+@Component
+@Profile("local")
+@RequiredArgsConstructor
+@Slf4j
+public class LocalDataSeeder implements CommandLineRunner {
+
+    private final MemberSeeder memberSeeder;
+
+    @Override
+    public void run(String... args) throws Exception {
+
+        log.info("로컬 데이터 초기화");
+
+        memberSeeder.seed();
+
+    }
+
+}

--- a/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.*;
 public class LocalDataSeeder implements CommandLineRunner {
 
     private final MemberSeeder memberSeeder;
+    private final ChapterSeeder chapterSeeder;
 
     @Override
     public void run(String... args) throws Exception {
@@ -20,6 +21,7 @@ public class LocalDataSeeder implements CommandLineRunner {
         log.info("로컬 데이터 초기화");
 
         memberSeeder.seed();
+        chapterSeeder.seed();
 
     }
 

--- a/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
@@ -14,6 +14,7 @@ public class LocalDataSeeder implements CommandLineRunner {
 
     private final MemberSeeder memberSeeder;
     private final ChapterSeeder chapterSeeder;
+    private final StorybookSeeder storybookSeeder;
 
     @Override
     public void run(String... args) throws Exception {
@@ -22,6 +23,7 @@ public class LocalDataSeeder implements CommandLineRunner {
 
         memberSeeder.seed();
         chapterSeeder.seed();
+        storybookSeeder.seed();
 
     }
 

--- a/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
@@ -19,6 +19,7 @@ public class LocalDataSeeder implements CommandLineRunner {
     private final RecordSeeder recordSeeder;
     private final TermSeeder termSeeder;
     private final NotificationSeeder notificationSeeder;
+    private final SettingSeeder settingSeeder;
 
     @Override
     public void run(String... args) throws Exception {
@@ -32,6 +33,7 @@ public class LocalDataSeeder implements CommandLineRunner {
         recordSeeder.seed();
         termSeeder.seed();
         notificationSeeder.seed();
+        settingSeeder.seed();
 
     }
 

--- a/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
@@ -18,6 +18,7 @@ public class LocalDataSeeder implements CommandLineRunner {
     private final TagSeeder tagSeeder;
     private final RecordSeeder recordSeeder;
     private final TermSeeder termSeeder;
+    private final NotificationSeeder notificationSeeder;
 
     @Override
     public void run(String... args) throws Exception {
@@ -30,6 +31,7 @@ public class LocalDataSeeder implements CommandLineRunner {
         tagSeeder.seed();
         recordSeeder.seed();
         termSeeder.seed();
+        notificationSeeder.seed();
 
     }
 

--- a/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
@@ -15,6 +15,7 @@ public class LocalDataSeeder implements CommandLineRunner {
     private final MemberSeeder memberSeeder;
     private final ChapterSeeder chapterSeeder;
     private final StorybookSeeder storybookSeeder;
+    private final TagSeeder tagSeeder;
 
     @Override
     public void run(String... args) throws Exception {
@@ -24,6 +25,7 @@ public class LocalDataSeeder implements CommandLineRunner {
         memberSeeder.seed();
         chapterSeeder.seed();
         storybookSeeder.seed();
+        tagSeeder.seed();
 
     }
 

--- a/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
@@ -17,6 +17,7 @@ public class LocalDataSeeder implements CommandLineRunner {
     private final StorybookSeeder storybookSeeder;
     private final TagSeeder tagSeeder;
     private final RecordSeeder recordSeeder;
+    private final TermSeeder termSeeder;
 
     @Override
     public void run(String... args) throws Exception {
@@ -28,6 +29,7 @@ public class LocalDataSeeder implements CommandLineRunner {
         storybookSeeder.seed();
         tagSeeder.seed();
         recordSeeder.seed();
+        termSeeder.seed();
 
     }
 

--- a/src/main/java/com/umc/halo/global/seed/MemberSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/MemberSeeder.java
@@ -1,0 +1,54 @@
+package com.umc.halo.global.seed;
+
+import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.domain.member.enums.*;
+import com.umc.halo.domain.member.repository.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.time.*;
+import java.util.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class MemberSeeder {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public List<Member> seed() {
+
+        List<Member> members = List.of(
+                Member.builder()
+                        .name("김하로")
+                        .guestUuid(UUID.randomUUID().toString())
+                        .provider(Provider.KAKAO)
+                        .providerId("kakao-0001")
+                        .gender(Gender.FEMALE)
+                        .birthDate(LocalDate.of(2000, 5, 12))
+                        .onboardingCompleted(true)
+                        .build(),
+                Member.builder()
+                        .name("이온")
+                        .guestUuid(UUID.randomUUID().toString())
+                        .provider(Provider.GOOGLE)
+                        .providerId("google-0001")
+                        .gender(Gender.MALE)
+                        .birthDate(LocalDate.of(1993, 8, 23))
+                        .onboardingCompleted(true)
+                        .build(),
+                Member.builder()
+                        .name("송하루")
+                        .guestUuid(UUID.randomUUID().toString())
+                        .gender(Gender.MALE)
+                        .birthDate(LocalDate.of(2011, 4, 5))
+                        .build()
+        );
+        List<Member> savedMembers = memberRepository.saveAll(members);
+        log.info("Member {}건 시딩 완료", savedMembers.size());
+
+        return savedMembers;
+    }
+}

--- a/src/main/java/com/umc/halo/global/seed/NotificationSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/NotificationSeeder.java
@@ -1,0 +1,88 @@
+package com.umc.halo.global.seed;
+
+import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.domain.member.repository.*;
+import com.umc.halo.domain.notification.entity.*;
+import com.umc.halo.domain.notification.enums.*;
+import com.umc.halo.domain.notification.repository.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.time.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationSeeder {
+    private final AnniversaryRepository anniversaryRepository;
+    private final CommonAnniversaryRepository commonAnniversaryRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public List<CommonAnniversary> seedCommonAnniversary() {
+        List<CommonAnniversary> commonAnniversaries = List.of(
+                CommonAnniversary.builder()
+                        .title("어버이날")
+                        .month(5)
+                        .day(8)
+                        .isLunar(false)
+                        .build(),
+                CommonAnniversary.builder()
+                        .title("추석")
+                        .month(8)
+                        .day(15)
+                        .isLunar(true)
+                        .build(),
+                CommonAnniversary.builder()
+                        .title("설날")
+                        .month(1)
+                        .day(1)
+                        .isLunar(true)
+                        .build()
+        );
+
+        List<CommonAnniversary> savedCommonAnniversaries = commonAnniversaryRepository.saveAll(commonAnniversaries);
+        log.info("CommonAnniversary {}건 시딩 완료", savedCommonAnniversaries.size());
+
+        return savedCommonAnniversaries;
+    }
+
+    @Transactional
+    public List<Anniversary> seedAnniversary() {
+        Map<String, Member> member = memberRepository.findAll().stream()
+                .collect(Collectors.toMap(Member::getName, Function.identity(), (a, b) -> a));
+
+        List<Anniversary> anniversaries = List.of(
+                Anniversary.builder()
+                        .member(member.get("김하로"))
+                        .title("아버지 생신")
+                        .anniversaryDate(LocalDate.of(2026, 9, 12))
+                        .target(Target.FATHER)
+                        .memo("아버지 생신! 열심히 준비해야겠다!")
+                        .build(),
+                Anniversary.builder()
+                        .member(member.get("이온"))
+                        .title("어머니 생신")
+                        .anniversaryDate(LocalDate.of(2026, 11, 20))
+                        .target(Target.MOTHER)
+                        .memo("어머니 생신! 이번에는 더 특별히 준비해야지!")
+                        .build()
+        );
+
+        List<Anniversary> savedAnniversaries = anniversaryRepository.saveAll(anniversaries);
+        log.info("Anniversary {}건 시딩 완료", savedAnniversaries.size());
+
+        return savedAnniversaries;
+    }
+
+    @Transactional
+    public void seed() {
+        seedCommonAnniversary();
+        seedAnniversary();
+    }
+}

--- a/src/main/java/com/umc/halo/global/seed/RecordSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/RecordSeeder.java
@@ -1,0 +1,146 @@
+package com.umc.halo.global.seed;
+
+import com.umc.halo.domain.content.chapter.entity.*;
+import com.umc.halo.domain.content.chapter.repository.*;
+import com.umc.halo.domain.content.storybook.entity.*;
+import com.umc.halo.domain.content.storybook.repository.*;
+import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.domain.member.repository.*;
+import com.umc.halo.domain.record.entity.*;
+import com.umc.halo.domain.record.enums.*;
+import com.umc.halo.domain.record.repository.*;
+import com.umc.halo.global.enums.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.time.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RecordSeeder {
+    private final MemberChapterAnswerRepository memberChapterAnswerRepository;
+    private final MemberChapterRepository memberChapterRepository;
+    private final MemberStorybookRepository memberStorybookRepository;
+    private final MemberRepository memberRepository;
+    private final StorybookRepository storybookRepository;
+    private final StorybookChapterRepository storybookChapterRepository;
+    private final ChapterQuestionRepository chapterQuestionRepository;
+    private final SceneCardRepository sceneCardRepository;
+
+    // 회원별 스토리북 진행 시나리오
+    private record ProgressScenario(String memberName, String storybookTitle, int lastChapterOrder,
+                                    Emotion emotion, LocalDate completedDate) {
+    }
+
+    private static final List<ProgressScenario> PROGRESS_SCENARIOS = List.of(
+            new ProgressScenario("김하로", "오래 전 당신", 10, Emotion.HAPPY, LocalDate.now()), // 완료
+            new ProgressScenario("김하로", "취향이 닿는 날", 3, Emotion.THOUGHTFUL, LocalDate.now()), // 진행중
+            new ProgressScenario("이온", "나란히 걷는 날", 9, Emotion.GRATEFUL, LocalDate.now().minusDays(1)) // 진행중 (1장 남음)
+    );
+
+    @Transactional
+    public List<MemberStorybook> seedMemberStorybook(Map<String, Member> member, Map<String, Storybook> storybook) {
+        List<MemberStorybook> memberStorybooks = PROGRESS_SCENARIOS.stream()
+                .map(scenario -> MemberStorybook.builder()
+                        .member(member.get(scenario.memberName()))
+                        .storybook(storybook.get(scenario.storybookTitle()))
+                        .lastChapterOrder(scenario.lastChapterOrder())
+                        .lastCompletedDate(scenario.completedDate())
+                        .emotion(scenario.emotion())
+                        .build())
+                .toList();
+
+        List<MemberStorybook> savedMemberStorybooks = memberStorybookRepository.saveAll(memberStorybooks);
+        log.info("MemberStorybook {}건 시딩 완료", savedMemberStorybooks.size());
+
+        return savedMemberStorybooks;
+    }
+
+    @Transactional
+    public List<MemberChapter> seedMemberChapter(Map<String, Member> member, List<StorybookChapter> storybookChapters, List<SceneCard> sceneCards) {
+        List<MemberChapter> memberChapters = PROGRESS_SCENARIOS.stream()
+                .flatMap(scenario -> IntStream.rangeClosed(1, scenario.lastChapterOrder())
+                        .mapToObj(chapterOrder -> buildMemberChapter(
+                                member.get(scenario.memberName()),
+                                scenario.storybookTitle(),
+                                chapterOrder,
+                                storybookChapters,
+                                sceneCards,
+                                scenario.emotion(),
+                                scenario.completedDate())))
+                .toList();
+
+        List<MemberChapter> savedMemberChapters = memberChapterRepository.saveAll(memberChapters);
+        log.info("MemberChapter {}건 시딩 완료", savedMemberChapters.size());
+
+        return savedMemberChapters;
+    }
+
+    private MemberChapter buildMemberChapter(Member member, String storybookTitle, int chapterOrder,
+                                             List<StorybookChapter> storybookChapters, List<SceneCard> sceneCards,
+                                             Emotion emotion, LocalDate completedDate) {
+        StorybookChapter storybookChapter = storybookChapters.stream()
+                .filter(sc -> sc.getStorybook().getTitle().equals(storybookTitle)
+                        && sc.getChapterOrder().equals(chapterOrder))
+                .findFirst()
+                .orElseThrow();
+
+        SceneCard sceneCard = sceneCards.stream()
+                .filter(sc -> sc.getChapter().getId().equals(storybookChapter.getChapter().getId()))
+                .findFirst()
+                .orElseThrow();
+
+        return MemberChapter.builder()
+                .member(member)
+                .storybookChapter(storybookChapter)
+                .sceneCard(sceneCard)
+                .emotion(emotion)
+                .coverType(CoverType.SCENE_CARD)
+                .completedDate(completedDate)
+                .summary("ai로 요약한 완료 기록")
+                .status(Status.COMPLETED)
+                .build();
+    }
+
+    @Transactional
+    public List<MemberChapterAnswer> seedMemberChapterAnswer(List<MemberChapter> memberChapters, List<ChapterQuestion> chapterQuestions) {
+        List<MemberChapterAnswer> memberChapterAnswers = memberChapters.stream()
+                .flatMap(memberChapter -> {
+                    Long chapterId = memberChapter.getStorybookChapter().getChapter().getId();
+                    return chapterQuestions.stream()
+                            .filter(question -> question.getChapter().getId().equals(chapterId))
+                            .map(question -> MemberChapterAnswer.builder()
+                                    .memberChapter(memberChapter)
+                                    .chapterQuestion(question)
+                                    .answer(memberChapter.getMember().getName() + "의 답변입니다.")
+                                    .build());
+                })
+                .toList();
+
+        List<MemberChapterAnswer> savedMemberChapterAnswers = memberChapterAnswerRepository.saveAll(memberChapterAnswers);
+        log.info("MemberChapterAnswer {}건 시딩 완료", savedMemberChapterAnswers.size());
+
+        return savedMemberChapterAnswers;
+    }
+
+    @Transactional
+    public void seed() {
+        Map<String, Member> member = memberRepository.findAll().stream()
+                .collect(Collectors.toMap(Member::getName, Function.identity(), (a, b) -> a));
+        Map<String, Storybook> storybook = storybookRepository.findAll().stream()
+                .collect(Collectors.toMap(Storybook::getTitle, Function.identity()));
+        List<StorybookChapter> storybookChapters = storybookChapterRepository.findAll();
+        List<ChapterQuestion> chapterQuestions = chapterQuestionRepository.findAll();
+        List<SceneCard> sceneCards = sceneCardRepository.findAll();
+
+        seedMemberStorybook(member, storybook);
+        List<MemberChapter> memberChapters = seedMemberChapter(member, storybookChapters, sceneCards);
+        seedMemberChapterAnswer(memberChapters, chapterQuestions);
+    }
+}

--- a/src/main/java/com/umc/halo/global/seed/SettingSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/SettingSeeder.java
@@ -1,0 +1,72 @@
+package com.umc.halo.global.seed;
+
+import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.domain.member.repository.*;
+import com.umc.halo.domain.setting.entity.*;
+import com.umc.halo.domain.setting.repository.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class SettingSeeder {
+    private final BgmRepository bgmRepository;
+    private final MemberSettingRepository memberSettingRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public List<Bgm> seedBgm() {
+        List<Bgm> bgms = List.of(
+                Bgm.builder()
+                        .title("산들 바람")
+                        .audioUrl("https://example.com/bgm1.mp3")
+                        .imageUrl("https://example.com/bgm1.png")
+                        .build(),
+                Bgm.builder()
+                        .title("따뜻한 오후")
+                        .audioUrl("https://example.com/bgm2.mp3")
+                        .imageUrl("https://example.com/bgm2.png")
+                        .build()
+        );
+
+        List<Bgm> savedBgms = bgmRepository.saveAll(bgms);
+        log.info("Bgm {}건 시딩 완료", savedBgms.size());
+
+        return savedBgms;
+    }
+
+    @Transactional
+    public List<MemberSetting> seedMemberSetting(List<Bgm> bgms) {
+        Map<String, Member> member = memberRepository.findAll().stream()
+                .collect(Collectors.toMap(Member::getName, Function.identity(), (a, b) -> a));
+
+        List<MemberSetting> memberSettings = List.of(
+                MemberSetting.builder()
+                        .member(member.get("김하로"))
+                        .bgm(bgms.get(0))
+                        .build(),
+                MemberSetting.builder()
+                        .member(member.get("이온"))
+                        .bgm(bgms.get(1))
+                        .build()
+        );
+
+        List<MemberSetting> savedMemberSettings = memberSettingRepository.saveAll(memberSettings);
+        log.info("MemberSetting {}건 시딩 완료", savedMemberSettings.size());
+
+        return savedMemberSettings;
+    }
+
+    @Transactional
+    public void seed() {
+        List<Bgm> bgms = seedBgm();
+        seedMemberSetting(bgms);
+    }
+}

--- a/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
@@ -1,0 +1,164 @@
+package com.umc.halo.global.seed;
+
+import com.umc.halo.domain.content.chapter.entity.*;
+import com.umc.halo.domain.content.chapter.repository.*;
+import com.umc.halo.domain.content.storybook.entity.*;
+import com.umc.halo.domain.content.storybook.enums.*;
+import com.umc.halo.domain.content.storybook.repository.*;
+import com.umc.halo.global.enums.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class StorybookSeeder {
+    private final StorybookRepository storybookRepository;
+    private final StorybookChapterRepository storybookChapterRepository;
+    private final StorybookCharacterRepository storybookCharacterRepository;
+    private final ChapterRepository chapterRepository;
+
+    @Transactional
+    public List<Storybook> seedStorybooks() {
+        List<Storybook> storybooks = List.of(
+                Storybook.builder()
+                        .title("오래 전 당신")
+                        .themeOrder(1)
+                        .shortDescription("가족과의 만남")
+                        .description("부모님을 ‘부모'가 아닌 한 사람으로 바라보며, 어린 시절의 기억과 \n" +
+                                "청춘의 순간, 지나온 시간을 차근차근 들어보는 이야기입니다. \n" +
+                                "지금의 부모님을 이해하고, 더 가까워지는 시간을 선물해보세요.")
+                        .imageUrl("https://example.com/storybook1.png")
+                        .spineColor("#E4B7A0")
+                        .build(),
+
+                Storybook.builder()
+                        .title("당신 사용설명서")
+                        .themeOrder(2)
+                        .shortDescription("나를 아는 시간")
+                        .description("좋아하는 것과 싫어하는 것, 습관과 취향을 하나씩 들여다보며 \n" +
+                                "스스로를 정리해보는 이야기입니다.")
+                        .imageUrl("https://example.com/storybook2.png")
+                        .spineColor("#A0C4E4")
+                        .build(),
+
+                Storybook.builder()
+                        .title("가족의 온도")
+                        .themeOrder(3)
+                        .shortDescription("가족이 서로에게 건네는 마음")
+                        .description("무심코 지나쳤던 가족의 온기를 다시 느껴보는 이야기입니다. \n" +
+                                "서로에게 전하지 못했던 마음을 꺼내어 가족 사이의 거리를 좁혀봅니다.")
+                        .imageUrl("https://example.com/storybook3.png")
+                        .spineColor("#B7E4A0")
+                        .build(),
+
+                Storybook.builder()
+                        .title("취향이 닿는 날")
+                        .themeOrder(4)
+                        .shortDescription("서로의 취향을 알아가는 시간")
+                        .description("좋아하는 것과 싫어하는 것을 하나씩 나누며, \n" +
+                                "서로의 취향이 닿는 순간들을 발견하는 이야기입니다.")
+                        .imageUrl("https://example.com/storybook4.png")
+                        .spineColor("#E4D4A0")
+                        .build(),
+
+                Storybook.builder()
+                        .title("나란히 걷는 날")
+                        .themeOrder(5)
+                        .shortDescription("함께 걸어온 시간을 돌아보는 이야기")
+                        .description("누군가와 나란히 걸어온 시간들을 돌아보며, \n" +
+                                "곁에 있어준 존재의 의미를 다시 새겨보는 이야기입니다.")
+                        .imageUrl("https://example.com/storybook5.png")
+                        .spineColor("#C4A0E4")
+                        .build(),
+
+                Storybook.builder()
+                        .title("오늘은 내가 먼저")
+                        .themeOrder(6)
+                        .shortDescription("먼저 다가서는 용기에 대한 이야기")
+                        .description("망설이던 마음을 내려놓고 오늘만큼은 내가 먼저 다가서 보는 이야기입니다. \n" +
+                                "작은 용기가 만들어내는 변화를 기록해보세요.")
+                        .imageUrl("https://example.com/storybook6.png")
+                        .spineColor("#E4A0C4")
+                        .build()
+        );
+
+        List<Storybook> savedStorybooks = storybookRepository.saveAll(storybooks);
+        log.info("Storybooks {}건 시딩 완료", savedStorybooks.size());
+
+        return savedStorybooks;
+    }
+
+    @Transactional
+    public List<StorybookChapter> seedStorybookChapter(Storybook storybook, List<Chapter> chapters) {
+        List<StorybookChapter> storybookChapters = IntStream.range(0, chapters.size())
+                .mapToObj(i -> StorybookChapter.builder()
+                        .storybook(storybook)
+                        .chapter(chapters.get(i))
+                        .chapterOrder(i + 1)
+                        .build())
+                .toList();
+
+        List<StorybookChapter> savedStorybookChapters = storybookChapterRepository.saveAll(storybookChapters);
+        log.info("StorybookChapters {}건 시딩 완료", savedStorybookChapters.size());
+
+        return savedStorybookChapters;
+    }
+
+    private static final List<String> CHARACTER_NAMES = List.of("하로", "온이", "다솜", "결", "다온", "가온");
+
+    @Transactional
+    public List<StorybookCharacter> seedStorybookCharacter(Storybook storybook, String characterName) {
+        List<StorybookCharacter> storybookCharacters = new ArrayList<>();
+
+        storybookCharacters.add(
+                StorybookCharacter.builder()
+                        .storybook(storybook)
+                        .name(characterName)
+                        .variant(Variant.ORIGINAL)
+                        .imageUrl("https://example.com/character-original.png")
+                        .build()
+        );
+        storybookCharacters.add(
+                StorybookCharacter.builder()
+                        .storybook(storybook)
+                        .name(characterName)
+                        .variant(Variant.IMAGE_CHOICE)
+                        .imageUrl("https://example.com/character-image-choice.png")
+                        .build()
+        );
+        storybookCharacters.addAll(
+                Arrays.stream(Emotion.values())
+                        .map(emotion -> StorybookCharacter.builder()
+                                .storybook(storybook)
+                                .name(characterName)
+                                .variant(Variant.EMOTION)
+                                .emotion(emotion)
+                                .imageUrl("https://example.com/character-emotion-" + emotion.name().toLowerCase() + ".png")
+                                .build())
+                        .toList()
+        );
+
+        List<StorybookCharacter> savedStorybookCharacters = storybookCharacterRepository.saveAll(storybookCharacters);
+        log.info("StorybookCharacters {}건 시딩 완료", savedStorybookCharacters.size());
+
+        return savedStorybookCharacters;
+    }
+
+    @Transactional
+    public void seed() {
+        List<Chapter> chapters = chapterRepository.findAll();
+        List<Storybook> storybooks = seedStorybooks();
+
+        for (int i = 0; i < storybooks.size(); i++) {
+            Storybook storybook = storybooks.get(i);
+            seedStorybookChapter(storybook, chapters);
+            seedStorybookCharacter(storybook, CHARACTER_NAMES.get(i));
+        }
+    }
+}

--- a/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
@@ -152,7 +152,7 @@ public class StorybookSeeder {
 
     @Transactional
     public void seed() {
-        List<Chapter> chapters = chapterRepository.findAll();
+        List<Chapter> chapters = chapterRepository.findAllByOrderByIdAsc();
         List<Storybook> storybooks = seedStorybooks();
 
         for (int i = 0; i < storybooks.size(); i++) {

--- a/src/main/java/com/umc/halo/global/seed/TagSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/TagSeeder.java
@@ -1,0 +1,294 @@
+package com.umc.halo.global.seed;
+
+import com.umc.halo.domain.content.storybook.entity.*;
+import com.umc.halo.domain.content.storybook.repository.*;
+import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.domain.member.repository.*;
+import com.umc.halo.domain.tag.entity.*;
+import com.umc.halo.domain.tag.enums.*;
+import com.umc.halo.domain.tag.repository.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TagSeeder {
+    private final TagRepository tagRepository;
+    private final MemberTagRepository memberTagRepository;
+    private final StorybookTagRepository storybookTagRepository;
+    private final MemberRepository memberRepository;
+    private final StorybookRepository storybookRepository;
+
+    @Transactional
+    public List<Tag> seedTag() {
+        List<Tag> tags = List.of(
+                // 부모님 성향 (긍정)
+                Tag.builder()
+                        .category(Category.PARENT_TENDENCY)
+                        .title("배려심 깊은")
+                        .subtitle(Subtitle.POSITIVE)
+                        .build(),
+                Tag.builder()
+                        .category(Category.PARENT_TENDENCY)
+                        .title("낙천적인")
+                        .subtitle(Subtitle.POSITIVE)
+                        .build(),
+
+                // 부모님 성향 (중립)
+                Tag.builder()
+                        .category(Category.PARENT_TENDENCY)
+                        .title("무뚝뚝한")
+                        .subtitle(Subtitle.NEUTRAL)
+                        .build(),
+                Tag.builder()
+                        .category(Category.PARENT_TENDENCY)
+                        .title("차분한")
+                        .subtitle(Subtitle.NEUTRAL)
+                        .build(),
+
+                // 부모님 성향 (중립)
+                Tag.builder()
+                        .category(Category.PARENT_TENDENCY)
+                        .title("걱정 많은")
+                        .subtitle(Subtitle.CAUTIOUS)
+                        .build(),
+                Tag.builder()
+                        .category(Category.PARENT_TENDENCY)
+                        .title("잔소리")
+                        .subtitle(Subtitle.CAUTIOUS)
+                        .build(),
+
+                // 현재 관계 상태
+                Tag.builder()
+                        .category(Category.CURRENT_RELATIONSHIP)
+                        .title("매우 가까운 편이에요")
+                        .description("부모이기 전에 친구 같은, 비밀까지 나누는 사이")
+                        .build(),
+                Tag.builder()
+                        .category(Category.CURRENT_RELATIONSHIP)
+                        .title("대체로 좋은 편이에요")
+                        .description("일상적인 안부를 나누며 서로를 존중해요")
+                        .build(),
+
+                // 원하는 관계 방향
+                Tag.builder()
+                        .category(Category.DESIRED_DIRECTION)
+                        .title("부모님을 더 알고 싶어요")
+                        .build(),
+                Tag.builder()
+                        .category(Category.DESIRED_DIRECTION)
+                        .title("같이 보내는 시간을 만들고 싶어요")
+                        .build(),
+                Tag.builder()
+                        .category(Category.DESIRED_DIRECTION)
+                        .title("어색하지 않게 이야기하고 싶어요")
+                        .build(),
+                Tag.builder()
+                        .category(Category.DESIRED_DIRECTION)
+                        .title("마음을 표현해보고 싶어요")
+                        .build(),
+                Tag.builder()
+                        .category(Category.DESIRED_DIRECTION)
+                        .title("특별한 날이나 응원을 준비하고 싶어요")
+                        .build()
+        );
+
+        List<Tag> savedTags = tagRepository.saveAll(tags);
+        log.info("Tags {}건 시딩 완료", savedTags.size());
+
+        return savedTags;
+    }
+
+    @Transactional
+    public List<MemberTag> seedMemberTag(List<Member> members, List<Tag> tags) {
+        Map<String, Member> member = members.stream()
+                .collect(Collectors.toMap(Member::getName, Function.identity(), (a, b) -> a));
+        Map<String, Tag> tag = tags.stream()
+                .collect(Collectors.toMap(Tag::getTitle, Function.identity()));
+
+        List<MemberTag> memberTags = List.of(
+                // 김하로 - 부모님 성향 3개, 현재 관계 상태 1개, 원하는 관계 방향 2개
+                MemberTag.builder().member(member.get("김하로")).tag(tag.get("배려심 깊은")).build(),
+                MemberTag.builder().member(member.get("김하로")).tag(tag.get("낙천적인")).build(),
+                MemberTag.builder().member(member.get("김하로")).tag(tag.get("무뚝뚝한")).build(),
+
+                MemberTag.builder().member(member.get("김하로")).tag(tag.get("매우 가까운 편이에요")).build(),
+
+                MemberTag.builder().member(member.get("김하로")).tag(tag.get("부모님을 더 알고 싶어요")).build(),
+                MemberTag.builder().member(member.get("김하로")).tag(tag.get("어색하지 않게 이야기하고 싶어요")).build(),
+
+                // 이온 - 부모님 성향 2개, 현재 관계 상태 1개, 원하는 관계 방향 2개
+                MemberTag.builder().member(member.get("이온")).tag(tag.get("차분한")).build(),
+                MemberTag.builder().member(member.get("이온")).tag(tag.get("걱정 많은")).build(),
+
+                MemberTag.builder().member(member.get("이온")).tag(tag.get("대체로 좋은 편이에요")).build(),
+
+                MemberTag.builder().member(member.get("이온")).tag(tag.get("같이 보내는 시간을 만들고 싶어요")).build(),
+                MemberTag.builder().member(member.get("이온")).tag(tag.get("특별한 날이나 응원을 준비하고 싶어요")).build(),
+
+                // 송하루(게스트) - 부모님 성향 1개, 지금의 관계 1개, 희망 관계 1개
+                MemberTag.builder().member(member.get("송하루")).tag(tag.get("잔소리")).build(),
+
+                MemberTag.builder().member(member.get("송하루")).tag(tag.get("대체로 좋은 편이에요")).build(),
+
+                MemberTag.builder().member(member.get("송하루")).tag(tag.get("마음을 표현해보고 싶어요")).build()
+        );
+
+        List<MemberTag> savedMemberTags = memberTagRepository.saveAll(memberTags);
+        log.info("MemberTags {}건 시딩 완료", savedMemberTags.size());
+
+        return savedMemberTags;
+    }
+
+    @Transactional
+    public List<StorybookTag> seedStorybookTag(List<Storybook> storybooks, List<Tag> tags) {
+        Map<String, Storybook> storybook = storybooks.stream()
+                .collect(Collectors.toMap(Storybook::getTitle, Function.identity()));
+        Map<String, Tag> tag = tags.stream()
+                .collect(Collectors.toMap(Tag::getTitle, Function.identity()));
+
+        List<StorybookTag> storybookTags = List.of(
+                // 오래 전 당신
+                StorybookTag.builder()
+                        .storybook(storybook.get("오래 전 당신"))
+                        .tag(tag.get("어색하지 않게 이야기하고 싶어요"))
+                        .priorityLevel(PriorityLevel.PRIMARY)
+                        .phrase("어색하지 않게 이야기하고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("오래 전 당신"))
+                        .tag(tag.get("부모님을 더 알고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("부모님을 더 알고, 어색하지 않게 이야기하고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("오래 전 당신"))
+                        .tag(tag.get("같이 보내는 시간을 만들고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("같이 보내는 시간을 만들고, 어색하지 않게 이야기하고 싶어요")
+                        .build(),
+
+                // 당신 사용설명서
+                StorybookTag.builder()
+                        .storybook(storybook.get("당신 사용설명서"))
+                        .tag(tag.get("부모님을 더 알고 싶어요"))
+                        .priorityLevel(PriorityLevel.PRIMARY)
+                        .phrase("부모님을 더 알고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("당신 사용설명서"))
+                        .tag(tag.get("같이 보내는 시간을 만들고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("부모님을 더 알고, 같이 보내는 시간을 만들고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("당신 사용설명서"))
+                        .tag(tag.get("특별한 날이나 응원을 준비하고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("부모님을 더 알고, 특별한 날이나 응원을 준비하고 싶어요")
+                        .build(),
+
+                // 가족의 온도
+                StorybookTag.builder()
+                        .storybook(storybook.get("가족의 온도"))
+                        .tag(tag.get("부모님을 더 알고 싶어요"))
+                        .priorityLevel(PriorityLevel.PRIMARY)
+                        .phrase("부모님을 더 알고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("가족의 온도"))
+                        .tag(tag.get("마음을 표현해보고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("부모님을 더 알고, 마음을 표현해보고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("가족의 온도"))
+                        .tag(tag.get("어색하지 않게 이야기하고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("부모님을 더 알고, 어색하지 않게 이야기하고 싶어요")
+                        .build(),
+
+                // 취향이 닿는 날
+                StorybookTag.builder()
+                        .storybook(storybook.get("취향이 닿는 날"))
+                        .tag(tag.get("같이 보내는 시간을 만들고 싶어요"))
+                        .priorityLevel(PriorityLevel.PRIMARY)
+                        .phrase("같이 보내는 시간을 만들고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("취향이 닿는 날"))
+                        .tag(tag.get("어색하지 않게 이야기하고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("같이 보내는 시간을 만들고, 어색하지 않게 이야기하고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("취향이 닿는 날"))
+                        .tag(tag.get("특별한 날이나 응원을 준비하고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("같이 보내는 시간을 만들고, 특별한 날이나 응원을 준비하고 싶어요")
+                        .build(),
+
+                // 나란히 걷는 날
+                StorybookTag.builder()
+                        .storybook(storybook.get("나란히 걷는 날"))
+                        .tag(tag.get("같이 보내는 시간을 만들고 싶어요"))
+                        .priorityLevel(PriorityLevel.PRIMARY)
+                        .phrase("같이 보내는 시간을 만들고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("나란히 걷는 날"))
+                        .tag(tag.get("마음을 표현해보고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("같이 보내는 시간을 만들고, 마음을 표현해보고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("나란히 걷는 날"))
+                        .tag(tag.get("부모님을 더 알고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("부모님을 더 알고, 같이 보내는 시간을 만들고 싶어요")
+                        .build(),
+
+                // 오늘은 내가 먼저
+                StorybookTag.builder()
+                        .storybook(storybook.get("오늘은 내가 먼저"))
+                        .tag(tag.get("마음을 표현해보고 싶어요"))
+                        .priorityLevel(PriorityLevel.PRIMARY)
+                        .phrase("마음을 표현해보고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("오늘은 내가 먼저"))
+                        .tag(tag.get("특별한 날이나 응원을 준비하고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("마음을 표현해보고, 특별한 날이나 응원을 준비하고 싶어요")
+                        .build(),
+                StorybookTag.builder()
+                        .storybook(storybook.get("오늘은 내가 먼저"))
+                        .tag(tag.get("어색하지 않게 이야기하고 싶어요"))
+                        .priorityLevel(PriorityLevel.SECONDARY)
+                        .phrase("어색하지 않게 이야기하고, 마음을 표현해보고 싶어요")
+                        .build()
+        );
+
+        List<StorybookTag> savedStorybookTags = storybookTagRepository.saveAll(storybookTags);
+        log.info("StorybookTags {}건 시딩 완료", savedStorybookTags.size());
+
+        return savedStorybookTags;
+    }
+
+    @Transactional
+    public void seed() {
+        List<Member> members = memberRepository.findAll();
+        List<Storybook> storybooks = storybookRepository.findAll();
+        List<Tag> tags = seedTag();
+
+        seedMemberTag(members, tags);
+        seedStorybookTag(storybooks, tags);
+    }
+}

--- a/src/main/java/com/umc/halo/global/seed/TermSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/TermSeeder.java
@@ -1,0 +1,92 @@
+package com.umc.halo.global.seed;
+
+import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.domain.member.repository.*;
+import com.umc.halo.domain.term.entity.*;
+import com.umc.halo.domain.term.repository.*;
+import lombok.*;
+import lombok.extern.slf4j.*;
+import org.springframework.stereotype.*;
+import org.springframework.transaction.annotation.*;
+
+import java.util.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TermSeeder {
+    private final TermRepository termRepository;
+    private final MemberTermRepository memberTermRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public List<Term> seedTerm() {
+        List<Term> terms = List.of(
+                Term.builder()
+                        .title("서비스 이용약관")
+                        .shortDescription("HALO 서비스 이용 기준")
+                        .description("제1조(목적) 이 약관은 HALO(이하 '회사')가 제공하는 서비스의 이용조건 및 절차, " +
+                                "회사와 회원 간의 권리·의무 및 책임사항을 규정함을 목적으로 합니다.\n" +
+                                "제2조(용어의 정의) '회원'이란 이 약관에 동의하고 서비스를 이용하는 자를 말합니다.\n" +
+                                "제3조(효력 및 변경) 회사는 약관을 변경할 수 있으며, 변경 시 서비스 내 공지사항을 통해 안내합니다.")
+                        .isRequired(true)
+                        .build(),
+                Term.builder()
+                        .title("개인정보 처리방침")
+                        .shortDescription("수집 항목 보관 기간 안내")
+                        .description("회사는 회원가입, 서비스 이용 과정에서 이름, 생년월일, 성별, 소셜 로그인 식별값 등을 수집합니다.\n" +
+                                "수집한 개인정보는 서비스 제공 목적으로만 이용되며, 회원 탈퇴 시 관련 법령에서 정한 기간 동안 " +
+                                "보관 후 파기됩니다.")
+                        .isRequired(true)
+                        .build(),
+                Term.builder()
+                        .title("콘텐츠 보관 및 활용 안내")
+                        .shortDescription("사진·기록 저장 기준")
+                        .description("회원이 작성한 기록, 사진, 장면카드 등의 콘텐츠는 서비스 제공을 위해 안전하게 저장되며, " +
+                                "회원 본인 외에는 공개되지 않습니다.\n" +
+                                "회원 탈퇴 시 해당 콘텐츠는 일정 기간 후 삭제됩니다.")
+                        .isRequired(true)
+                        .build(),
+                Term.builder()
+                        .title("마케팅 정보 수신 동의")
+                        .shortDescription("이벤트·업데이트 안내")
+                        .description("이벤트, 신규 기능, 프로모션 등의 정보를 이메일 또는 앱 푸시 알림으로 받아보실 수 있습니다.\n" +
+                                "동의하지 않아도 서비스 이용에는 제한이 없으며, 언제든지 설정에서 수신 동의를 철회할 수 있습니다.")
+                        .isRequired(false)
+                        .build()
+        );
+
+        List<Term> savedTerms = termRepository.saveAll(terms);
+        log.info("Term {}건 시딩 완료", savedTerms.size());
+
+        return savedTerms;
+    }
+
+    @Transactional
+    public List<MemberTerm> seedMemberTerm(List<Member> members, List<Term> terms) {
+        List<MemberTerm> memberTerms = members.stream()
+                .flatMap(member -> terms.stream()
+                        .map(term -> MemberTerm.builder()
+                                .member(member)
+                                .term(term)
+                                .isAgreed(term.getIsRequired())
+                                .build()))
+                .toList();
+
+        List<MemberTerm> savedMemberTerms = memberTermRepository.saveAll(memberTerms);
+        log.info("MemberTerm {}건 시딩 완료", savedMemberTerms.size());
+
+        return savedMemberTerms;
+    }
+
+    @Transactional
+    public void seed() {
+        List<Term> terms = seedTerm();
+
+        List<Member> members = memberRepository.findAll().stream()
+                .filter(member -> List.of("김하로", "이온").contains(member.getName()))
+                .toList();
+
+        seedMemberTerm(members, terms);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,7 +2,6 @@ spring:
   config:
     activate:
       on-profile: local
-
-jpa:
-  hibernate:
-    ddl-auto: create-drop
+  jpa:
+    hibernate:
+      ddl-auto: create-drop

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,8 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+
+jpa:
+  hibernate:
+    ddl-auto: create-drop


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.

- 로컬 시드 데이터 기능 구현
- 시드 데이터 조회/저장에 필요한 각 엔티티별 Repository 생성
- `application-local.yml`을 추가하여 `local` 프로필에서 `ddl-auto: create-drop` 설정

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.

 - `global/seed/LocalDataSeeder.java`  `CommandLineRunner`, 각 Seeder 실행 진입점 생성
 - `global/seed/MemberSeeder.java`등 도메인별 Seeder 생성
 - `domain/content/storybook/repository/StorybookChapterRepository`등 전체 엔티티 Repository 생성
 - 전체 엔티티 `@Builder`, `@AllArgsConstructor(access = PRIVATE)` 추가
 - `src/main/resources/application-local.yml` : local 프로필 설정 (`ddl-auto: create-drop`)위해 생성
 - `scenecard`를 `chapter` 패키지 하위로 이동

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)

- 

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #18

---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.

- 시드 데이터는 `local` 프로필에서만 실행되며, 기동 시마다 초기화되므로 로컬에서만 사용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로컬 프로파일에서 챕터·질문·씬카드, 스토리북, 태그, 약관, 알림, 설정 등 샘플 데이터 초기 구성이 추가되었습니다.
  * 앱 실행 시 로컬 DB가 자동으로 초기화/시딩되어 확인용 데이터가 준비됩니다.
* **개선 사항**
  * 콘텐츠 생성 방식이 일관되게 정리되어 빌더 기반 생성 시 기본값이 더 안정적으로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->