### PR TITLE
[feat] 온보딩 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -53,4 +53,21 @@ public class Member extends BaseEntity {
     public void updateRefreshTokenToHash(String refreshTokenHash) {
         this.refreshTokenHash = refreshTokenHash;
     }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateGenderAndBirthDate(Gender gender, LocalDate birthDate) {
+        this.gender = gender;
+        this.birthDate = birthDate;
+    }
+
+    public void updateOnboardingStep(Integer step) {
+        this.onboardingStep = step;
+    }
+
+    public void completeOnboarding() {
+        this.onboardingCompleted = true;
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/halo/domain/member/repository/MemberRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 public class OnboardingController implements OnboardingControllerDocs {
 
     private final OnboardingService onboardingService;
-
+    // 닉네임 중복 확인
     @GetMapping("/nickname/check")
     public ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
             @RequestParam String nickname
@@ -31,7 +31,7 @@ public class OnboardingController implements OnboardingControllerDocs {
         return ApiResponse.onSuccess(code, onboardingService.checkNickname(nickname));
     }
 
-
+    // 온보딩 정보 저장
     @PostMapping
     public ApiResponse<OnboardingResDTO.Save> saveOnboarding(
             @AuthenticationPrincipal Long memberId,
@@ -39,5 +39,14 @@ public class OnboardingController implements OnboardingControllerDocs {
     ) {
         BaseSuccessCode code = OnboardingSuccessCode.SAVE_SUCCESS;
         return ApiResponse.onSuccess(code, onboardingService.saveOnboarding(memberId, request));
+    }
+
+    // 온보딩 진행 상태 조회
+    @GetMapping("/status")
+    public ApiResponse<OnboardingResDTO.Status> getStatus(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        BaseSuccessCode code = OnboardingSuccessCode.STATUS_SUCCESS;
+        return ApiResponse.onSuccess(code, onboardingService.getStatus(memberId));
     }
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
@@ -11,6 +11,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import com.umc.halo.domain.onboarding.dto.OnboardingReqDTO;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +29,15 @@ public class OnboardingController implements OnboardingControllerDocs {
     ) {
         BaseSuccessCode code = OnboardingSuccessCode.NICKNAME_AVAILABLE;
         return ApiResponse.onSuccess(code, onboardingService.checkNickname(nickname));
+    }
+
+
+    @PostMapping
+    public ApiResponse<OnboardingResDTO.Save> saveOnboarding(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody OnboardingReqDTO.Save request
+    ) {
+        BaseSuccessCode code = OnboardingSuccessCode.SAVE_SUCCESS;
+        return ApiResponse.onSuccess(code, onboardingService.saveOnboarding(memberId, request));
     }
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
@@ -1,0 +1,29 @@
+package com.umc.halo.domain.onboarding.controller;
+
+import com.umc.halo.domain.onboarding.controller.docs.OnboardingControllerDocs;
+import com.umc.halo.domain.onboarding.dto.OnboardingResDTO;
+import com.umc.halo.domain.onboarding.exception.code.OnboardingSuccessCode;
+import com.umc.halo.domain.onboarding.service.OnboardingService;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/onboarding")
+public class OnboardingController implements OnboardingControllerDocs {
+
+    private final OnboardingService onboardingService;
+
+    @GetMapping("/nickname/check")
+    public ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
+            @RequestParam String nickname
+    ) {
+        BaseSuccessCode code = OnboardingSuccessCode.NICKNAME_AVAILABLE;
+        return ApiResponse.onSuccess(code, onboardingService.checkNickname(nickname));
+    }
+}

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -1,5 +1,6 @@
 package com.umc.halo.domain.onboarding.controller.docs;
 
+import com.umc.halo.domain.onboarding.dto.OnboardingReqDTO;
 import com.umc.halo.domain.onboarding.dto.OnboardingResDTO;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -58,5 +59,118 @@ public interface OnboardingControllerDocs {
     })
     ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
             @Parameter(description = "확인할 닉네임", example = "정민") String nickname
+    );
+
+    @Operation(
+            summary = "온보딩 정보 저장 API",
+            description = """
+                    # 온보딩 정보 저장 (step 1~5 부분 저장)
+                    
+                    ## 요청 형식
+                    - 헤더: Authorize: Bearer {JWT 토큰}
+                    - Body: step + 해당 단계 필드
+                    
+                    ## 단계별 필드
+                    - step 1: name
+                    - step 2: gender, birthDate
+                    - step 3: parentPersonalityTagIds (최대 3)
+                    - step 4: currentRelationStateTagId (1개)
+                    - step 5: goalRelationshipTagIds (최소 1, 최대 2) → 저장 시 온보딩 완료
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "저장 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "ONBOARDING200",
+                                      "message": "온보딩 정보가 저장되었습니다.",
+                                      "result": { "onboardingStep": 1, "onboardingCompleted": false }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "필수값 누락 / 태그 개수 초과",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ONBOARDING400_3",
+                                      "message": "필수 입력값이 누락되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 태그",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ONBOARDING404_1",
+                                      "message": "존재하지 않는 태그입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<OnboardingResDTO.Save> saveOnboarding(
+            @Parameter(hidden = true) Long memberId,
+            OnboardingReqDTO.Save request
+    );
+
+    @Operation(
+            summary = "온보딩 진행 상태 조회 API",
+            description = """
+                    # 온보딩 진행 상태 조회
+                    
+                    ## 요청 형식
+                    - 헤더: Authorize: Bearer {JWT 토큰}
+                    
+                    완료 여부 + 이어할 단계(currentStep) + 지금까지 저장된 값(savedData)을 반환합니다.
+                    시작 전이면 currentStep, savedData는 null 입니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공 (step 3까지 진행한 예시)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "ONBOARDING200",
+                                      "message": "온보딩 상태 조회 성공",
+                                      "result": {
+                                        "onboardingCompleted": false,
+                                        "currentStep": 3,
+                                        "savedData": {
+                                          "name": "정민",
+                                          "gender": "FEMALE",
+                                          "birthDate": "2005-05-03",
+                                          "parentPersonalityTagIds": [12, 15],
+                                          "currentRelationStateTagId": null,
+                                          "goalRelationshipTagIds": []
+                                        }
+                                      }
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<OnboardingResDTO.Status> getStatus(
+            @Parameter(hidden = true) Long memberId
     );
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -34,7 +34,7 @@ public interface OnboardingControllerDocs {
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": true,
-                                      "code": "ONBOARDING200",
+                                      "code": "ONBOARDING200_3",
                                       "message": "사용 가능한 닉네임입니다.",
                                       "result": { "isAvailable": true }
                                     }
@@ -87,7 +87,7 @@ public interface OnboardingControllerDocs {
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": true,
-                                      "code": "ONBOARDING200",
+                                      "code": "ONBOARDING200_1",
                                       "message": "온보딩 정보가 저장되었습니다.",
                                       "result": { "onboardingStep": 1, "onboardingCompleted": false }
                                     }
@@ -151,7 +151,7 @@ public interface OnboardingControllerDocs {
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": true,
-                                      "code": "ONBOARDING200",
+                                      "code": "ONBOARDING200_2",
                                       "message": "온보딩 상태 조회 성공",
                                       "result": {
                                         "onboardingCompleted": false,

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -19,7 +19,7 @@ public interface OnboardingControllerDocs {
                     # 닉네임 중복 확인
                     
                     ## 요청 형식
-                    - 헤더: Authorize: Bearer {JWT 토큰}
+                    - 헤더: Authorization: Bearer {JWT 토큰}
                     - 쿼리 파라미터: nickname
                     
                     닉네임은 2~10자, 특수문자를 사용할 수 없습니다.
@@ -55,6 +55,21 @@ public interface OnboardingControllerDocs {
                                     }
                                     """)
                     )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 헤더에 JWT 토큰 미삽입/만료",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
             )
     })
     ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
@@ -67,7 +82,7 @@ public interface OnboardingControllerDocs {
                     # 온보딩 정보 저장 (step 1~5 부분 저장)
                     
                     ## 요청 형식
-                    - 헤더: Authorize: Bearer {JWT 토큰}
+                   - 헤더: Authorization: Bearer {JWT 토큰}
                     - Body: step + 해당 단계 필드
                     
                     ## 단계별 필드
@@ -122,6 +137,22 @@ public interface OnboardingControllerDocs {
                                       "result": null
                                     }
                                     """)
+
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 헤더에 JWT 토큰 미삽입/만료",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
                     )
             )
     })
