### PR TITLE
[feat] 내 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -57,4 +57,13 @@ public class MemberController implements MemberControllerDocs {
         BaseSuccessCode code = MemberSuccessCode.DELETE_SUCCESS;
         return ApiResponse.onSuccess(code);
     }
+
+    @GetMapping("/v1/members/me")
+    public ApiResponse<MemberResDTO.MyInfo> getMyInfo(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long memberId
+    ) {
+        BaseSuccessCode code = MemberSuccessCode.INFO_SUCCESS;
+        return ApiResponse.onSuccess(code, memberService.getMyInfo(memberId));
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,7 +17,25 @@ public interface MemberControllerDocs {
 
     // 소셜 로그인
     @Operation(
-            summary = "소셜 로그인 API"
+            summary = "소셜 로그인 API",
+            description = """
+                    # 소셜 로그인
+                    카카오/구글 ID Token(OIDC)을 검증해 회원을 확인하고, 신규 회원이면 계정을 생성한 뒤 서버 토큰(access·refresh)을 발급합니다.
+                    
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                    - **Body**
+                        - provider : 소셜 로그인 제공자 ('KAKAO' / 'GOOGLE')
+                        - providerToken : Google 또는 Kakao에서 발급한 ID Token(OIDC)
+                    
+                    ## 동작 방식
+                    1. providerToken을 검증합니다.
+                    2. provider와 providerId로 기존 회원을 조회합니다.
+                    3. 기존 회원이면 로그인을 진행합니다.
+                    4. 회원이 없으면 신규 회원을 생성한 후 로그인합니다.
+                    5. Access Token과 Refresh Token을 발급합니다.
+                    """
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -79,7 +96,24 @@ public interface MemberControllerDocs {
 
     // 토큰 재발급 API
     @Operation(
-            summary = "토큰 재발급 API"
+            summary = "토큰 재발급 API",
+            description = """
+                    # 토큰 재발급
+                    refreshToken을 검증해 새 accessToken을 재발급합니다. 자동 로그인에도 사용.
+                    
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {Access Token}
+                    - **Body**
+                        - refreshToken : 재발급에 사용할 Refresh Token
+                    
+                    ## 동작 방식
+                    1. Refresh Token의 서명, 만료 여부 및 토큰 타입을 검증합니다.
+                    2. 회원 DB에 저장된 Refresh Token과 일치하는지 검증합니다.
+                    3. 검증에 성공하면 새로운 Access Token과 Refresh Token을 발급합니다.
+                    4. 기존 Refresh Token은 무효화되고 새 Refresh Token으로 교체됩니다.
+                    """
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -122,7 +156,21 @@ public interface MemberControllerDocs {
 
     // 로그아웃 API
     @Operation(
-            summary = "로그아웃 API"
+            summary = "로그아웃 API",
+            description = """
+                    # 로그아웃
+                    accessToken의 memberId로 서버가 해당 refreshToken을 찾아 무효화합니다.
+                    
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {Access Token}
+                    
+                    ## 동작 방식
+                    1. Access Token으로 현재 회원을 인증합니다.
+                    2. 회원 DB에 저장된 Refresh Token을 삭제합니다.
+                    3. 이후 기존 Refresh Token으로는 토큰 재발급을 할 수 없습니다.
+                    """
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -162,7 +210,21 @@ public interface MemberControllerDocs {
 
     // 회원 탈퇴 API
     @Operation(
-            summary = "회원 탈퇴 API"
+            summary = "회원 탈퇴 API",
+            description = """
+                    # 회원 탈퇴
+                    로그인 회원의 계정/관련 데이터를 삭제합니다.
+                    
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {Access Token}
+                    
+                    ## 동작 방식
+                    1. Access Token으로 현재 회원을 인증합니다.
+                    2. 회원 정보를 포함한 관련 데이터를 삭제합니다.
+                    3. 회원 탈퇴가 완료되면 기존 로그인 정보는 모두 무효화됩니다.
+                    """
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -215,4 +277,82 @@ public interface MemberControllerDocs {
             )
     })
     ApiResponse<Void> withdraw(@Parameter(hidden = true) @AuthenticationPrincipal Long memberId);
+
+    // 내 정보 조회
+    @Operation(
+            summary = "내 정보 조회 API",
+            description = """
+                    # 내 정보 조회
+                    로그인 회원의 기본 정보를 조회합니다.
+                    
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {Access Token}
+                    
+                    # 동작 방식
+                    1. Access Token으로 현재 회원을 인증합니다.
+                    2. 회원 정보를 조회합니다.
+                    3. 회원의 기본 정보를 반환합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "MEMBER200_1",
+                                        "message": "내 정보 조회 성공",
+                                        "result": {
+                                            "memberId": 1,
+                                            "name": "신재현",
+                                            "gender": "MALE",
+                                            "birthDate": "2002-02-25",
+                                            "provider": "KAKAO",
+                                            "onboardingCompleted": true,
+                                            "createdAt": "2026-06-30T14:20:00+09:00"
+                                        }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_1",
+                                        "message": "토큰이 만료되었습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "해당 member 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "MEMBER404_1",
+                                        "message": "존재하지 않는 회원입니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ApiResponse<MemberResDTO.MyInfo> getMyInfo(@Parameter(hidden = true) @AuthenticationPrincipal Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -104,7 +104,6 @@ public interface MemberControllerDocs {
                     ## 요청 형식
                     - **Header**
                         - Content-Type: application/json
-                        - Authorization: Bearer {Access Token}
                     - **Body**
                         - refreshToken : 재발급에 사용할 Refresh Token
                     
@@ -314,7 +313,7 @@ public interface MemberControllerDocs {
                                             "birthDate": "2002-02-25",
                                             "provider": "KAKAO",
                                             "onboardingCompleted": true,
-                                            "createdAt": "2026-06-30T14:20:00+09:00"
+                                            "createdAt": "2026-06-30T14:20:00"
                                         }
                                     }
                                     """

--- a/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/umc/halo/domain/member/converter/MemberConverter.java
@@ -29,6 +29,18 @@ public class MemberConverter {
                 .build();
     }
 
+    public static MemberResDTO.MyInfo toMyInfo(Member member) {
+        return MemberResDTO.MyInfo.builder()
+                .memberId(member.getId())
+                .name(member.getName())
+                .gender(member.getGender())
+                .birthDate(member.getBirthDate())
+                .provider(member.getProvider())
+                .onboardingCompleted(member.getOnboardingCompleted())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+
     public static MemberResDTO.TokenReissue toTokenReissueResponse(
             String accessToken,
             String refreshToken

--- a/src/main/java/com/umc/halo/domain/member/dto/MemberResDTO.java
+++ b/src/main/java/com/umc/halo/domain/member/dto/MemberResDTO.java
@@ -1,6 +1,11 @@
 package com.umc.halo.domain.member.dto;
 
+import com.umc.halo.domain.member.enums.Gender;
+import com.umc.halo.domain.member.enums.Provider;
 import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class MemberResDTO {
 
@@ -16,5 +21,16 @@ public class MemberResDTO {
     public record TokenReissue(
             String accessToken,
             String refreshToken
+    ) {}
+
+    @Builder
+    public record MyInfo(
+            Long memberId,
+            String name,
+            Gender gender,
+            LocalDate birthDate,
+            Provider provider,
+            Boolean onboardingCompleted,
+            LocalDateTime createdAt
     ) {}
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -129,4 +129,13 @@ public class MemberService {
 
         memberRepository.delete(member);
     }
+
+    @Transactional(readOnly = true)
+    public MemberResDTO.MyInfo getMyInfo(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ProjectException(MemberErrorCode.NOT_FOUND));
+
+        return MemberConverter.toMyInfo(member);
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 내 정보 조회 API 구현
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 내 정보 조회 관련 Request/Response DTO 추가
- 내 정보 조회 관련 converter 추가
- GET /api/v1/members/me
- Swagger 문서 작성
- Swagger에서 각 API별 description 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="1930" height="1042" alt="image" src="https://github.com/user-attachments/assets/c28818b9-b312-4c9d-9914-47d9b6feb0e9" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #40 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp


- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61?p=38fca1e217c080f89331dd6ff35a4880&pm=s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 로그인한 사용자가 자신의 회원 정보를 조회할 수 있는 ‘내 정보 조회’ API를 추가했습니다.
  * 회원 ID, 이름, 성별, 생년월일, 로그인 제공자, 온보딩 완료 여부, 가입일을 제공합니다.
* **문서**
  * ‘내 정보 조회’ API의 요청·응답 형식 및 성공/오류 응답 예시를 API 문서에 추가했습니다.
  * 소셜 로그인, 토큰 재발급, 로그아웃, 회원 탈퇴 관련 API 설명을 정리/보완했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->