### PR TITLE
[feat] 약관 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/term/controller/TermController.java
+++ b/src/main/java/com/umc/halo/domain/term/controller/TermController.java
@@ -1,0 +1,54 @@
+package com.umc.halo.domain.term.controller;
+
+import com.umc.halo.domain.term.controller.docs.TermControllerDocs;
+import com.umc.halo.domain.term.dto.TermReqDTO;
+import com.umc.halo.domain.term.dto.TermResDTO;
+import com.umc.halo.domain.term.exception.code.TermSuccessCode;
+import com.umc.halo.domain.term.service.TermService;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/terms")
+public class TermController implements TermControllerDocs {
+
+    private final TermService termService;
+
+    // 약관 목록 조회
+    @GetMapping
+    public ApiResponse<List<TermResDTO.Info>> getTerms() {
+        BaseSuccessCode code = TermSuccessCode.LIST_SUCCESS;
+        return ApiResponse.onSuccess(code, termService.getTerms());
+    }
+
+    // 약관 동의 처리
+    @PostMapping("/agreements")
+    public ApiResponse<Void> agree(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody TermReqDTO.Agree request
+    ) {
+        termService.agree(memberId, request);
+        BaseSuccessCode code = TermSuccessCode.AGREE_SUCCESS;
+        return ApiResponse.onSuccess(code);
+    }
+
+    // 약관 동의 여부 조회
+    @GetMapping("/agreements")
+    public ApiResponse<TermResDTO.AgreementStatus> getAgreementStatus(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        BaseSuccessCode code = TermSuccessCode.AGREEMENT_STATUS_SUCCESS;
+        return ApiResponse.onSuccess(code, termService.getAgreementStatus(memberId));
+    }
+}

