### PR TITLE
[feat] 감정별 캐릭터 삭제 

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
@@ -2,7 +2,6 @@ package com.umc.halo.domain.content.storybook.entity;
 
 import com.umc.halo.domain.content.storybook.enums.*;
 import com.umc.halo.global.entity.*;
-import com.umc.halo.global.enums.*;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -29,10 +28,6 @@ public class StorybookCharacter extends BaseEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Variant variant;
-
-    @Column
-    @Enumerated(EnumType.STRING)
-    private Emotion emotion;
 
     @Column(name = "image_url", nullable = false)
     private String imageUrl;

--- a/src/main/java/com/umc/halo/domain/content/storybook/enums/Variant.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/enums/Variant.java
@@ -2,6 +2,5 @@ package com.umc.halo.domain.content.storybook.enums;
 
 public enum Variant {
     ORIGINAL,
-    IMAGE_CHOICE,
-    EMOTION
+    IMAGE_CHOICE
 }

--- a/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
@@ -5,7 +5,6 @@ import com.umc.halo.domain.content.chapter.repository.*;
 import com.umc.halo.domain.content.storybook.entity.*;
 import com.umc.halo.domain.content.storybook.enums.*;
 import com.umc.halo.domain.content.storybook.repository.*;
-import com.umc.halo.global.enums.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
 import org.springframework.stereotype.*;
@@ -131,17 +130,6 @@ public class StorybookSeeder {
                         .variant(Variant.IMAGE_CHOICE)
                         .imageUrl("https://example.com/character-image-choice.png")
                         .build()
-        );
-        storybookCharacters.addAll(
-                Arrays.stream(Emotion.values())
-                        .map(emotion -> StorybookCharacter.builder()
-                                .storybook(storybook)
-                                .name(characterName)
-                                .variant(Variant.EMOTION)
-                                .emotion(emotion)
-                                .imageUrl("https://example.com/character-emotion-" + emotion.name().toLowerCase() + ".png")
-                                .build())
-                        .toList()
         );
 
         List<StorybookCharacter> savedStorybookCharacters = storybookCharacterRepository.saveAll(storybookCharacters);


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 감정별 캐릭터 삭제 
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- StorybookCharacter 엔티티 emotion 컬럼 제거
- Varient enum의 emotion 제거
- StorybookSeeder에서 emotion별 캐릭터 시딩 제거
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #49
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 동화 캐릭터가 감정 정보 대신 이미지 URL을 사용하도록 변경되었습니다.
  * 캐릭터 이미지 URL은 필수 정보로 관리됩니다.
  * 캐릭터 생성 시 감정 기반 변형 항목이 제거되고, 원본 및 이미지 선택 변형만 제공됩니다.
  * 지원되는 변형 유형에서 감정 항목이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->