@@ -136,7 +167,7 @@ public interface OnboardingControllerDocs {
                     # 온보딩 진행 상태 조회
                     
                     ## 요청 형식
-                    - 헤더: Authorize: Bearer {JWT 토큰}
+                  - 헤더: Authorization: Bearer {JWT 토큰}
                     
                     완료 여부 + 이어할 단계(currentStep) + 지금까지 저장된 값(savedData)을 반환합니다.
                     시작 전이면 currentStep, savedData는 null 입니다.
@@ -165,6 +196,21 @@ public interface OnboardingControllerDocs {
                                           "goalRelationshipTagIds": []
                                         }
                                       }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 헤더에 JWT 토큰 미삽입/만료",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
                                     }
                                     """)
                     )

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -1,0 +1,62 @@
+package com.umc.halo.domain.onboarding.controller.docs;
+
+import com.umc.halo.domain.onboarding.dto.OnboardingResDTO;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "온보딩 API")
+public interface OnboardingControllerDocs {
+
+    @Operation(
+            summary = "닉네임 중복 확인 API",
+            description = """
+                    # 닉네임 중복 확인
+                    
+                    ## 요청 형식
+                    - 헤더: Authorize: Bearer {JWT 토큰}
+                    - 쿼리 파라미터: nickname
+                    
+                    닉네임은 2~10자, 특수문자를 사용할 수 없습니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "ONBOARDING200",
+                                      "message": "사용 가능한 닉네임입니다.",
+                                      "result": { "isAvailable": true }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "닉네임 규칙 위반",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ONBOARDING400_1",
+                                      "message": "닉네임은 2~10자, 특수문자를 사용할 수 없습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
+            @Parameter(description = "확인할 닉네임", example = "정민") String nickname
+    );
+}

