### PR TITLE
[feat] 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -9,6 +9,7 @@ import com.umc.halo.global.apiPayload.ApiResponse;
 import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +36,15 @@ public class MemberController implements MemberControllerDocs {
     ) {
         BaseSuccessCode code = AuthSuccessCode.TOKEN_REISSUE_SUCCESS;
         return ApiResponse.onSuccess(code, memberService.tokenReissue(dto));
+    }
+
+    @PostMapping("/v1/auth/logout")
+    public ApiResponse<Void> logout(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        memberService.logout(memberId);
+        BaseSuccessCode code = AuthSuccessCode.LOGOUT_SUCCESS;
+        return ApiResponse.onSuccess(code);
+
     }
 }

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -6,8 +6,10 @@ import com.umc.halo.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "회원 API")
@@ -116,4 +118,44 @@ public interface MemberControllerDocs {
             )
     })
     ApiResponse<MemberResDTO.TokenReissue> tokenReissue(@RequestBody MemberReqDTO.TokenReissue dto);
+
+    // 로그아웃 API
+    @Operation(
+            summary = "로그아웃 API"
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "AUTH200_3",
+                                        "message": "로그아웃 성공",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_1",
+                                        "message": "토큰이 만료되었습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ApiResponse<Void> logout(@AuthenticationPrincipal Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -56,4 +56,8 @@ public class Member extends BaseEntity {
     public void updateRefreshTokenToHash(String refreshTokenHash) {
         this.refreshTokenHash = refreshTokenHash;
     }
+
+    public void deleteRefreshToken() {
+        this.refreshTokenHash = null;
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -19,6 +19,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService {
@@ -85,5 +87,12 @@ public class MemberService {
         member.updateRefreshTokenToHash(hashUtil.hash(newRefreshToken));
 
         return MemberConverter.toTokenReissueResponse(newAccessToken, newRefreshToken);
+    }
+
+    @Transactional
+    public void logout(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ProjectException(MemberErrorCode.NOT_FOUND));
+        member.deleteRefreshToken();
     }
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -91,7 +91,7 @@ public class MemberService {
 
     @Transactional
     public void logout(Long memberId) {
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdForUpdate(memberId)
                 .orElseThrow(() -> new ProjectException(MemberErrorCode.NOT_FOUND));
         member.deleteRefreshToken();
     }

--- a/src/main/java/com/umc/halo/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/halo/global/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/v3/api-docs/**",
             // 인증(소셜 로그인 / 토큰 재발급)
-            "/api/v1/auth/**",
+            "/api/v1/auth/login",
+            "/api/v1/auth/reissue",
             // 온보딩 (로그인 전 guest_uuid 기반)
             "/api/v1/onboarding/**"
     };


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- POST /api/v1/auth/logout API 구현
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- SecurityConfig 파일에서 PUBLIC_URIS 수정 (/api/v1/auth/logout은 PRIVATE_URIS이기 때문에 /api/v1/auth/** -> /api/v1/auth/login & /api/v1/auth/reissue로 수정)
- Member 엔티티에 refreshToken을 null로 만드는 메서드 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
<img width="953" height="455" alt="image" src="https://github.com/user-attachments/assets/948fe55e-f99b-46c7-9eba-f2c75162a577" />

<img width="949" height="275" alt="image" src="https://github.com/user-attachments/assets/ac9a1daf-68b0-42c2-b0a4-75aef680bee4" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #33 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp


- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61?p=38fca1e217c0808da4dcdacf7e224a0c&pm=s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자를 위한 로그아웃 API를 추가했습니다.
* **개선 사항**
  * 로그인 및 토큰 재발급 경로만 공개 접근이 가능하도록 보안을 강화했습니다.
  * 로그아웃 시 저장된 리프레시 토큰이 삭제됩니다.
* **문서**
  * 로그아웃 API의 Swagger 문서 및 응답 예시를 추가했습니다.
* **오류 처리**
  * 존재하지 않는 회원의 로그아웃 요청 시 적절한 오류 응답을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->