### PR TITLE
[fix] ApiResponse 내 의도치 않은 success 필드 반환 수정

### DIFF
--- a/src/main/java/com/umc/halo/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.umc.halo.global.apiPayload;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.umc.halo.global.apiPayload.code.BaseErrorCode;
@@ -11,6 +12,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 @JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@JsonIgnoreProperties({"success"})
 public class ApiResponse<T> {
 
 	@JsonProperty("isSuccess")


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- ApiResponse 내 의도치 않은 success 필드 반환 수정
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `ApiResponse` `@JsonIgnoreProperties({"success"})` 추
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="342" height="122" alt="image" src="https://github.com/user-attachments/assets/54126df9-12fa-4ab3-b3c1-f462cf174441" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #27
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * API 응답의 JSON 처리 시 `success` 속성이 불필요하게 직렬화되거나 역직렬화되지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->