--- a/src/main/java/com/umc/halo/domain/onboarding/converter/OnboardingConverter.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/converter/OnboardingConverter.java
@@ -1,0 +1,46 @@
+package com.umc.halo.domain.onboarding.converter;
+
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.onboarding.dto.OnboardingResDTO;
+
+import java.util.List;
+
+public class OnboardingConverter {
+
+    public static OnboardingResDTO.NicknameCheck toNicknameCheck(boolean available) {
+        return OnboardingResDTO.NicknameCheck.builder()
+                .isAvailable(available)
+                .build();
+    }
+
+    public static OnboardingResDTO.Save toSave(Member member) {
+        return OnboardingResDTO.Save.builder()
+                .onboardingStep(member.getOnboardingStep())
+                .onboardingCompleted(member.getOnboardingCompleted())
+                .build();
+    }
+
+    public static OnboardingResDTO.Status toStatus(Member member, OnboardingResDTO.SavedData savedData) {
+        return OnboardingResDTO.Status.builder()
+                .onboardingCompleted(member.getOnboardingCompleted())
+                .currentStep(member.getOnboardingStep())
+                .savedData(savedData)
+                .build();
+    }
+
+    public static OnboardingResDTO.SavedData toSavedData(
+            Member member,
+            List<Long> parentPersonalityTagIds,
+            Long currentRelationStateTagId,
+            List<Long> goalRelationshipTagIds
+    ) {
+        return OnboardingResDTO.SavedData.builder()
+                .name(member.getName())
+                .gender(member.getGender())
+                .birthDate(member.getBirthDate())
+                .parentPersonalityTagIds(parentPersonalityTagIds)
+                .currentRelationStateTagId(currentRelationStateTagId)
+                .goalRelationshipTagIds(goalRelationshipTagIds)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/halo/domain/onboarding/dto/OnboardingReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/dto/OnboardingReqDTO.java
@@ -1,0 +1,21 @@
+package com.umc.halo.domain.onboarding.dto;
+
+import com.umc.halo.domain.member.enums.Gender;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class OnboardingReqDTO {
+
+    public record Save(
+            Integer step, // 현재 저장 단계 (필수)
+
+            String name,  // step 1
+            Gender gender, // step 2
+            LocalDate birthDate, // step 2
+
+            List<Long> parentPersonalityTagIds,   // step 3 (최대 3)
+            Long currentRelationStateTagId, // step 4 (1개)
+            List<Long> goalRelationshipTagIds // step 5 (최소 1, 최대 2)
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/onboarding/dto/OnboardingResDTO.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/dto/OnboardingResDTO.java
@@ -8,4 +8,10 @@ public class OnboardingResDTO {
     public record NicknameCheck(
             Boolean isAvailable
     ) {}
+
+    @Builder
+    public record Save(
+            Integer onboardingStep,
+            Boolean onboardingCompleted
+    ) {}
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/dto/OnboardingResDTO.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/dto/OnboardingResDTO.java
@@ -1,0 +1,11 @@
+package com.umc.halo.domain.onboarding.dto;
+
+import lombok.Builder;
+
+public class OnboardingResDTO {
+
+    @Builder
+    public record NicknameCheck(
+            Boolean isAvailable
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/onboarding/dto/OnboardingResDTO.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/dto/OnboardingResDTO.java
@@ -1,6 +1,7 @@
 package com.umc.halo.domain.onboarding.dto;
 
 import lombok.Builder;
+import com.umc.halo.domain.member.enums.Gender;
 
 public class OnboardingResDTO {
 
@@ -13,5 +14,24 @@ public class OnboardingResDTO {
     public record Save(
             Integer onboardingStep,
             Boolean onboardingCompleted
+    ) {}
+
+    // 온보딩 진행 상태 조회하기
+    @Builder
+    public record Status(
+            Boolean onboardingCompleted,
+            Integer currentStep,        // 시작 전 null
+            SavedData savedData         // 시작 전 null
+    ) {}
+
+    // 지금까지 저장된 값
+    @Builder
+    public record SavedData(
+            String name,
+            Gender gender,
+            java.time.LocalDate birthDate,
+            java.util.List<Long> parentPersonalityTagIds,
+            Long currentRelationStateTagId,
+            java.util.List<Long> goalRelationshipTagIds
     ) {}
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/exception/OnboardingException.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/exception/OnboardingException.java
@@ -1,0 +1,10 @@
+package com.umc.halo.domain.onboarding.exception;
+
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+
+public class OnboardingException extends ProjectException {
+    public OnboardingException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingErrorCode.java
@@ -25,6 +25,9 @@ public enum OnboardingErrorCode implements BaseErrorCode {
     INVALID_BIRTH_DATE(HttpStatus.BAD_REQUEST,
             "ONBOARDING400_5",
             "생년월일 형식이 올바르지 않습니다."),
+    INVALID_TAG_CATEGORY(HttpStatus.BAD_REQUEST,
+            "ONBOARDING400_6",
+            "해당 단계에 맞지 않는 태그입니다."),
 
     // 404
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND,

--- a/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingErrorCode.java
@@ -1,0 +1,38 @@
+package com.umc.halo.domain.onboarding.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OnboardingErrorCode implements BaseErrorCode {
+
+    // 400
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST,
+            "ONBOARDING400_1",
+            "닉네임은 2~10자, 특수문자를 사용할 수 없습니다."),
+    PARENT_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST,
+            "ONBOARDING400_2",
+            "부모 성향 태그는 최대 3개까지 선택할 수 있습니다."),
+    MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST,
+            "ONBOARDING400_3",
+            "필수 입력값이 누락되었습니다."),
+    GOAL_TAG_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST,
+            "ONBOARDING400_4",
+            "원하는 관계 방향은 최대 2개까지 선택할 수 있습니다."),
+    INVALID_BIRTH_DATE(HttpStatus.BAD_REQUEST,
+            "ONBOARDING400_5",
+            "생년월일 형식이 올바르지 않습니다."),
+
+    // 404
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "ONBOARDING404_1",
+            "존재하지 않는 태그입니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingSuccessCode.java
@@ -11,15 +11,15 @@ public enum OnboardingSuccessCode implements BaseSuccessCode {
 
     // 온보딩 정보 저장
     SAVE_SUCCESS(HttpStatus.OK,
-            "ONBOARDING200",
+            "ONBOARDING200_1",
             "온보딩 정보가 저장되었습니다."),
     // 온보딩 진행 상태 조회
     STATUS_SUCCESS(HttpStatus.OK,
-            "ONBOARDING200",
+            "ONBOARDING200_2",
             "온보딩 상태 조회 성공"),
     // 닉네임 중복 확인
     NICKNAME_AVAILABLE(HttpStatus.OK,
-            "ONBOARDING200",
+            "ONBOARDING200_3",
             "사용 가능한 닉네임입니다.")
     ;
 

--- a/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingSuccessCode.java
@@ -1,0 +1,29 @@
+package com.umc.halo.domain.onboarding.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OnboardingSuccessCode implements BaseSuccessCode {
+
+    // 온보딩 정보 저장
+    SAVE_SUCCESS(HttpStatus.OK,
+            "ONBOARDING200",
+            "온보딩 정보가 저장되었습니다."),
+    // 온보딩 진행 상태 조회
+    STATUS_SUCCESS(HttpStatus.OK,
+            "ONBOARDING200",
+            "온보딩 상태 조회 성공"),
+    // 닉네임 중복 확인
+    NICKNAME_AVAILABLE(HttpStatus.OK,
+            "ONBOARDING200",
+            "사용 가능한 닉네임입니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -7,17 +7,29 @@ import com.umc.halo.domain.onboarding.exception.code.OnboardingErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.tag.entity.MemberTag;
+import com.umc.halo.domain.tag.entity.Tag;
+import com.umc.halo.domain.tag.repository.MemberTagRepository;
+import com.umc.halo.domain.tag.repository.TagRepository;
+import com.umc.halo.domain.onboarding.dto.OnboardingReqDTO;
 
 import java.util.regex.Pattern;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class OnboardingService {
 
     private final MemberRepository memberRepository;
+    private final TagRepository tagRepository;
+    private final MemberTagRepository memberTagRepository;
 
     private static final Pattern NICKNAME_PATTERN =
             Pattern.compile("^[가-힣a-zA-Z0-9]{2,10}$");
+    private static final int PARENT_TAG_MAX = 3;
+    private static final int GOAL_TAG_MIN = 1;
+    private static final int GOAL_TAG_MAX = 2;
 
     @Transactional(readOnly = true)
     public OnboardingResDTO.NicknameCheck checkNickname(String nickname) {
@@ -32,5 +44,82 @@ public class OnboardingService {
         return OnboardingResDTO.NicknameCheck.builder()
                 .isAvailable(available)
                 .build();
+    }
+
+    // 온보딩 정보 저장 이어서 하는 작업용
+    @Transactional
+    public OnboardingResDTO.Save saveOnboarding(Long memberId, OnboardingReqDTO.Save request) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD));
+
+        Integer step = request.step();
+        if (step == null || step < 1 || step > 5) {
+            throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
+        }
+
+        switch (step) {
+            case 1 -> {
+                if (request.name() == null) {
+                    throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
+                }
+                member.updateName(request.name());
+            }
+            case 2 -> {
+                if (request.gender() == null || request.birthDate() == null) {
+                    throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
+                }
+                member.updateGenderAndBirthDate(request.gender(), request.birthDate());
+            }
+            case 3 -> {
+                List<Long> tagIds = request.parentPersonalityTagIds();
+                if (tagIds == null || tagIds.isEmpty()) {
+                    throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
+                }
+                if (tagIds.size() > PARENT_TAG_MAX) {
+                    throw new OnboardingException(OnboardingErrorCode.PARENT_TAG_LIMIT_EXCEEDED);
+                }
+                saveTags(member, tagIds);
+            }
+            case 4 -> {
+                if (request.currentRelationStateTagId() == null) {
+                    throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
+                }
+                saveTags(member, List.of(request.currentRelationStateTagId()));
+            }
+            case 5 -> {
+                List<Long> tagIds = request.goalRelationshipTagIds();
+                if (tagIds == null || tagIds.size() < GOAL_TAG_MIN) {
+                    throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
+                }
+                if (tagIds.size() > GOAL_TAG_MAX) {
+                    throw new OnboardingException(OnboardingErrorCode.GOAL_TAG_LIMIT_EXCEEDED);
+                }
+                saveTags(member, tagIds);
+            }
+        }
+
+        member.updateOnboardingStep(step);
+
+        if (step == 5) {
+            member.completeOnboarding();
+        }
+
+        return OnboardingResDTO.Save.builder()
+                .onboardingStep(member.getOnboardingStep())
+                .onboardingCompleted(member.getOnboardingCompleted())
+                .build();
+    }
+
+    private void saveTags(Member member, List<Long> tagIds) {
+        for (Long tagId : tagIds) {
+            Tag tag = tagRepository.findById(tagId)
+                    .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.TAG_NOT_FOUND));
+            MemberTag memberTag = MemberTag.builder()
+                    .member(member)
+                    .tag(tag)
+                    .build();
+            memberTagRepository.save(memberTag);
+        }
     }
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -127,6 +127,9 @@ public class OnboardingService {
     }
 
     private void saveTags(Member member, List<Long> tagIds, Category expectedCategory) {
+        memberTagRepository.deleteByMemberAndTag_Category(member, expectedCategory);
+        memberTagRepository.flush();
+
         for (Long tagId : tagIds) {
             Tag tag = tagRepository.findById(tagId)
                     .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.TAG_NOT_FOUND));

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -40,9 +40,7 @@ public class OnboardingService {
     @Transactional(readOnly = true)
     public OnboardingResDTO.NicknameCheck checkNickname(String nickname) {
 
-        if (nickname == null || !NICKNAME_PATTERN.matcher(nickname).matches()) {
-            throw new OnboardingException(OnboardingErrorCode.INVALID_NICKNAME);
-        }
+        validateNicknameFormat(nickname);
         // 중복 조회
         boolean available = !memberRepository.existsByName(nickname);
         return OnboardingResDTO.NicknameCheck.builder()

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -1,0 +1,36 @@
+package com.umc.halo.domain.onboarding.service;
+
+import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.domain.onboarding.dto.OnboardingResDTO;
+import com.umc.halo.domain.onboarding.exception.OnboardingException;
+import com.umc.halo.domain.onboarding.exception.code.OnboardingErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class OnboardingService {
+
+    private final MemberRepository memberRepository;
+
+    private static final Pattern NICKNAME_PATTERN =
+            Pattern.compile("^[가-힣a-zA-Z0-9]{2,10}$");
+
+    @Transactional(readOnly = true)
+    public OnboardingResDTO.NicknameCheck checkNickname(String nickname) {
+
+        if (nickname == null || !NICKNAME_PATTERN.matcher(nickname).matches()) {
+            throw new OnboardingException(OnboardingErrorCode.INVALID_NICKNAME);
+        }
+
+        // 중복 조회
+        boolean available = !memberRepository.existsByName(nickname);
+
+        return OnboardingResDTO.NicknameCheck.builder()
+                .isAvailable(available)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -41,15 +41,17 @@ public class OnboardingService {
         if (nickname == null || !NICKNAME_PATTERN.matcher(nickname).matches()) {
             throw new OnboardingException(OnboardingErrorCode.INVALID_NICKNAME);
         }
-
         // 중복 조회
         boolean available = !memberRepository.existsByName(nickname);
-
         return OnboardingResDTO.NicknameCheck.builder()
                 .isAvailable(available)
                 .build();
     }
-
+    private void validateNicknameFormat(String nickname) {
+        if (nickname == null || !NICKNAME_PATTERN.matcher(nickname).matches()) {
+            throw new OnboardingException(OnboardingErrorCode.INVALID_NICKNAME);
+        }
+    }
     // 온보딩 정보 저장 이어서 하는 작업용
     @Transactional
     public OnboardingResDTO.Save saveOnboarding(Long memberId, OnboardingReqDTO.Save request) {
@@ -67,6 +69,9 @@ public class OnboardingService {
                 if (request.name() == null) {
                     throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
                 }
+
+
+                validateNicknameFormat(request.name());
                 member.updateName(request.name());
             }
             case 2 -> {

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -15,6 +15,7 @@ import com.umc.halo.domain.tag.repository.TagRepository;
 import com.umc.halo.domain.onboarding.dto.OnboardingReqDTO;
 import com.umc.halo.domain.member.enums.Gender;
 import com.umc.halo.domain.tag.enums.Category;
+import com.umc.halo.domain.onboarding.converter.OnboardingConverter;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -43,9 +44,7 @@ public class OnboardingService {
         validateNicknameFormat(nickname);
         // 중복 조회
         boolean available = !memberRepository.existsByName(nickname);
-        return OnboardingResDTO.NicknameCheck.builder()
-                .isAvailable(available)
-                .build();
+        return OnboardingConverter.toNicknameCheck(available);
     }
     private void validateNicknameFormat(String nickname) {
         if (nickname == null || !NICKNAME_PATTERN.matcher(nickname).matches()) {
@@ -118,10 +117,7 @@ public class OnboardingService {
             member.completeOnboarding();
         }
 
-        return OnboardingResDTO.Save.builder()
-                .onboardingStep(member.getOnboardingStep())
-                .onboardingCompleted(member.getOnboardingCompleted())
-                .build();
+        return OnboardingConverter.toSave(member);
     }
 
     private void saveTags(Member member, List<Long> tagIds, Category expectedCategory) {
@@ -149,13 +145,9 @@ public class OnboardingService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD));
 
-        // 아직 온보딩 시작 전 → savedData 없음
+        // 아직 온보딩 시작 전
         if (member.getOnboardingStep() == null) {
-            return OnboardingResDTO.Status.builder()
-                    .onboardingCompleted(member.getOnboardingCompleted())
-                    .currentStep(null)
-                    .savedData(null)
-                    .build();
+            return OnboardingConverter.toStatus(member, null);
         }
 
         // 저장된 태그들을 카테고리별로 분류
@@ -175,19 +167,9 @@ public class OnboardingService {
             }
         }
 
-        OnboardingResDTO.SavedData savedData = OnboardingResDTO.SavedData.builder()
-                .name(member.getName())
-                .gender(member.getGender())
-                .birthDate(member.getBirthDate())
-                .parentPersonalityTagIds(parentTagIds)
-                .currentRelationStateTagId(currentRelationTagId)
-                .goalRelationshipTagIds(goalTagIds)
-                .build();
+        OnboardingResDTO.SavedData savedData = OnboardingConverter.toSavedData(
+                member, parentTagIds, currentRelationTagId, goalTagIds);
 
-        return OnboardingResDTO.Status.builder()
-                .onboardingCompleted(member.getOnboardingCompleted())
-                .currentStep(member.getOnboardingStep())
-                .savedData(savedData)
-                .build();
+        return OnboardingConverter.toStatus(member, savedData);
     }
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -13,6 +13,9 @@ import com.umc.halo.domain.tag.entity.Tag;
 import com.umc.halo.domain.tag.repository.MemberTagRepository;
 import com.umc.halo.domain.tag.repository.TagRepository;
 import com.umc.halo.domain.onboarding.dto.OnboardingReqDTO;
+import com.umc.halo.domain.member.enums.Gender;
+import com.umc.halo.domain.tag.enums.Category;
+import java.util.ArrayList;
 
 import java.util.regex.Pattern;
 import java.util.List;
@@ -31,6 +34,7 @@ public class OnboardingService {
     private static final int GOAL_TAG_MIN = 1;
     private static final int GOAL_TAG_MAX = 2;
 
+    // 닉네임 중복 확인
     @Transactional(readOnly = true)
     public OnboardingResDTO.NicknameCheck checkNickname(String nickname) {
 
@@ -121,5 +125,54 @@ public class OnboardingService {
                     .build();
             memberTagRepository.save(memberTag);
         }
+    }
+
+    // 온보딩 진행 상태 조회
+    @Transactional(readOnly = true)
+    public OnboardingResDTO.Status getStatus(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD));
+
+        // 아직 온보딩 시작 전 → savedData 없음
+        if (member.getOnboardingStep() == null) {
+            return OnboardingResDTO.Status.builder()
+                    .onboardingCompleted(member.getOnboardingCompleted())
+                    .currentStep(null)
+                    .savedData(null)
+                    .build();
+        }
+
+        // 저장된 태그들을 카테고리별로 분류
+        List<Long> parentTagIds = new ArrayList<>();
+        Long currentRelationTagId = null;
+        List<Long> goalTagIds = new ArrayList<>();
+
+        for (MemberTag memberTag : memberTagRepository.findAllByMember(member)) {
+            Category category = memberTag.getTag().getCategory();
+            Long tagId = memberTag.getTag().getId();
+
+            switch (category) {
+                case PARENT_TENDENCY -> parentTagIds.add(tagId);
+                case CURRENT_RELATIONSHIP -> currentRelationTagId = tagId;
+                case DESIRED_DIRECTION -> goalTagIds.add(tagId);
+                default -> { /* 온보딩과 무관한 카테고리는 무시 */ }
+            }
+        }
+
+        OnboardingResDTO.SavedData savedData = OnboardingResDTO.SavedData.builder()
+                .name(member.getName())
+                .gender(member.getGender())
+                .birthDate(member.getBirthDate())
+                .parentPersonalityTagIds(parentTagIds)
+                .currentRelationStateTagId(currentRelationTagId)
+                .goalRelationshipTagIds(goalTagIds)
+                .build();
+
+        return OnboardingResDTO.Status.builder()
+                .onboardingCompleted(member.getOnboardingCompleted())
+                .currentStep(member.getOnboardingStep())
+                .savedData(savedData)
+                .build();
     }
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -94,13 +94,13 @@ public class OnboardingService {
                 if (tagIds.size() > PARENT_TAG_MAX) {
                     throw new OnboardingException(OnboardingErrorCode.PARENT_TAG_LIMIT_EXCEEDED);
                 }
-                saveTags(member, tagIds);
+                saveTags(member, tagIds, Category.PARENT_TENDENCY);
             }
             case 4 -> {
                 if (request.currentRelationStateTagId() == null) {
                     throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
                 }
-                saveTags(member, List.of(request.currentRelationStateTagId()));
+                saveTags(member, List.of(request.currentRelationStateTagId()), Category.CURRENT_RELATIONSHIP);
             }
             case 5 -> {
                 List<Long> tagIds = request.goalRelationshipTagIds();
@@ -110,7 +110,7 @@ public class OnboardingService {
                 if (tagIds.size() > GOAL_TAG_MAX) {
                     throw new OnboardingException(OnboardingErrorCode.GOAL_TAG_LIMIT_EXCEEDED);
                 }
-                saveTags(member, tagIds);
+                saveTags(member, tagIds, Category.DESIRED_DIRECTION);
             }
         }
 
@@ -126,10 +126,13 @@ public class OnboardingService {
                 .build();
     }
 
-    private void saveTags(Member member, List<Long> tagIds) {
+    private void saveTags(Member member, List<Long> tagIds, Category expectedCategory) {
         for (Long tagId : tagIds) {
             Tag tag = tagRepository.findById(tagId)
                     .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.TAG_NOT_FOUND));
+            if (tag.getCategory() != expectedCategory) {
+                throw new OnboardingException(OnboardingErrorCode.INVALID_TAG_CATEGORY);
+            }
             MemberTag memberTag = MemberTag.builder()
                     .member(member)
                     .tag(tag)

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -15,6 +15,8 @@ import com.umc.halo.domain.tag.repository.TagRepository;
 import com.umc.halo.domain.onboarding.dto.OnboardingReqDTO;
 import com.umc.halo.domain.member.enums.Gender;
 import com.umc.halo.domain.tag.enums.Category;
+
+import java.time.LocalDate;
 import java.util.ArrayList;
 
 import java.util.regex.Pattern;
@@ -77,6 +79,10 @@ public class OnboardingService {
             case 2 -> {
                 if (request.gender() == null || request.birthDate() == null) {
                     throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
+                }
+                if (request.birthDate().isAfter(LocalDate.now())) {
+
+                    throw new OnboardingException(OnboardingErrorCode.INVALID_BIRTH_DATE);
                 }
                 member.updateGenderAndBirthDate(request.gender(), request.birthDate());
             }

--- a/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
+++ b/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
 import com.umc.halo.domain.member.entity.Member;
 import java.util.List;
+import com.umc.halo.domain.tag.enums.Category;
 
 @Repository
 public interface MemberTagRepository extends JpaRepository<MemberTag, Long> {
     List<MemberTag> findAllByMember(Member member);
     void deleteByMemberId(Long memberId);
+    void deleteByMemberAndTag_Category(Member member, Category category);
 }

--- a/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
+++ b/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
@@ -3,7 +3,10 @@ package com.umc.halo.domain.tag.repository;
 import com.umc.halo.domain.tag.entity.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
+import com.umc.halo.domain.member.entity.Member;
+import java.util.List;
 
 @Repository
 public interface MemberTagRepository extends JpaRepository<MemberTag, Long> {
+    List<MemberTag> findAllByMember(Member member);
 }

--- a/src/main/java/com/umc/halo/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/halo/global/config/SecurityConfig.java
@@ -28,8 +28,6 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             // 인증(소셜 로그인 / 토큰 재발급)
             "/api/v1/auth/**",
-            // 온보딩 (로그인 전 guest_uuid 기반)
-            "/api/v1/onboarding/**"
     };
 
     @Bean


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 온보딩 API 3종 구현 (닉네임 중복 확인 / 온보딩 정보 저장 / 온보딩 진행 상태 조회)
- 온보딩 저장은 step 1~5 단계별 부분 저장 방식으로, 중간에 나가도 이어하기가 가능하도록 구현
- 온보딩 경로를 Private(JWT 인증 필요)으로 전환
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- OnboardingController / OnboardingControllerDocs (Swagger 문서 분리)
- OnboardingService (닉네임 검증·중복 조회, step별 저장, 태그 카테고리 분류)
- OnboardingReqDTO / OnboardingResDTO
- OnboardingSuccessCode / OnboardingErrorCode / OnboardingException
- OnboardingConverter

**변경한 도메인**
- MemberRepository: existsByName 추가 (닉네임 중복 확인용)
- Member 엔티티: 온보딩 업데이트 메서드 추가 
- MemberTagRepository: findAllByMember 추가 (진행 상태 조회용)
- SecurityConfig: 온보딩 경로 Public → Private 변경
- MemberTagRepository: deleteByMemberAndTag_Category 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="1326" height="430" alt="image" src="https://github.com/user-attachments/assets/742b1af1-5c62-4a47-a03c-7839f94328c8" />

- 
<img width="1262" height="892" alt="image" src="https://github.com/user-attachments/assets/8fa5545d-6138-4c11-b7b8-5b74d02ca999" />


---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #19
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 온보딩 API를 추가해 닉네임 중복 확인, 1~5단계 정보 저장, 온보딩 진행 상태 조회를 지원합니다.
  * 온보딩 요청/응답 DTO를 도입하고 단계별 완료 여부 및 저장 데이터를 반환합니다.
* **개선 사항**
  * 단계/태그/필수 입력값 검증 및 온보딩 예외·성공 코드 체계를 확장했습니다.
  * Swagger 문서를 엔드포인트별 예시 응답과 함께 제공합니다.
* **보안**
  * 온보딩 경로의 접근 범위를 조정하여 인증이 필요한 경로로 전환했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->