### PR TITLE
[feat] 소셜 로그인(카카오) API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
     // OIDC ID Token
-    implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.37.4'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     implementation 'io.jsonwebtoken:jjwt-impl:0.13.0'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+    // OIDC ID Token
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -1,0 +1,4 @@
+package com.umc.halo.domain.member.controller;
+
+public class MemberController {
+}

--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -1,4 +1,7 @@
 package com.umc.halo.domain.member.controller;
 
-public class MemberController {
+import com.umc.halo.domain.member.controller.docs.MemberControllerDocs;
+
+public class MemberController implements MemberControllerDocs {
+
 }

--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import com.umc.halo.domain.member.exception.code.AuthSuccessCode;
 import com.umc.halo.domain.member.service.MemberService;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,7 +23,7 @@ public class MemberController implements MemberControllerDocs {
 
     @PostMapping("/v1/auth/login")
     public ApiResponse<LoginResponseDTO.LoginResponse> login(
-            @RequestBody LoginRequestDTO.Login dto
+            @RequestBody @Valid LoginRequestDTO.Login dto
     ) {
         BaseSuccessCode code = AuthSuccessCode.LOGIN_SUCCESS;
         return ApiResponse.onSuccess(code, memberService.login(dto));

--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -1,7 +1,30 @@
 package com.umc.halo.domain.member.controller;
 
 import com.umc.halo.domain.member.controller.docs.MemberControllerDocs;
+import com.umc.halo.domain.member.dto.request.LoginRequestDTO;
+import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
+import com.umc.halo.domain.member.exception.code.AuthSuccessCode;
+import com.umc.halo.domain.member.service.MemberService;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class MemberController implements MemberControllerDocs {
 
+    private final MemberService memberService;
+
+    @PostMapping("/v1/auth/login")
+    public ApiResponse<LoginResponseDTO.LoginResponse> login(
+            @RequestBody LoginRequestDTO.Login dto
+    ) {
+        BaseSuccessCode code = AuthSuccessCode.LOGIN_SUCCESS;
+        return ApiResponse.onSuccess(code, memberService.login(dto));
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -24,7 +24,6 @@ public interface MemberControllerDocs {
                     description = "성공 예시",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
                             examples = @ExampleObject(value = """
                                     {
                                         "isSuccess": true,
@@ -46,7 +45,6 @@ public interface MemberControllerDocs {
                     description = "provider가 KAKAO/GOOGLE 외 값",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
                             examples = @ExampleObject(value = """
                                     {
                                         "isSuccess":false,
@@ -63,7 +61,6 @@ public interface MemberControllerDocs {
                     description = "providerToken 검증 실패",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
                             examples = @ExampleObject(value = """
                                     {
                                         "isSuccess":false,

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -1,4 +1,80 @@
 package com.umc.halo.domain.member.controller.docs;
 
+import com.umc.halo.domain.member.dto.request.LoginRequestDTO;
+import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "회원 API")
 public interface MemberControllerDocs {
+
+    // 소셜 로그인
+    @Operation(
+            summary = "소셜 로그인 API"
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "AUTH200_1",
+                                        "message": "로그인 성공",
+                                        "result": {
+                                            "accessToken": "eyJ...",
+                                            "refreshToken": "eyJ...",
+                                            "isNewUser": true,
+                                            "onboardingCompleted": true
+                                        }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "provider가 KAKAO/GOOGLE 외 값",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess":false,
+                                        "code": "AUTH400_1",
+                                        "message": "지원하지 않는 소셜 로그인 제공자입니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "providerToken 검증 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess":false,
+                                        "code": "AUTH401_3",
+                                        "message": "소셜 인증 토큰 검증에 실패했습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ApiResponse<LoginResponseDTO.LoginResponse> login(@RequestBody LoginRequestDTO.Login dto);
 }

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -1,0 +1,4 @@
+package com.umc.halo.domain.member.controller.docs;
+
+public interface MemberControllerDocs {
+}

--- a/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
@@ -1,0 +1,8 @@
+package com.umc.halo.domain.member.converter;
+
+import com.umc.halo.domain.member.dto.request.LoginRequestDTO;
+import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
+
+public class MemberConverter {
+
+}

--- a/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
@@ -1,8 +1,4 @@
 package com.umc.halo.domain.member.converter;
 
-import com.umc.halo.domain.member.dto.request.LoginRequestDTO;
-import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
-
 public class MemberConverter {
-
 }

--- a/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
@@ -1,4 +1,29 @@
 package com.umc.halo.domain.member.converter;
 
+import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.member.enums.Provider;
+
 public class MemberConverter {
+
+    public static Member toMember(Provider provider, String providerId) {
+        return Member.builder()
+                .provider(provider)
+                .providerId(providerId)
+                .build();
+    }
+
+    public static LoginResponseDTO.LoginResponse toLoginResponse(
+            String accessToken,
+            String refreshToken,
+            Boolean isNewUser,
+            Boolean onboardingCompleted
+    ) {
+        return LoginResponseDTO.LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isNewUser(isNewUser)
+                .onboardingCompleted(onboardingCompleted)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/dto/request/LoginRequestDTO.java
+++ b/src/main/java/com/umc/halo/domain/member/dto/request/LoginRequestDTO.java
@@ -9,7 +9,7 @@ public class LoginRequestDTO {
     // 로그인
     public record Login (
             @NotNull
-            Provider provider,
+            String provider,
             @NotBlank
             String providerToken
     ) {}

--- a/src/main/java/com/umc/halo/domain/member/dto/request/LoginRequestDTO.java
+++ b/src/main/java/com/umc/halo/domain/member/dto/request/LoginRequestDTO.java
@@ -1,0 +1,16 @@
+package com.umc.halo.domain.member.dto.request;
+
+import com.umc.halo.domain.member.enums.Provider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class LoginRequestDTO {
+
+    // 로그인
+    public record Login (
+            @NotNull
+            Provider provider,
+            @NotBlank
+            String providerToken
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/member/dto/response/LoginResponseDTO.java
+++ b/src/main/java/com/umc/halo/domain/member/dto/response/LoginResponseDTO.java
@@ -1,0 +1,14 @@
+package com.umc.halo.domain.member.dto.response;
+
+import lombok.Builder;
+
+public class LoginResponseDTO {
+
+    @Builder
+    public record LoginResponse (
+            String accessToken,
+            String refreshToken,
+            Boolean isNewUser,
+            Boolean onboardingCompleted
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -44,6 +44,10 @@ public class Member extends BaseEntity {
     @Builder.Default
     private Boolean onboardingCompleted = false;
 
-    @Column(name = "refresh_token", length = 500)
-    private String refreshToken;
+    @Column(name = "refresh_token_hash", length = 64)
+    private String refreshTokenHash;
+
+    public void updateRefreshTokenToHash(String refreshTokenHash) {
+        this.refreshTokenHash = refreshTokenHash;
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -26,10 +26,7 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(name = "guest_uuid", length = 36)
-    private String guestUuid;
-
-    @Column(length = 10, nullable = false)
+    @Column(length = 10)
     private String name;
 
     @Enumerated(EnumType.STRING)
@@ -38,11 +35,10 @@ public class Member extends BaseEntity {
     @Column(name = "provider_id", length = 255)
     private String providerId;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    @Column(name = "birth_date", nullable = false)
+    @Column(name = "birth_date")
     private LocalDate birthDate;
 
     @Column(name = "onboarding_completed", nullable = false)

--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -47,6 +47,9 @@ public class Member extends BaseEntity {
     @Column(name = "refresh_token_hash", length = 64)
     private String refreshTokenHash;
 
+    @Column(name = "onboarding_step")
+    private Integer onboardingStep;
+
     public void updateRefreshTokenToHash(String refreshTokenHash) {
         this.refreshTokenHash = refreshTokenHash;
     }

--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -11,7 +11,6 @@ import java.time.*;
 @Table(
         name = "member",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_member_guest_uuid", columnNames = {"guest_uuid"}),
                 @UniqueConstraint(name = "uk_member_provider", columnNames = {"provider", "provider_id"})
         }
 )

--- a/src/main/java/com/umc/halo/domain/member/exception/MemberException.java
+++ b/src/main/java/com/umc/halo/domain/member/exception/MemberException.java
@@ -1,0 +1,10 @@
+package com.umc.halo.domain.member.exception;
+
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+
+public class MemberException extends ProjectException {
+    public MemberException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/member/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/member/exception/code/AuthErrorCode.java
@@ -1,0 +1,32 @@
+package com.umc.halo.domain.member.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+    // 400
+    UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST,
+            "AUTH400_1",
+            "지원하지 않는 소셜 로그인 제공자입니다."),
+
+    // 401
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,
+            "AUTH401_1",
+            "토큰이 만료되었습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,
+            "AUTH401_2",
+            "refreshToken이 만료되었거나 유효하지 않습니다."),
+    INVALID_PROVIDER_TOKEN(HttpStatus.UNAUTHORIZED,
+            "AUTH401_3",
+            "소셜 인증 토큰 검증에 실패했습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/member/exception/code/AuthSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/member/exception/code/AuthSuccessCode.java
@@ -1,0 +1,26 @@
+package com.umc.halo.domain.member.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthSuccessCode implements BaseSuccessCode {
+
+    LOGIN_SUCCESS(HttpStatus.OK,
+            "AUTH200_1",
+            "로그인 성공"),
+    TOKEN_REISSUE_SUCCESS(HttpStatus.OK,
+            "AUTH200_2",
+            "토큰 재발급 성공"),
+    LOGOUT_SUCCESS(HttpStatus.OK,
+            "AUTH200_3",
+            "로그아웃 성공")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/member/exception/code/MemberErrorCode.java
@@ -1,0 +1,20 @@
+package com.umc.halo.domain.member.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND,
+            "MEMBER404_1",
+            "존재하지 않는 회원입니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/member/exception/code/MemberSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/member/exception/code/MemberSuccessCode.java
@@ -1,0 +1,23 @@
+package com.umc.halo.domain.member.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberSuccessCode implements BaseSuccessCode {
+
+    INFO_SUCCESS(HttpStatus.OK,
+            "MEMBER200_1",
+            "내 정보 조회 성공"),
+    DELETE_SUCCESS(HttpStatus.OK,
+            "MEMBER200_2",
+            "회원 탈퇴가 완료되었습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/member/oauth/GoogleOidcProvider.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/GoogleOidcProvider.java
@@ -1,0 +1,18 @@
+package com.umc.halo.domain.member.oauth;
+
+import com.umc.halo.domain.member.enums.Provider;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoogleOidcProvider implements OidcProvider {
+
+    @Override
+    public String verify(String providerToken) {
+        return "";
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.GOOGLE;
+    }
+}

--- a/src/main/java/com/umc/halo/domain/member/oauth/KakaoOidcProvider.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/KakaoOidcProvider.java
@@ -1,0 +1,94 @@
+package com.umc.halo.domain.member.oauth;
+
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.umc.halo.domain.member.enums.Provider;
+import com.umc.halo.domain.member.exception.code.AuthErrorCode;
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.util.Date;
+
+@Component
+public class KakaoOidcProvider implements OidcProvider {
+
+    private final String clientId;
+    private final String jwksUri;
+    private final String issuer;
+    private final OidcJwksClient oidcJwksClient;
+
+    public KakaoOidcProvider(
+            @Value("${kakao.client-id}") String clientId,
+            @Value("${kakao.jwks-uri}") String jwksUri,
+            @Value("${kakao.issuer}") String issuer,
+            OidcJwksClient oidcJwksClient
+    ) {
+        this.clientId = clientId;
+        this.jwksUri = jwksUri;
+        this.issuer = issuer;
+        this.oidcJwksClient = oidcJwksClient;
+    }
+
+
+    @Override
+    public String verify(String providerToken) {
+
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(providerToken);
+            String kid = signedJWT.getHeader().getKeyID();
+
+            if (kid == null) {
+                throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            }
+
+            RSAPublicKey publicKey = oidcJwksClient.getPublicKey(jwksUri, kid);
+            JWSVerifier verifier = new RSASSAVerifier(publicKey);
+            
+            if (!signedJWT.verify(verifier)) {
+                throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            }
+
+            JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+
+            if (!issuer.equals(claims.getIssuer())) {
+                throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            }
+
+            if (claims.getAudience() == null || !claims.getAudience().contains(clientId)) {
+                throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            }
+
+            Date expiration = claims.getExpirationTime();
+
+            if (expiration == null || expiration.before(new Date())) {
+                throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            }
+
+            String subject = claims.getSubject();
+
+            if (subject == null) {
+                throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            }
+
+            return subject;
+
+        } catch (ProjectException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+        }
+    }
+
+    @Override
+    public Provider getProvider() {
+        return Provider.KAKAO;
+    }
+}

--- a/src/main/java/com/umc/halo/domain/member/oauth/OidcJwksClient.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/OidcJwksClient.java
@@ -1,32 +1,48 @@
 package com.umc.halo.domain.member.oauth;
 
 import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.JWKMatcher;
+import com.nimbusds.jose.jwk.JWKSelector;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.SecurityContext;
 import com.umc.halo.domain.member.exception.code.AuthErrorCode;
 import com.umc.halo.global.apiPayload.exception.ProjectException;
 import org.springframework.stereotype.Component;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.interfaces.RSAPublicKey;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 public class OidcJwksClient {
 
-    private final ConcurrentHashMap<String, JWKSet> cache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, RemoteJWKSet<SecurityContext>> jwkSources = new ConcurrentHashMap<>();
 
     public RSAPublicKey getPublicKey(String jwksUri, String kid) {
 
-        JWKSet jwkSet = cache.computeIfAbsent(jwksUri, this::loadJwkSet);
-
         try {
-            JWK jwk = jwkSet.getKeyByKeyId(kid);
+            JWKSource<SecurityContext> jwkSource = jwkSources.computeIfAbsent(
+                    jwksUri,
+                    uri -> new RemoteJWKSet<>(
+                            createURL(uri)
+                    )
+            );
 
-            if (jwk == null) {
+            JWKSelector selector = new JWKSelector(new JWKMatcher.Builder()
+                    .keyID(kid)
+                    .build()
+            );
+
+            List<JWK> jwks = jwkSource.get(selector, null);
+
+            if (jwks.isEmpty()) {
                 throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
             }
 
-            return jwk.toRSAKey().toRSAPublicKey();
+            return jwks.get(0).toRSAKey().toRSAPublicKey();
 
         } catch (ProjectException e) {
             throw e;
@@ -35,11 +51,11 @@ public class OidcJwksClient {
         }
     }
 
-    private JWKSet loadJwkSet(String jwksUri) {
+    private URL createURL(String uri) {
         try {
-            return JWKSet.load(new URL(jwksUri));
-        } catch (Exception e) {
-            throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            return new URL(uri);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/main/java/com/umc/halo/domain/member/oauth/OidcJwksClient.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/OidcJwksClient.java
@@ -1,0 +1,45 @@
+package com.umc.halo.domain.member.oauth;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.umc.halo.domain.member.exception.code.AuthErrorCode;
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+import org.springframework.stereotype.Component;
+
+import java.net.URL;
+import java.security.interfaces.RSAPublicKey;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class OidcJwksClient {
+
+    private final ConcurrentHashMap<String, JWKSet> cache = new ConcurrentHashMap<>();
+
+    public RSAPublicKey getPublicKey(String jwksUri, String kid) {
+
+        JWKSet jwkSet = cache.computeIfAbsent(jwksUri, this::loadJwkSet);
+
+        try {
+            JWK jwk = jwkSet.getKeyByKeyId(kid);
+
+            if (jwk == null) {
+                throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            }
+
+            return jwk.toRSAKey().toRSAPublicKey();
+
+        } catch (ProjectException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+        }
+    }
+
+    private JWKSet loadJwkSet(String jwksUri) {
+        try {
+            return JWKSet.load(new URL(jwksUri));
+        } catch (Exception e) {
+            throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/umc/halo/domain/member/oauth/OidcProvider.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/OidcProvider.java
@@ -1,0 +1,8 @@
+package com.umc.halo.domain.member.oauth;
+
+import com.umc.halo.domain.member.enums.Provider;
+
+public interface OidcProvider {
+    String verify(String providerToken);
+    Provider getProvider();
+}

--- a/src/main/java/com/umc/halo/domain/member/oauth/OidcProviderFactory.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/OidcProviderFactory.java
@@ -1,0 +1,35 @@
+package com.umc.halo.domain.member.oauth;
+
+import com.umc.halo.domain.member.enums.Provider;
+import com.umc.halo.domain.member.exception.code.AuthErrorCode;
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class OidcProviderFactory {
+
+    private final Map<Provider, OidcProvider> providers;
+
+    public OidcProviderFactory(List<OidcProvider> oidcProviders) {
+        this.providers = oidcProviders.stream()
+                .collect(Collectors.toMap(
+                        OidcProvider::getProvider,
+                        provider->provider
+                ));
+    }
+
+    public OidcProvider getProvider(Provider provider) {
+        OidcProvider oidcProvider = providers.get(provider);
+
+        if (oidcProvider == null) {
+            throw new ProjectException(AuthErrorCode.UNSUPPORTED_PROVIDER);
+        }
+
+        return oidcProvider;
+    }
+}

--- a/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
@@ -1,9 +1,13 @@
 package com.umc.halo.domain.member.repository;
 
 import com.umc.halo.domain.member.entity.*;
+import com.umc.halo.domain.member.enums.Provider;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -1,4 +1,9 @@
 package com.umc.halo.domain.member.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class MemberService {
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -1,7 +1,5 @@
 package com.umc.halo.domain.member.service;
 
-import com.umc.halo.domain.member.dto.request.LoginRequestDTO;
-import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
 import com.umc.halo.domain.member.repository.MemberRepository;
 import com.umc.halo.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +11,4 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
-
-    public LoginResponseDTO.LoginResponse login(LoginRequestDTO.Login dto) {
-        return null;
-    }
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -4,12 +4,16 @@ import com.umc.halo.domain.member.converter.MemberConverter;
 import com.umc.halo.domain.member.dto.request.LoginRequestDTO;
 import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
 import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.member.enums.Provider;
+import com.umc.halo.domain.member.exception.code.AuthErrorCode;
 import com.umc.halo.domain.member.oauth.OidcProvider;
 import com.umc.halo.domain.member.oauth.OidcProviderFactory;
 import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.global.apiPayload.exception.ProjectException;
 import com.umc.halo.global.security.HashUtil;
 import com.umc.halo.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,16 +29,29 @@ public class MemberService {
     @Transactional
     public LoginResponseDTO.LoginResponse login(LoginRequestDTO.Login dto) {
 
-        OidcProvider oidcProvider = oidcProviderFactory.getProvider(dto.provider());
+        Provider provider;
+
+        try {
+            provider = Provider.valueOf(dto.provider());
+        } catch (IllegalArgumentException e) {
+            throw new ProjectException(AuthErrorCode.UNSUPPORTED_PROVIDER);
+        }
+
+        OidcProvider oidcProvider = oidcProviderFactory.getProvider(provider);
         String providerId = oidcProvider.verify(dto.providerToken());
 
-        Member member = memberRepository.findByProviderAndProviderId(dto.provider(), providerId).orElse(null);
+        Member member = memberRepository.findByProviderAndProviderId(provider, providerId).orElse(null);
         boolean isNewUser = false;
 
         if (member == null) {
-            member = MemberConverter.toMember(dto.provider(), providerId);
-            memberRepository.save(member);
-            isNewUser = true;
+            try{
+                member = MemberConverter.toMember(provider, providerId);
+                memberRepository.save(member);
+                isNewUser = true;
+            } catch (DataIntegrityViolationException e) {
+                member = memberRepository.findByProviderAndProviderId(provider, providerId).orElseThrow(() -> e);
+            }
+
         }
 
         String accessToken = jwtUtil.createAccessToken(member.getId());

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -1,9 +1,18 @@
 package com.umc.halo.domain.member.service;
 
+import com.umc.halo.domain.member.dto.request.LoginRequestDTO;
+import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
+import com.umc.halo.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public LoginResponseDTO.LoginResponse login(LoginRequestDTO.Login dto) {
+        return null;
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.umc.halo.domain.member.service;
 import com.umc.halo.domain.member.dto.request.LoginRequestDTO;
 import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
 import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
 
     public LoginResponseDTO.LoginResponse login(LoginRequestDTO.Login dto) {
         return null;

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -1,0 +1,4 @@
+package com.umc.halo.domain.member.service;
+
+public class MemberService {
+}

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -1,9 +1,17 @@
 package com.umc.halo.domain.member.service;
 
+import com.umc.halo.domain.member.converter.MemberConverter;
+import com.umc.halo.domain.member.dto.request.LoginRequestDTO;
+import com.umc.halo.domain.member.dto.response.LoginResponseDTO;
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.member.oauth.OidcProvider;
+import com.umc.halo.domain.member.oauth.OidcProviderFactory;
 import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.global.security.HashUtil;
 import com.umc.halo.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -11,4 +19,28 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
+    private final HashUtil hashUtil;
+    private final OidcProviderFactory oidcProviderFactory;
+
+    @Transactional
+    public LoginResponseDTO.LoginResponse login(LoginRequestDTO.Login dto) {
+
+        OidcProvider oidcProvider = oidcProviderFactory.getProvider(dto.provider());
+        String providerId = oidcProvider.verify(dto.providerToken());
+
+        Member member = memberRepository.findByProviderAndProviderId(dto.provider(), providerId).orElse(null);
+        boolean isNewUser = false;
+
+        if (member == null) {
+            member = MemberConverter.toMember(dto.provider(), providerId);
+            memberRepository.save(member);
+            isNewUser = true;
+        }
+
+        String accessToken = jwtUtil.createAccessToken(member.getId());
+        String refreshToken = jwtUtil.createRefreshToken(member.getId());
+        member.updateRefreshTokenToHash(hashUtil.hash(refreshToken));
+
+        return MemberConverter.toLoginResponse(accessToken, refreshToken, isNewUser, member.getOnboardingCompleted());
+    }
 }

--- a/src/main/java/com/umc/halo/global/security/HashUtil.java
+++ b/src/main/java/com/umc/halo/global/security/HashUtil.java
@@ -1,0 +1,24 @@
+package com.umc.halo.global.security;
+
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+@Component
+public class HashUtil {
+
+    public String hash(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/umc/halo/global/security/JwtUtil.java
+++ b/src/main/java/com/umc/halo/global/security/JwtUtil.java
@@ -35,6 +35,7 @@ public class JwtUtil {
         Instant now = Instant.now();
         return Jwts.builder()
                 .subject(String.valueOf(memberId))
+                .claim("type", "access")
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.plus(accessExpiration)))
                 .signWith(secretKey)
@@ -46,6 +47,7 @@ public class JwtUtil {
         Instant now = Instant.now();
         return Jwts.builder()
                 .subject(String.valueOf(memberId))
+                .claim("type", "refresh")
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.plus(refreshExpiration)))
                 .signWith(secretKey)

--- a/src/main/java/com/umc/halo/global/security/JwtUtil.java
+++ b/src/main/java/com/umc/halo/global/security/JwtUtil.java
@@ -18,13 +18,16 @@ public class JwtUtil {
 
     private final SecretKey secretKey;
     private final Duration accessExpiration;
+    private final Duration refreshExpiration;
 
     public JwtUtil(
             @Value("${jwt.token.secretKey}") String secret,
-            @Value("${jwt.token.expiration.access}") Long accessExpiration
+            @Value("${jwt.token.expiration.access}") Long accessExpiration,
+            @Value("${jwt.token.expiration.refresh}") Long refreshExpiration
     ) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessExpiration = Duration.ofMillis(accessExpiration);
+        this.refreshExpiration = Duration.ofMillis(refreshExpiration);
     }
 
     // accessToken 생성: subject(sub)에 memberId를 담음
@@ -34,6 +37,17 @@ public class JwtUtil {
                 .subject(String.valueOf(memberId))
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.plus(accessExpiration)))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // refreshToken 생성: subject(sub)에 memberId를 담음
+    public String createRefreshToken(Long memberId) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(refreshExpiration)))
                 .signWith(secretKey)
                 .compact();
     }

--- a/src/main/java/com/umc/halo/global/seed/MemberSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/MemberSeeder.java
@@ -23,7 +23,6 @@ public class MemberSeeder {
         List<Member> members = List.of(
                 Member.builder()
                         .name("김하로")
-                        .guestUuid(UUID.randomUUID().toString())
                         .provider(Provider.KAKAO)
                         .providerId("kakao-0001")
                         .gender(Gender.FEMALE)
@@ -32,7 +31,6 @@ public class MemberSeeder {
                         .build(),
                 Member.builder()
                         .name("이온")
-                        .guestUuid(UUID.randomUUID().toString())
                         .provider(Provider.GOOGLE)
                         .providerId("google-0001")
                         .gender(Gender.MALE)
@@ -41,7 +39,6 @@ public class MemberSeeder {
                         .build(),
                 Member.builder()
                         .name("송하루")
-                        .guestUuid(UUID.randomUUID().toString())
                         .gender(Gender.MALE)
                         .birthDate(LocalDate.of(2011, 4, 5))
                         .build()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,5 @@ jwt:
 
 kakao:
   client-id: ${KAKAO_REST_API_KEY}
+  jwks-uri: https://kauth.kakao.com/.well-known/jwks.json
+  issuer: https://kauth.kakao.com

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,3 +28,6 @@ jwt:
     secretKey: ${JWT_SECRET_KEY}
     expiration:
       access: 3600000   # 1시간
+
+kakao:
+  client-id: ${KAKAO_REST_API_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ jwt:
     secretKey: ${JWT_SECRET_KEY}
     expiration:
       access: 3600000   # 1시간
+      refresh: 1209600000 # 2주
 
 kakao:
   client-id: ${KAKAO_REST_API_KEY}


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 소셜 로그인(카카오) API 구현
- Member 엔티티 수정 
- OIDC ID Token 검증 로직 구현  
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 변경된 ERD에 맞추어 Member 엔티티 수정
- MemberSuccessCode/MemberErrorCode 추가
- AuthSuccessCode/AuthErrorCode 추가
- 소셜 로그인(카카오) 관련 Request/Response DTO 추가
- 소셜 로그인(카카오) 관련 MemberConverter 추가
- POST /api/v1/auth/login 구현
- Swagger 문서 작성
- OIDC ID TOKEN 검증을 위한 OidcJwksClient/KakaoOidcProvider 구현
- 소셜 제공자 구분을 위한 OicdProviderFactory 구현
- refreshToken 생성 로직 추가
- refreshToken 해시 처리 추가  
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="959" height="548" alt="image" src="https://github.com/user-attachments/assets/7bd1f529-c9ad-4e2e-a06c-5e250589398b" />


---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #25 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp


- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61?p=abeca1e217c0832493ac8163fef58c69&pm=s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 소셜 로그인 `POST /api/v1/auth/login`(구글/카카오)을 추가했습니다.
  * 로그인 응답에 액세스/리프레시 토큰, 신규 여부, 온보딩 완료 상태를 제공합니다.
* **개선 사항**
  * OIDC 기반 공급자 토큰 검증과 표준화된 성공/오류 응답(미지원/토큰 오류)을 제공합니다.
  * Swagger 문서에 요청/응답 예시와 상태 코드(200/400/401)를 추가했습니다.
  * 리프레시 토큰 만료 정책을 확장하고, 리프레시 토큰은 해시 형태로 관리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->