--- a/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
@@ -1,0 +1,198 @@
+package com.umc.halo.domain.term.controller.docs;
+
+import com.umc.halo.domain.term.dto.TermReqDTO;
+import com.umc.halo.domain.term.dto.TermResDTO;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
+
+@Tag(name = "약관 API")
+public interface TermControllerDocs {
+
+    @Operation(
+            summary = "약관 목록 조회 API",
+            description = """
+                    # 약관 목록 조회
+                    
+                    ## 요청 형식
+                    - 인증이 필요하지 않습니다. (Public)
+                    
+                    약관 동의 화면에 노출할 약관 목록을 조회합니다.
+                    isRequired가 true면 필수 약관, false면 선택 약관입니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "TERMS200_1",
+                                      "message": "약관 목록 조회 성공",
+                                      "result": [
+                                        { "termId": 1, "title": "서비스 이용약관", "shortDescription": "HALO 서비스 이용 기준", "isRequired": true },
+                                        { "termId": 2, "title": "개인정보 처리방침", "shortDescription": "수집 항목 보관 기간 안내", "isRequired": true },
+                                        { "termId": 3, "title": "콘텐츠 보관 및 활용 안내", "shortDescription": "사진·기록 저장 기준", "isRequired": true },
+                                        { "termId": 4, "title": "마케팅 정보 수신 동의", "shortDescription": "이벤트·업데이트 안내", "isRequired": false }
+                                      ]
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<List<TermResDTO.Info>> getTerms();
+
+    @Operation(
+            summary = "약관 동의 처리 API",
+            description = """
+                    # 약관 동의 처리
+                    
+                    ## 요청 형식
+                    - 헤더: Authorization: Bearer {JWT 토큰}
+                    - Body: agreements (약관별 동의 내역)
+                    
+                    필수 약관에 모두 동의해야 저장됩니다.
+                    선택 약관은 동의하지 않아도 서비스 이용이 가능합니다.
+                    이미 동의한 약관은 새로 저장하지 않고 동의 여부만 갱신합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "저장 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "TERMS200_2",
+                                      "message": "약관 동의가 저장되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "필수 약관 미동의",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TERMS400_1",
+                                      "message": "필수 약관에 모두 동의해야 합니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 헤더에 JWT 토큰 미삽입/만료",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 약관(TERMS404_1) / 토큰의 회원이 존재하지 않음(MEMBER404_1)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "TERMS404_1",
+                                      "message": "존재하지 않는 약관입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<Void> agree(
+            @Parameter(hidden = true) Long memberId,
+            TermReqDTO.Agree request
+    );
+
+    @Operation(
+            summary = "약관 동의 여부 조회 API",
+            description = """
+                    # 약관 동의 여부 조회
+                    
+                    ## 요청 형식
+                    - 헤더: Authorization: Bearer {JWT 토큰}
+                    
+                    필수 약관 전체 동의 여부를 조회합니다.
+                    앱 실행 시 약관 동의 화면 노출 여부 판단에 사용합니다.
+                    필수 약관 중 하나라도 동의하지 않았으면 false를 반환합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "TERMS200_3",
+                                      "message": "약관 동의 여부 조회 성공",
+                                      "result": { "termsAgreed": true }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - 헤더에 JWT 토큰 미삽입/만료",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "토큰의 회원이 존재하지 않음 (탈퇴 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<TermResDTO.AgreementStatus> getAgreementStatus(
+            @Parameter(hidden = true) Long memberId
+    );
+}

--- a/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -129,7 +131,7 @@ public interface TermControllerDocs {
     })
     ApiResponse<Void> agree(
             @Parameter(hidden = true) Long memberId,
-            TermReqDTO.Agree request
+            @Valid @RequestBody TermReqDTO.Agree request
     );
 
     @Operation(
@@ -195,4 +197,5 @@ public interface TermControllerDocs {
     ApiResponse<TermResDTO.AgreementStatus> getAgreementStatus(
             @Parameter(hidden = true) Long memberId
     );
+
 }

--- a/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
@@ -1,0 +1,22 @@
+package com.umc.halo.domain.term.converter;
+
+import com.umc.halo.domain.term.dto.TermResDTO;
+import com.umc.halo.domain.term.entity.Term;
+
+public class TermConverter {
+
+    public static TermResDTO.Info toInfo(Term term) {
+        return TermResDTO.Info.builder()
+                .termId(term.getId())
+                .title(term.getTitle())
+                .shortDescription(term.getShortDescription())
+                .isRequired(term.getIsRequired())
+                .build();
+    }
+
+    public static TermResDTO.AgreementStatus toAgreementStatus(boolean termsAgreed) {
+        return TermResDTO.AgreementStatus.builder()
+                .termsAgreed(termsAgreed)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
@@ -1,7 +1,9 @@
 package com.umc.halo.domain.term.converter;
 
 import com.umc.halo.domain.term.dto.TermResDTO;
+import com.umc.halo.domain.term.entity.MemberTerm;
 import com.umc.halo.domain.term.entity.Term;
+import com.umc.halo.domain.member.entity.Member;
 
 public class TermConverter {
 
@@ -17,6 +19,14 @@ public class TermConverter {
     public static TermResDTO.AgreementStatus toAgreementStatus(boolean termsAgreed) {
         return TermResDTO.AgreementStatus.builder()
                 .termsAgreed(termsAgreed)
+                .build();
+    }
+
+    public static MemberTerm toMemberTerm(Member member, Term term, Boolean isAgreed) {
+        return MemberTerm.builder()
+                .member(member)
+                .term(term)
+                .isAgreed(isAgreed)
                 .build();
     }
 }

--- a/src/main/java/com/umc/halo/domain/term/dto/TermReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/term/dto/TermReqDTO.java
@@ -1,0 +1,14 @@
+package com.umc.halo.domain.term.dto;
+
+import java.util.List;
+
+public class TermReqDTO {
+
+    public record Agree(
+            List<Agreement> agreements
+    ) {}
+    public record Agreement(
+            Long termId,
+            Boolean isAgreed
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/term/dto/TermReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/term/dto/TermReqDTO.java
@@ -1,14 +1,19 @@
 package com.umc.halo.domain.term.dto;
 
 import java.util.List;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 public class TermReqDTO {
 
     public record Agree(
+            @Valid
             List<Agreement> agreements
     ) {}
     public record Agreement(
+            @NotNull(message = "termId는 필수입니다.")
             Long termId,
+            @NotNull(message = "isAgreed는 필수입니다.")
             Boolean isAgreed
     ) {}
 }

--- a/src/main/java/com/umc/halo/domain/term/dto/TermResDTO.java
+++ b/src/main/java/com/umc/halo/domain/term/dto/TermResDTO.java
@@ -1,0 +1,19 @@
+package com.umc.halo.domain.term.dto;
+
+import lombok.Builder;
+
+public class TermResDTO {
+
+    @Builder
+    public record Info(
+            Long termId,
+            String title,
+            String shortDescription,
+            Boolean isRequired
+    ) {}
+
+    @Builder
+    public record AgreementStatus(
+            Boolean termsAgreed
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/term/entity/MemberTerm.java
+++ b/src/main/java/com/umc/halo/domain/term/entity/MemberTerm.java
@@ -29,4 +29,8 @@ public class MemberTerm extends BaseEntity {
     @Column(name = "is_agreed", nullable = false)
     @Builder.Default
     private Boolean isAgreed = false;
+
+    public void updateIsAgreed(Boolean isAgreed) {
+        this.isAgreed = isAgreed;
+    }
 }

--- a/src/main/java/com/umc/halo/domain/term/entity/MemberTerm.java
+++ b/src/main/java/com/umc/halo/domain/term/entity/MemberTerm.java
@@ -6,7 +6,10 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "member_term")
+@Table(name = "member_term",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_member_term", columnNames = {"member_id", "term_id"})
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder

--- a/src/main/java/com/umc/halo/domain/term/exception/TermException.java
+++ b/src/main/java/com/umc/halo/domain/term/exception/TermException.java
@@ -1,0 +1,10 @@
+package com.umc.halo.domain.term.exception;
+
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+
+public class TermException extends ProjectException {
+    public TermException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/term/exception/code/TermErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/term/exception/code/TermErrorCode.java
@@ -1,0 +1,23 @@
+package com.umc.halo.domain.term.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermErrorCode implements BaseErrorCode {
+
+    REQUIRED_NOT_AGREED(HttpStatus.BAD_REQUEST,
+            "TERMS400_1",
+            "필수 약관에 모두 동의해야 합니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND,
+            "TERMS404_1",
+            "존재하지 않는 약관입니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/term/exception/code/TermSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/term/exception/code/TermSuccessCode.java
@@ -1,0 +1,26 @@
+package com.umc.halo.domain.term.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermSuccessCode implements BaseSuccessCode {
+
+    LIST_SUCCESS(HttpStatus.OK,
+            "TERMS200_1",
+            "약관 목록 조회 성공"),
+    AGREE_SUCCESS(HttpStatus.OK,
+            "TERMS200_2",
+            "약관 동의가 저장되었습니다."),
+    AGREEMENT_STATUS_SUCCESS(HttpStatus.OK,
+            "TERMS200_3",
+            "약관 동의 여부 조회 성공")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/term/repository/MemberTermRepository.java
+++ b/src/main/java/com/umc/halo/domain/term/repository/MemberTermRepository.java
@@ -5,9 +5,11 @@ import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
 import com.umc.halo.domain.member.entity.Member;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
     List<MemberTerm> findAllByMember(Member member);
+    Optional<MemberTerm> findByMemberAndTerm(Member member, Term term);
     void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/term/repository/MemberTermRepository.java
+++ b/src/main/java/com/umc/halo/domain/term/repository/MemberTermRepository.java
@@ -3,9 +3,11 @@ package com.umc.halo.domain.term.repository;
 import com.umc.halo.domain.term.entity.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
+import com.umc.halo.domain.member.entity.Member;
+import java.util.List;
 
 @Repository
 public interface MemberTermRepository extends JpaRepository<MemberTerm, Long> {
-
+    List<MemberTerm> findAllByMember(Member member);
     void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/umc/halo/domain/term/repository/TermRepository.java
@@ -4,6 +4,10 @@ import com.umc.halo.domain.term.entity.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
 
+import java.util.List;
+
 @Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
+
+    List<Term> findAllByOrderByIdAsc();
 }

--- a/src/main/java/com/umc/halo/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/umc/halo/domain/term/repository/TermRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface TermRepository extends JpaRepository<Term, Long> {
 
     List<Term> findAllByOrderByIdAsc();
+
+    List<Term> findAllByIsRequiredTrue();
 }

--- a/src/main/java/com/umc/halo/domain/term/service/TermService.java
+++ b/src/main/java/com/umc/halo/domain/term/service/TermService.java
@@ -114,8 +114,7 @@ public class TermService {
                 .map(memberTerm -> memberTerm.getTerm().getId())
                 .collect(Collectors.toSet());
 
-        boolean termsAgreed = termRepository.findAll().stream()
-                .filter(term -> Boolean.TRUE.equals(term.getIsRequired()))
+        boolean termsAgreed = termRepository.findAllByIsRequiredTrue().stream()
                 .allMatch(term -> agreedTermIds.contains(term.getId()));
 
         return TermConverter.toAgreementStatus(termsAgreed);

--- a/src/main/java/com/umc/halo/domain/term/service/TermService.java
+++ b/src/main/java/com/umc/halo/domain/term/service/TermService.java
@@ -97,11 +97,8 @@ public class TermService {
             if (memberTerm != null) {
                 memberTerm.updateIsAgreed(entry.getValue());
             } else {
-                memberTermRepository.save(MemberTerm.builder()
-                        .member(member)
-                        .term(termMap.get(entry.getKey()))
-                        .isAgreed(entry.getValue())
-                        .build());
+                memberTermRepository.save(TermConverter.toMemberTerm(
+                        member, termMap.get(entry.getKey()), entry.getValue()));
             }
         }
     }

--- a/src/main/java/com/umc/halo/domain/term/service/TermService.java
+++ b/src/main/java/com/umc/halo/domain/term/service/TermService.java
@@ -1,0 +1,126 @@
+package com.umc.halo.domain.term.service;
+
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.member.exception.MemberException;
+import com.umc.halo.domain.member.exception.code.MemberErrorCode;
+import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.domain.term.converter.TermConverter;
+import com.umc.halo.domain.term.dto.TermReqDTO;
+import com.umc.halo.domain.term.dto.TermResDTO;
+import com.umc.halo.domain.term.entity.MemberTerm;
+import com.umc.halo.domain.term.entity.Term;
+import com.umc.halo.domain.term.exception.TermException;
+import com.umc.halo.domain.term.exception.code.TermErrorCode;
+import com.umc.halo.domain.term.repository.MemberTermRepository;
+import com.umc.halo.domain.term.repository.TermRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TermService {
+
+    private final MemberRepository memberRepository;
+    private final TermRepository termRepository;
+    private final MemberTermRepository memberTermRepository;
+
+    // 약관 목록 조회
+    @Transactional(readOnly = true)
+    public List<TermResDTO.Info> getTerms() {
+        return termRepository.findAllByOrderByIdAsc().stream()
+                .map(TermConverter::toInfo)
+                .toList();
+    }
+
+    // 약관 동의 처리
+    @Transactional
+    public void agree(Long memberId, TermReqDTO.Agree request) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        List<TermReqDTO.Agreement> agreements =
+                (request == null || request.agreements() == null) ? List.of() : request.agreements();
+
+        Map<Long, Boolean> requested = new HashMap<>();
+        for (TermReqDTO.Agreement agreement : agreements) {
+            requested.put(agreement.termId(), Boolean.TRUE.equals(agreement.isAgreed()));
+        }
+
+        List<Term> terms = termRepository.findAllByOrderByIdAsc();
+        Map<Long, Term> termMap = terms.stream()
+                .collect(Collectors.toMap(Term::getId, term -> term));
+
+        validateTermsExist(requested.keySet(), termMap);
+        validateRequiredAgreed(terms, requested);
+
+        saveAgreements(member, requested, termMap);
+    }
+
+    private void validateTermsExist(Set<Long> requestedTermIds, Map<Long, Term> termMap) {
+
+        for (Long termId : requestedTermIds) {
+            if (termId == null || !termMap.containsKey(termId)) {
+                throw new TermException(TermErrorCode.NOT_FOUND);
+            }
+        }
+    }
+
+    private void validateRequiredAgreed(List<Term> terms, Map<Long, Boolean> requested) {
+
+        for (Term term : terms) {
+            if (Boolean.TRUE.equals(term.getIsRequired())
+                    && !Boolean.TRUE.equals(requested.get(term.getId()))) {
+                throw new TermException(TermErrorCode.REQUIRED_NOT_AGREED);
+            }
+        }
+    }
+
+    private void saveAgreements(Member member, Map<Long, Boolean> requested, Map<Long, Term> termMap) {
+
+        Map<Long, MemberTerm> existing = memberTermRepository.findAllByMember(member).stream()
+                .collect(Collectors.toMap(
+                        memberTerm -> memberTerm.getTerm().getId(),
+                        memberTerm -> memberTerm,
+                        (first, second) -> first));
+
+        for (Map.Entry<Long, Boolean> entry : requested.entrySet()) {
+            MemberTerm memberTerm = existing.get(entry.getKey());
+
+            if (memberTerm != null) {
+                memberTerm.updateIsAgreed(entry.getValue());
+            } else {
+                memberTermRepository.save(MemberTerm.builder()
+                        .member(member)
+                        .term(termMap.get(entry.getKey()))
+                        .isAgreed(entry.getValue())
+                        .build());
+            }
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public TermResDTO.AgreementStatus getAgreementStatus(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        Set<Long> agreedTermIds = memberTermRepository.findAllByMember(member).stream()
+                .filter(memberTerm -> Boolean.TRUE.equals(memberTerm.getIsAgreed()))
+                .map(memberTerm -> memberTerm.getTerm().getId())
+                .collect(Collectors.toSet());
+
+        boolean termsAgreed = termRepository.findAll().stream()
+                .filter(term -> Boolean.TRUE.equals(term.getIsRequired()))
+                .allMatch(term -> agreedTermIds.contains(term.getId()));
+
+        return TermConverter.toAgreementStatus(termsAgreed);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/term/service/TermService.java
+++ b/src/main/java/com/umc/halo/domain/term/service/TermService.java
@@ -16,7 +16,7 @@ import com.umc.halo.domain.term.repository.TermRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import org.springframework.dao.DataIntegrityViolationException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,8 +97,14 @@ public class TermService {
             if (memberTerm != null) {
                 memberTerm.updateIsAgreed(entry.getValue());
             } else {
-                memberTermRepository.save(TermConverter.toMemberTerm(
-                        member, termMap.get(entry.getKey()), entry.getValue()));
+                Term term = termMap.get(entry.getKey());
+                try {
+                    memberTermRepository.save(TermConverter.toMemberTerm(
+                            member, term, entry.getValue()));
+                } catch (DataIntegrityViolationException e) {
+                    memberTermRepository.findByMemberAndTerm(member, term)
+                            .ifPresent(saved -> saved.updateIsAgreed(entry.getValue()));
+                }
             }
         }
     }


### PR DESCRIPTION
## 📝 작업 내용

- 약관 API 3종 구현 (목록 조회 / 동의 처리 / 동의 여부 조회)
- 동의 여부 조회는 신규 API입니다. 로그인 순서 변경안의 "로그인 O + 약관 미동의 → 약관 동의 화면" 분기를 안드에서 판단할 수단이 없어 추가했습니다.

- ---

## 🔧 변경 사항

- `GET /api/v1/terms` (Public) / `POST /api/v1/terms/agreements` (Private) / `GET /api/v1/terms/agreements` (Private)
- `domain/term`에 Controller / ControllerDocs / Service / Converter / ReqDTO / ResDTO / SuccessCode / ErrorCode / Exception 추가
- `TermRepository.findAllByOrderByIdAsc`, `MemberTermRepository.findAllByMember`, `MemberTerm.updateIsAgreed` 추가
- 동의 처리 재호출 시 기존 `member_term` 행의 `isAgreed`만 갱신합니다. 
- **타 도메인 변경 없음** 
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="2764" height="1464" alt="image" src="https://github.com/user-attachments/assets/0aee5bfc-5c00-438b-806c-58e117cc44fd" />
- 
<img width="1288" height="408" alt="image" src="https://github.com/user-attachments/assets/4338c3f1-0a7e-4b50-81ad-b0b04de593df" />
- <img width="1280" height="540" alt="image" src="https://github.com/user-attachments/assets/e0034bfa-c7f5-4619-a499-60e7b7dfbd54" />

-필수 약관 동의 안함 
<img width="1312" height="352" alt="image" src="https://github.com/user-attachments/assets/32ba913e-bfd3-4745-bb51-d4e63e9021a3" />

- 존재하지 않는 약관 
<img width="1266" height="338" alt="image" src="https://github.com/user-attachments/assets/ad7585d9-5ac2-41af-a189-8aa929961eb7" />


- 동의 여부 조회 
- 
<img width="1280" height="444" alt="image" src="https://github.com/user-attachments/assets/12f978e9-6c36-4034-a2c5-f1e912ea8b26" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #46 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- Notion API 명세서: 약관 목록 조회 / 약관 동의 처리 / 약관 동의 여부 조회


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새 기능**
  - 약관 목록 조회 API(`GET /api/v1/terms`)를 제공합니다.
  - 약관별 동의 제출 및 동의값 저장/갱신 API(`POST /api/v1/terms/agreements`)를 제공합니다.
  - 회원의 약관 동의 여부 확인 API(`GET /api/v1/terms/agreements`)를 제공합니다.
- **오류 처리**
  - 존재하지 않는 약관 또는 필수 약관 미동의 요청에 대해 명확한 오류 코드/메시지를 반환합니다.
- **문서**
  - 세 API의 요청/응답 예시와 응답 코드를 문서화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->