### PR TITLE
[feat] 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -4,16 +4,14 @@ import com.umc.halo.domain.member.controller.docs.MemberControllerDocs;
 import com.umc.halo.domain.member.dto.MemberReqDTO;
 import com.umc.halo.domain.member.dto.MemberResDTO;
 import com.umc.halo.domain.member.exception.code.AuthSuccessCode;
+import com.umc.halo.domain.member.exception.code.MemberSuccessCode;
 import com.umc.halo.domain.member.service.MemberService;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,5 +44,14 @@ public class MemberController implements MemberControllerDocs {
         BaseSuccessCode code = AuthSuccessCode.LOGOUT_SUCCESS;
         return ApiResponse.onSuccess(code);
 
+    }
+
+    @DeleteMapping("/v1/members/me")
+    public ApiResponse<Void> withdraw(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        memberService.withdraw(memberId);
+        BaseSuccessCode code = MemberSuccessCode.DELETE_SUCCESS;
+        return ApiResponse.onSuccess(code);
     }
 }

--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.umc.halo.domain.member.exception.code.MemberSuccessCode;
 import com.umc.halo.domain.member.service.MemberService;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -38,6 +39,7 @@ public class MemberController implements MemberControllerDocs {
 
     @PostMapping("/v1/auth/logout")
     public ApiResponse<Void> logout(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal Long memberId
     ) {
         memberService.logout(memberId);
@@ -48,6 +50,7 @@ public class MemberController implements MemberControllerDocs {
 
     @DeleteMapping("/v1/members/me")
     public ApiResponse<Void> withdraw(
+            @Parameter(hidden = true)
             @AuthenticationPrincipal Long memberId
     ) {
         memberService.withdraw(memberId);

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -158,4 +158,60 @@ public interface MemberControllerDocs {
             )
     })
     ApiResponse<Void> logout(@AuthenticationPrincipal Long memberId);
+
+    // 회원 탈퇴 API
+    @Operation(
+            summary = "회원 탈퇴 API"
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "MEMBER200_2",
+                                        "message": "회원 탈퇴가 완료되었습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_1",
+                                        "message": "토큰이 만료되었습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "해당 member 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "MEMBER404_1",
+                                        "message": "존재하지 않는 회원입니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ApiResponse<Void> withdraw(@AuthenticationPrincipal Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -4,6 +4,7 @@ import com.umc.halo.domain.member.dto.MemberReqDTO;
 import com.umc.halo.domain.member.dto.MemberResDTO;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -157,7 +158,7 @@ public interface MemberControllerDocs {
                     )
             )
     })
-    ApiResponse<Void> logout(@AuthenticationPrincipal Long memberId);
+    ApiResponse<Void> logout(@Parameter(hidden = true) @AuthenticationPrincipal Long memberId);
 
     // 회원 탈퇴 API
     @Operation(
@@ -213,5 +214,5 @@ public interface MemberControllerDocs {
                     )
             )
     })
