### PR TITLE
[feat] 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -28,4 +28,12 @@ public class MemberController implements MemberControllerDocs {
         BaseSuccessCode code = AuthSuccessCode.LOGIN_SUCCESS;
         return ApiResponse.onSuccess(code, memberService.login(dto));
     }
+
+    @PostMapping("/v1/auth/reissue")
+    public ApiResponse<MemberResDTO.TokenReissue> tokenReissue(
+            @RequestBody @Valid MemberReqDTO.TokenReissue dto
+    ) {
+        BaseSuccessCode code = AuthSuccessCode.TOKEN_REISSUE_SUCCESS;
+        return ApiResponse.onSuccess(code, memberService.tokenReissue(dto));
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -74,6 +74,7 @@ public interface MemberControllerDocs {
     })
     ApiResponse<MemberResDTO.Login> login(@RequestBody MemberReqDTO.Login dto);
 
+    // 토큰 재발급 API
     @Operation(
             summary = "토큰 재발급 API"
     )

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -46,7 +46,7 @@ public interface MemberControllerDocs {
                             mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
-                                        "isSuccess":false,
+                                        "isSuccess": false,
                                         "code": "AUTH400_1",
                                         "message": "지원하지 않는 소셜 로그인 제공자입니다.",
                                         "result": null
@@ -62,7 +62,7 @@ public interface MemberControllerDocs {
                             mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
-                                        "isSuccess":false,
+                                        "isSuccess": false,
                                         "code": "AUTH401_3",
                                         "message": "소셜 인증 토큰 검증에 실패했습니다.",
                                         "result": null
@@ -73,4 +73,46 @@ public interface MemberControllerDocs {
             )
     })
     ApiResponse<MemberResDTO.Login> login(@RequestBody MemberReqDTO.Login dto);
+
+    @Operation(
+            summary = "토큰 재발급 API"
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "AUTH200_2",
+                                        "message": "토큰 재발급 성공",
+                                        "result": {
+                                            "accessToken": "eyJ...",
+                                            "refreshToken": "eyJ..."
+                                        }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "refreshToken 만료·위변조·저장값 불일치",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_2",
+                                        "message": "refreshToken이 만료되었거나 유효하지 않습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ApiResponse<MemberResDTO.TokenReissue> tokenReissue(@RequestBody MemberReqDTO.TokenReissue dto);
 }

--- a/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
@@ -28,4 +28,14 @@ public class MemberConverter {
                 .onboardingCompleted(onboardingCompleted)
                 .build();
     }
