### PR TITLE
[feat] 관계 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/relationship/controller/RelationshipController.java
+++ b/src/main/java/com/umc/halo/domain/relationship/controller/RelationshipController.java
@@ -1,0 +1,26 @@
+package com.umc.halo.domain.relationship.controller;
+
+import com.umc.halo.domain.relationship.dto.RelationshipResDTO;
+import com.umc.halo.domain.relationship.exception.code.RelationshipSuccessCode;
+import com.umc.halo.domain.relationship.service.RelationshipService;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/relationships")
+public class RelationshipController {
+    private final RelationshipService relationshipService;
+    @GetMapping
+    public ApiResponse<RelationshipResDTO.Info> getRelationshipInfo(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        BaseSuccessCode code = RelationshipSuccessCode.INFO_SUCCESS;
+        return ApiResponse.onSuccess(code, relationshipService.getRelationshipInfo(memberId));
+    }
+}

--- a/src/main/java/com/umc/halo/domain/relationship/controller/RelationshipController.java
+++ b/src/main/java/com/umc/halo/domain/relationship/controller/RelationshipController.java
@@ -1,5 +1,6 @@
 package com.umc.halo.domain.relationship.controller;
 
+import com.umc.halo.domain.relationship.controller.docs.RelationshipControllerDocs;
 import com.umc.halo.domain.relationship.dto.RelationshipResDTO;
 import com.umc.halo.domain.relationship.exception.code.RelationshipSuccessCode;
 import com.umc.halo.domain.relationship.service.RelationshipService;
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/relationships")
-public class RelationshipController {
+public class RelationshipController implements RelationshipControllerDocs {
     private final RelationshipService relationshipService;
     @GetMapping
     public ApiResponse<RelationshipResDTO.Info> getRelationshipInfo(

--- a/src/main/java/com/umc/halo/domain/relationship/controller/docs/RelationshipControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/relationship/controller/docs/RelationshipControllerDocs.java
@@ -1,0 +1,87 @@
+package com.umc.halo.domain.relationship.controller.docs;
+
+import com.umc.halo.domain.relationship.dto.RelationshipResDTO;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "관계 정보 API")
+public interface RelationshipControllerDocs {
+
+    @Operation(
+            summary = "관계 정보 조회 API",
+            description = """
+                    # 관계 정보 조회
+                    
+                    ## 요청 형식
+                    - 헤더: Authorization: Bearer {JWT 토큰}
+                    
+                    마이페이지에서 온보딩 때 선택한 관계 태그를 조회합니다.
+                    온보딩 전이면 빈 목록([])과 null을 반환합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "RELATIONSHIP200_1",
+                                      "message": "관계 정보 조회 성공",
+                                      "result": {
+                                        "parentPersonalityTags": [
+                                          { "tagId": 12, "title": "다정하게 표현하는 편" },
+                                          { "tagId": 15, "title": "걱정이 많은 편" }
+                                        ],
+                                        "currentRelationState": { "tagId": 23, "title": "안부는 하지만 조금 어색한 편" },
+                                        "goalRelationships": [
+                                          { "tagId": 31, "title": "어색하지 않게 이야기하고 싶어요" },
+                                          { "tagId": 33, "title": "부모님을 더 알고 싶어요" }
+                                        ]
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 헤더에 JWT 토큰 미삽입/만료",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "토큰의 회원이 존재하지 않음 (탈퇴 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<RelationshipResDTO.Info> getRelationshipInfo(
+            @Parameter(hidden = true) Long memberId
+    );
+}

--- a/src/main/java/com/umc/halo/domain/relationship/converter/RelationshipConverter.java
+++ b/src/main/java/com/umc/halo/domain/relationship/converter/RelationshipConverter.java
@@ -1,0 +1,26 @@
+package com.umc.halo.domain.relationship.converter;
+
+import com.umc.halo.domain.relationship.dto.RelationshipResDTO;
+import com.umc.halo.domain.tag.entity.Tag;
+
+import java.util.List;
+
+public class RelationshipConverter {
+    public static RelationshipResDTO.TagInfo toTagInfo(Tag tag) {
+        return RelationshipResDTO.TagInfo.builder()
+                .tagId(tag.getId())
+                .title(tag.getTitle())
+                .build();
+    }
+    public static RelationshipResDTO.Info toInfo(
+            List<RelationshipResDTO.TagInfo> parentPersonalityTags,
+            RelationshipResDTO.TagInfo currentRelationState,
+            List<RelationshipResDTO.TagInfo> goalRelationships
+    ) {
+        return RelationshipResDTO.Info.builder()
+                .parentPersonalityTags(parentPersonalityTags)
+                .currentRelationState(currentRelationState)
+                .goalRelationships(goalRelationships)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/halo/domain/relationship/dto/RelationshipResDTO.java
+++ b/src/main/java/com/umc/halo/domain/relationship/dto/RelationshipResDTO.java
@@ -1,0 +1,20 @@
+package com.umc.halo.domain.relationship.dto;
+
+import lombok.Builder;
+import java.util.List;
+
+public class RelationshipResDTO {
+
+    @Builder
+    public record Info(
+            List<TagInfo> parentPersonalityTags,
+            TagInfo currentRelationState,
+            List<TagInfo> goalRelationships
+    ) {}
+
+    @Builder
+    public record TagInfo(
+            Long tagId,
+            String title
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/relationship/exception/code/RelationshipSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/relationship/exception/code/RelationshipSuccessCode.java
@@ -1,0 +1,19 @@
+package com.umc.halo.domain.relationship.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RelationshipSuccessCode implements BaseSuccessCode {
+    INFO_SUCCESS(HttpStatus.OK,
+            "RELATIONSHIP200_1",
+            "관계 정보 조회 성공")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/relationship/service/RelationshipService.java
+++ b/src/main/java/com/umc/halo/domain/relationship/service/RelationshipService.java
@@ -1,0 +1,49 @@
+package com.umc.halo.domain.relationship.service;
+
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.member.exception.MemberException;
+import com.umc.halo.domain.member.exception.code.MemberErrorCode;
+import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.domain.relationship.converter.RelationshipConverter;
+import com.umc.halo.domain.relationship.dto.RelationshipResDTO;
+import com.umc.halo.domain.tag.entity.MemberTag;
+import com.umc.halo.domain.tag.entity.Tag;
+import com.umc.halo.domain.tag.repository.MemberTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RelationshipService {
+
+    private final MemberRepository memberRepository;
+    private final MemberTagRepository memberTagRepository;
+
+    @Transactional(readOnly = true)
+    public RelationshipResDTO.Info getRelationshipInfo(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        List<RelationshipResDTO.TagInfo> parentPersonalityTags = new ArrayList<>();
+        RelationshipResDTO.TagInfo currentRelationState = null;
+        List<RelationshipResDTO.TagInfo> goalRelationships = new ArrayList<>();
+
+        for (MemberTag memberTag : memberTagRepository.findAllByMember(member)) {
+            Tag tag = memberTag.getTag();
+
+            switch (tag.getCategory()) {
+                case PARENT_TENDENCY -> parentPersonalityTags.add(RelationshipConverter.toTagInfo(tag));
+                case CURRENT_RELATIONSHIP -> currentRelationState = RelationshipConverter.toTagInfo(tag);
+                case DESIRED_DIRECTION -> goalRelationships.add(RelationshipConverter.toTagInfo(tag));
+                default -> { /* 관계 정보와 무관한 카테고리는 무시하려고 넣음*/ }
+            }
+        }
+
+        return RelationshipConverter.toInfo(parentPersonalityTags, currentRelationState, goalRelationships);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
+++ b/src/main/java/com/umc/halo/domain/tag/repository/MemberTagRepository.java
@@ -2,6 +2,7 @@ package com.umc.halo.domain.tag.repository;
 
 import com.umc.halo.domain.tag.entity.*;
 import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.*;
 import com.umc.halo.domain.member.entity.Member;
 import java.util.List;
@@ -9,7 +10,9 @@ import com.umc.halo.domain.tag.enums.Category;
 
 @Repository
 public interface MemberTagRepository extends JpaRepository<MemberTag, Long> {
-    List<MemberTag> findAllByMember(Member member);
+    @Query("SELECT mt FROM MemberTag mt JOIN FETCH mt.tag WHERE mt.member = :member")
+    List<MemberTag> findAllByMember(@Param("member") Member member);
+
     void deleteByMemberId(Long memberId);
     void deleteByMemberAndTag_Category(Member member, Category category);
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
-  마이페이지 > 관계 정보 보기 화면용 관계 정보 조회 API 구현
- 온보딩에서 선택한 태그를 카테고리별(부모 성향 / 현재 관계 상태 / 원하는 관계 방향)로 분류해 반환
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `GET /api/v1/relationships` (Private)
- `domain/relationship` 패키지 신규 추가 (Controller / ControllerDocs / Service / Converter / ResDTO / SuccessCode)
- 별도 테이블 없이 `member_tag` + `tag`를 조회해 가공 → 엔티티·레포지토리 없음
- `MemberTagRepository.findAllByMember`에 fetch join 적용 (리뷰 반영, tag 도메인)
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="2696" height="920" alt="image" src="https://github.com/user-attachments/assets/5a80197d-6146-4435-8ddb-427a3d0c6186" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #39
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 성공 코드: 명세서엔 `RELATIONSHIP200`이었으나 기존 코드(`AUTH200_1`, `ONBOARDING200_1`)와 통일해 `RELATIONSHIP200_1`로 구현, 명세서 수정 완료
- 회원 미존재 시 기존 `MEMBER404_1` 재사용, 명세서 Error 표에 추가 완료

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마이페이지에서 사용자의 관계 정보를 조회하는 API(`/api/v1/relationships`)를 추가했습니다.
  * 부모 성향 태그, 현재 관계 상태, 목표 관계 태그를 구분해 응답합니다.
  * 온보딩 전인 경우 빈 목록 및 `null` 형태로 관계 정보가 반환됩니다.
* **문서**
  * 관계 정보 조회 API의 요청/응답 예시를 Swagger로 추가했습니다.
  * 표준 성공 응답 코드와 메시지를 적용했습니다.
* **개선**
  * 관계 데이터 조회 시 응답 생성 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->