-    ApiResponse<Void> withdraw(@AuthenticationPrincipal Long memberId);
+    ApiResponse<Void> withdraw(@Parameter(hidden = true) @AuthenticationPrincipal Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/member/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/member/exception/code/AuthErrorCode.java
@@ -15,9 +15,6 @@ public enum AuthErrorCode implements BaseErrorCode {
             "지원하지 않는 소셜 로그인 제공자입니다."),
 
     // 401
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,
-            "AUTH401_1",
-            "토큰이 만료되었습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,
             "AUTH401_2",
             "refreshToken이 만료되었거나 유효하지 않습니다."),

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -115,9 +115,8 @@ public class MemberService {
     @Transactional
     public void withdraw(Long memberId) {
 
-        if (!memberRepository.existsById(memberId)) {
-            throw new ProjectException(MemberErrorCode.NOT_FOUND);
-        }
+        Member member = memberRepository.findByIdForUpdate(memberId)
+                .orElseThrow(() -> new ProjectException(MemberErrorCode.NOT_FOUND));
 
         memberChapterAnswerRepository.deleteByMemberChapterMemberId(memberId);
         memberChapterRepository.deleteByMemberId(memberId);
@@ -128,6 +127,6 @@ public class MemberService {
         anniversaryRepository.deleteByMemberId(memberId);
         memberTagRepository.deleteByMemberId(memberId);
 
-        memberRepository.deleteById(memberId);
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -11,6 +11,14 @@ import com.umc.halo.domain.member.oauth.AbstractOidcProvider;
 import com.umc.halo.domain.member.oauth.OidcProviderFactory;
 import com.umc.halo.domain.member.oauth.OidcUserInfo;
 import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.domain.notification.repository.AnniversaryRepository;
+import com.umc.halo.domain.notification.repository.NotificationRepository;
+import com.umc.halo.domain.record.repository.MemberChapterAnswerRepository;
+import com.umc.halo.domain.record.repository.MemberChapterRepository;
+import com.umc.halo.domain.record.repository.MemberStorybookRepository;
+import com.umc.halo.domain.setting.repository.MemberSettingRepository;
+import com.umc.halo.domain.tag.repository.MemberTagRepository;
+import com.umc.halo.domain.term.repository.MemberTermRepository;
 import com.umc.halo.global.apiPayload.exception.ProjectException;
 import com.umc.halo.global.util.HashUtil;
 import com.umc.halo.global.security.JwtUtil;
@@ -26,6 +34,14 @@ import java.util.Optional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final MemberTermRepository memberTermRepository;
+    private final MemberSettingRepository memberSettingRepository;
+    private final NotificationRepository notificationRepository;
+    private final AnniversaryRepository anniversaryRepository;
+    private final MemberStorybookRepository memberStorybookRepository;
+    private final MemberChapterRepository memberChapterRepository;
+    private final MemberChapterAnswerRepository memberChapterAnswerRepository;
+    private final MemberTagRepository memberTagRepository;
     private final JwtUtil jwtUtil;
     private final HashUtil hashUtil;
     private final OidcProviderFactory oidcProviderFactory;
@@ -94,5 +110,24 @@ public class MemberService {
         Member member = memberRepository.findByIdForUpdate(memberId)
                 .orElseThrow(() -> new ProjectException(MemberErrorCode.NOT_FOUND));
         member.deleteRefreshToken();
+    }
+
+    @Transactional
+    public void withdraw(Long memberId) {
+
+        if (!memberRepository.existsById(memberId)) {
+            throw new ProjectException(MemberErrorCode.NOT_FOUND);
+        }
+
+        memberChapterAnswerRepository.deleteByMemberChapterMemberId(memberId);
+        memberChapterRepository.deleteByMemberId(memberId);
+        memberStorybookRepository.deleteByMemberId(memberId);
+        memberTermRepository.deleteByMemberId(memberId);
+        memberSettingRepository.deleteByMemberId(memberId);
+        notificationRepository.deleteByMemberId(memberId);
+        anniversaryRepository.deleteByMemberId(memberId);
+        memberTagRepository.deleteByMemberId(memberId);
+
+        memberRepository.deleteById(memberId);
     }
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/AnniversaryRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/AnniversaryRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.*;
 
 @Repository
 public interface AnniversaryRepository extends JpaRepository<Anniversary, Long> {
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.*;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberChapterAnswerRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberChapterAnswerRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.*;
 
 @Repository
 public interface MemberChapterAnswerRepository extends JpaRepository<MemberChapterAnswer, Long> {
+    void deleteByMemberChapterMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberChapterRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberChapterRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.*;
 
 @Repository
 public interface MemberChapterRepository extends JpaRepository<MemberChapter, Long> {
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberStorybookRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberStorybookRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.*;
 
 @Repository
 public interface MemberStorybookRepository extends JpaRepository<MemberStorybook, Long> {
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/setting/repository/MemberSettingRepository.java
+++ b/src/main/java/com/umc/halo/domain/setting/repository/MemberSettingRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.*;
 @Repository
 public interface MemberSettingRepository extends JpaRepository<MemberSetting, Long> {
 
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
+++ b/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.*;
 
 @Repository
 public interface MemberTagRepository extends JpaRepository<MemberTag, Long> {
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/term/repository/MemberTermRepository.java
+++ b/src/main/java/com/umc/halo/domain/term/repository/MemberTermRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.*;
 @Repository
 public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
 
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/code/GeneralErrorCode.java
@@ -18,7 +18,7 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404_1", "요청하신 리소스를 찾을 수 없습니다."),
 
 	// 401 Unauthorized (인증 실패)
-	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401_1", "인증이 필요합니다."),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_1", "토큰이 만료되었습니다."),
 
 	// 403 Forbidden (권한 없음)
 	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403_1", "접근 권한이 없습니다."),


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 회원 탈퇴 API 구현
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- DELETE /api/v1/members/me 구현
- Swagger 문서화
- GeneralErrorCode 파일에서 COMMON401_1 -> AUTH401_1로 변경
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
<img width="964" height="452" alt="image" src="https://github.com/user-attachments/assets/8682a2b9-415f-43f9-8bd8-ef6e86d843cd" />

<img width="968" height="473" alt="image" src="https://github.com/user-attachments/assets/d27926f3-aaf3-4280-a339-b65020c497c2" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #35 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp


- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61?p=38fca1e217c080c4b9aac43234407ac3&pm=s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원 탈퇴 API(DELETE /v1/members/me)가 추가되었습니다. 탈퇴 시 회원과 연결된 기록, 설정, 알림, 태그 등이 함께 정리됩니다.
* **문서**
  * 회원 탈퇴 API 및 로그아웃 관련 문서의 요청/응답 예시가 보강되었습니다.
* **변경 사항**
  * 토큰 만료 시 오류 코드와 안내 문구가 변경되어 더 명확히 표시됩니다.
  * 기존 액세스 토큰 오류 항목은 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->