+
+    public static MemberResDTO.TokenReissue toTokenReissueResponse(
+            String accessToken,
+            String refreshToken
+    ) {
+        return MemberResDTO.TokenReissue.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
@@ -3,13 +3,15 @@ package com.umc.halo.domain.member.converter;
 import com.umc.halo.domain.member.dto.MemberResDTO;
 import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.member.enums.Provider;
+import com.umc.halo.domain.member.oauth.OidcUserInfo;
 
 public class MemberConverter {
 
-    public static Member toMember(Provider provider, String providerId) {
+    public static Member toMember(Provider provider, OidcUserInfo oidcUserInfo) {
         return Member.builder()
                 .provider(provider)
-                .providerId(providerId)
+                .providerId(oidcUserInfo.providerId())
+                .email(oidcUserInfo.email())
                 .build();
     }
 

--- a/src/main/java/com/umc/halo/domain/member/dto/MemberReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/member/dto/MemberReqDTO.java
@@ -6,10 +6,16 @@ import jakarta.validation.constraints.NotNull;
 public class MemberReqDTO {
 
     // 로그인
-    public record Login (
+    public record Login(
             @NotNull
             String provider,
             @NotBlank
             String providerToken
+    ) {}
+
+    // 토큰 재발급
+    public record TokenReissue(
+            @NotBlank
+            String refreshToken
     ) {}
 }

--- a/src/main/java/com/umc/halo/domain/member/dto/MemberResDTO.java
+++ b/src/main/java/com/umc/halo/domain/member/dto/MemberResDTO.java
@@ -11,4 +11,10 @@ public class MemberResDTO {
             Boolean isNewUser,
             Boolean onboardingCompleted
     ) {}
+
+    @Builder
+    public record TokenReissue(
+            String accessToken,
+            String refreshToken
+    ) {}
 }

--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -40,12 +40,15 @@ public class Member extends BaseEntity {
     @Column(name = "birth_date")
     private LocalDate birthDate;
 
-    @Column(name = "onboarding_completed", nullable = false)
-    @Builder.Default
-    private Boolean onboardingCompleted = false;
+    @Column(name = "email", length = 255)
+    private String email;
 
     @Column(name = "refresh_token_hash", length = 64)
     private String refreshTokenHash;
+
+    @Column(name = "onboarding_completed", nullable = false)
+    @Builder.Default
+    private Boolean onboardingCompleted = false;
 
     @Column(name = "onboarding_step")
     private Integer onboardingStep;

--- a/src/main/java/com/umc/halo/domain/member/oauth/AbstractOidcProvider.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/AbstractOidcProvider.java
@@ -31,7 +31,7 @@ public abstract class AbstractOidcProvider {
         return getIssuer().equals(issuer);
     }
 
-    public final String verify(String providerToken) {
+    public final OidcUserInfo verify(String providerToken) {
         try {
             SignedJWT signedJWT = SignedJWT.parse(providerToken);
             String kid = signedJWT.getHeader().getKeyID();
@@ -69,7 +69,9 @@ public abstract class AbstractOidcProvider {
                 throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
             }
 
-            return subject;
+            String email = claims.getStringClaim("email");
+
+            return new OidcUserInfo(subject, email);
 
         } catch (ProjectException e) {
             throw e;

--- a/src/main/java/com/umc/halo/domain/member/oauth/OidcUserInfo.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/OidcUserInfo.java
@@ -1,0 +1,6 @@
+package com.umc.halo.domain.member.oauth;
+
+public record OidcUserInfo(
+        String providerId,
+        String email
+) {}

--- a/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
@@ -2,7 +2,9 @@ package com.umc.halo.domain.member.repository;
 
 import com.umc.halo.domain.member.entity.*;
 import com.umc.halo.domain.member.enums.Provider;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.*;
 
 import java.util.Optional;
@@ -10,4 +12,12 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select m
+        from Member m
+        where m.id = :id
+       """)
+    Optional<Member> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
@@ -11,7 +11,15 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        select m
+        from Member m
+        where m.provider = :provider
+        and m.providerId = :providerId
+    """)
+    Optional<Member> findByProviderAndProviderIdForUpdate(@Param("provider") Provider provider, @Param("providerId") String providerId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("""

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -8,6 +8,7 @@ import com.umc.halo.domain.member.enums.Provider;
 import com.umc.halo.domain.member.exception.code.AuthErrorCode;
 import com.umc.halo.domain.member.oauth.AbstractOidcProvider;
 import com.umc.halo.domain.member.oauth.OidcProviderFactory;
+import com.umc.halo.domain.member.oauth.OidcUserInfo;
 import com.umc.halo.domain.member.repository.MemberRepository;
 import com.umc.halo.global.apiPayload.exception.ProjectException;
 import com.umc.halo.global.security.HashUtil;
@@ -38,18 +39,18 @@ public class MemberService {
         }
 
         AbstractOidcProvider oidcProvider = oidcProviderFactory.getProvider(provider);
-        String providerId = oidcProvider.verify(dto.providerToken());
+        OidcUserInfo oidcUserInfo = oidcProvider.verify(dto.providerToken());
 
-        Member member = memberRepository.findByProviderAndProviderId(provider, providerId).orElse(null);
+        Member member = memberRepository.findByProviderAndProviderId(provider, oidcUserInfo.providerId()).orElse(null);
         boolean isNewUser = false;
 
         if (member == null) {
             try{
-                member = MemberConverter.toMember(provider, providerId);
+                member = MemberConverter.toMember(provider, oidcUserInfo);
                 memberRepository.save(member);
                 isNewUser = true;
             } catch (DataIntegrityViolationException e) {
-                member = memberRepository.findByProviderAndProviderId(provider, providerId).orElseThrow(() -> e);
+                member = memberRepository.findByProviderAndProviderId(provider, oidcUserInfo.providerId()).orElseThrow(() -> e);
             }
 
         }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -6,12 +6,13 @@ import com.umc.halo.domain.member.dto.MemberResDTO;
 import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.member.enums.Provider;
 import com.umc.halo.domain.member.exception.code.AuthErrorCode;
+import com.umc.halo.domain.member.exception.code.MemberErrorCode;
 import com.umc.halo.domain.member.oauth.AbstractOidcProvider;
 import com.umc.halo.domain.member.oauth.OidcProviderFactory;
 import com.umc.halo.domain.member.oauth.OidcUserInfo;
 import com.umc.halo.domain.member.repository.MemberRepository;
 import com.umc.halo.global.apiPayload.exception.ProjectException;
-import com.umc.halo.global.security.HashUtil;
+import com.umc.halo.global.util.HashUtil;
 import com.umc.halo.global.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -60,5 +61,29 @@ public class MemberService {
         member.updateRefreshTokenToHash(hashUtil.hash(refreshToken));
 
         return MemberConverter.toLoginResponse(accessToken, refreshToken, isNewUser, member.getOnboardingCompleted());
+    }
+
+    @Transactional
+    public MemberResDTO.TokenReissue tokenReissue(MemberReqDTO.TokenReissue dto) {
+
+        String refreshToken = dto.refreshToken();
+
+        if (!jwtUtil.isValid(refreshToken) || !jwtUtil.isRefreshToken(refreshToken)) {
+            throw new ProjectException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        Long memberId = jwtUtil.getMemberId(refreshToken);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ProjectException(MemberErrorCode.NOT_FOUND));
+
+        if (!hashUtil.matches(refreshToken, member.getRefreshTokenHash())) {
+            throw new ProjectException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        String newAccessToken = jwtUtil.createAccessToken(memberId);
+        String newRefreshToken = jwtUtil.createRefreshToken(memberId);
+        member.updateRefreshTokenToHash(hashUtil.hash(newRefreshToken));
+
+        return MemberConverter.toTokenReissueResponse(newAccessToken, newRefreshToken);
     }
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -73,7 +73,7 @@ public class MemberService {
         }
 
         Long memberId = jwtUtil.getMemberId(refreshToken);
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdForUpdate(memberId)
                 .orElseThrow(() -> new ProjectException(MemberErrorCode.NOT_FOUND));
 
         if (!hashUtil.matches(refreshToken, member.getRefreshTokenHash())) {

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
         AbstractOidcProvider oidcProvider = oidcProviderFactory.getProvider(provider);
         OidcUserInfo oidcUserInfo = oidcProvider.verify(dto.providerToken());
 
-        Member member = memberRepository.findByProviderAndProviderId(provider, oidcUserInfo.providerId()).orElse(null);
+        Member member = memberRepository.findByProviderAndProviderIdForUpdate(provider, oidcUserInfo.providerId()).orElse(null);
         boolean isNewUser = false;
 
         if (member == null) {
@@ -51,7 +51,7 @@ public class MemberService {
                 memberRepository.save(member);
                 isNewUser = true;
             } catch (DataIntegrityViolationException e) {
-                member = memberRepository.findByProviderAndProviderId(provider, oidcUserInfo.providerId()).orElseThrow(() -> e);
+                member = memberRepository.findByProviderAndProviderIdForUpdate(provider, oidcUserInfo.providerId()).orElseThrow(() -> e);
             }
 
         }

--- a/src/main/java/com/umc/halo/global/security/JwtUtil.java
+++ b/src/main/java/com/umc/halo/global/security/JwtUtil.java
@@ -69,6 +69,11 @@ public class JwtUtil {
         }
     }
 
+    // refreshToken인지 검증
+    public boolean isRefreshToken(String token) {
+        return "refresh".equals(getClaims(token).get("type", String.class));
+    }
+
     private Claims getClaims(String token) {
         return Jwts.parser()
                 .verifyWith(secretKey)

--- a/src/main/java/com/umc/halo/global/util/HashUtil.java
+++ b/src/main/java/com/umc/halo/global/util/HashUtil.java
@@ -1,6 +1,5 @@
-package com.umc.halo.global.security;
+package com.umc.halo.global.util;
 
-import com.umc.halo.global.apiPayload.exception.ProjectException;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
@@ -20,5 +19,9 @@ public class HashUtil {
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public boolean matches(String token, String hashedToken) {
+        return hash(token).equals(hashedToken);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- Member 엔티티에 email 추가
- 토큰 재발급 관련 Request/Response DTO 추가
- 토큰 재발급 관련 Converter 추가
- POST /ap1/v1/auth/reissue 구현
- refreshToken인지 확인하기 위한 JwtUtil.isRefreshToken() 메서드 구현
- refreshToken 값과 해싱으로 저장된 refreshToken 값을 비교하기 위한 HashUtil.matches() 메서드 구현
- member 테이블에 email을 전달하기 위한 OidcUserInfo record 생성
- Swagger 문서화
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- member 테이블에 email을 전달하기 위해 OidcUserInfo 파일 추가
- 사용자의 refreshToken과 DB에 해시돼서 저장된 refreshToken 값을 비교하기 위한 HashUtil의 메서드 추가
- Request Body에 전달한 토큰이 refreshToken이 맞는지 확인하기 위한 검증 로직 JwtUtil에 추가
- 토큰 재발급 관련 Request/Response DTO 추가
- 토큰 재발급 관련 Converter 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="959" height="514" alt="image" src="https://github.com/user-attachments/assets/1eaa4a88-6bc1-4fae-a079-4be63d4d5c4b" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #31 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp


- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61?p=38fca1e217c08039aa4ccec18106b065&pm=s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리프레시 토큰 기반 인증 토큰 재발급 API를 추가했습니다(성공 시 새 액세스/리프레시 토큰 발급).
  * 소셜 로그인에서 이메일 정보를 함께 처리하도록 개선했습니다.
* **문서**
  * 토큰 재발급 API의 성공/실패 응답 예시를 추가하고 표기 형식을 일관되게 정리했습니다.
* **오류 수정**
  * 리프레시 토큰 유효성/유형 및 저장된 정보 불일치에 대한 검증을 강화해 재발급 안정성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->