### PR TITLE
[fix] 에러핸들러 내 누락된 예외 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
@@ -119,14 +119,34 @@ public interface ChapterControllerDocs {
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ApiResponse.class),
-                                    examples = @ExampleObject("""
-                                            {
-                                                "isSuccess": false,
-                                                "code": "COMMON400_1",
-                                                "message": "잘못된 요청입니다.",
-                                                "result": "장 순서는 10 이하여야 합니다."
-                                            }
-                                            """)
+                                    examples = {
+                                            @ExampleObject(
+                                                    name = "chapterOrder가 1 미만",
+                                                    value = """
+                                                            {
+                                                                "isSuccess": false,
+                                                                "code": "COMMON400_1",
+                                                                "message": "잘못된 요청입니다.",
+                                                                "result": {
+                                                                    "chapterOrder": "장 순서는 1 이상이어야 합니다."
+                                                                }
+                                                            }
+                                                            """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "chapterOrder가 10 초과",
+                                                    value = """
+                                                            {
+                                                                "isSuccess": false,
+                                                                "code": "COMMON400_1",
+                                                                "message": "잘못된 요청입니다.",
+                                                                "result": {
+                                                                    "chapterOrder": "장 순서는 10 이하여야 합니다."
+                                                                }
+                                                            }
+                                                            """
+                                            )
+                                    }
                             )
                     ),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -61,18 +61,35 @@ public interface MemberControllerDocs {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "provider가 KAKAO/GOOGLE 외 값",
+                    description = "요청값 누락 또는 지원하지 않는 provider",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                        "isSuccess": false,
-                                        "code": "AUTH400_1",
-                                        "message": "지원하지 않는 소셜 로그인 제공자입니다.",
-                                        "result": null
-                                    }
-                                    """
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "provider/providerToken 누락",
+                                            value = """
+                                                    {
+                                                        "isSuccess": false,
+                                                        "code": "COMMON400_1",
+                                                        "message": "잘못된 요청입니다.",
+                                                        "result": {
+                                                            "provider": "provider는 필수입니다."
+                                                        }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "provider가 KAKAO/GOOGLE 외 값",
+                                            value = """
+                                                    {
+                                                        "isSuccess": false,
+                                                        "code": "AUTH400_1",
+                                                        "message": "지원하지 않는 소셜 로그인 제공자입니다.",
+                                                        "result": null
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -128,6 +145,24 @@ public interface MemberControllerDocs {
                                         "result": {
                                             "accessToken": "eyJ...",
                                             "refreshToken": "eyJ..."
+                                        }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "refreshToken 누락",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "COMMON400_1",
+                                        "message": "잘못된 요청입니다.",
+                                        "result": {
+                                            "refreshToken": "refreshToken은 필수입니다."
                                         }
                                     }
                                     """

--- a/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/docs/MemberControllerDocs.java
@@ -66,7 +66,7 @@ public interface MemberControllerDocs {
                             mediaType = "application/json",
                             examples = {
                                     @ExampleObject(
-                                            name = "provider/providerToken 누락",
+                                            name = "provider 누락",
                                             value = """
                                                     {
                                                         "isSuccess": false,
@@ -74,6 +74,19 @@ public interface MemberControllerDocs {
                                                         "message": "잘못된 요청입니다.",
                                                         "result": {
                                                             "provider": "provider는 필수입니다."
+                                                        }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "providerToken 누락",
+                                            value = """
+                                                    {
+                                                        "isSuccess": false,
+                                                        "code": "COMMON400_1",
+                                                        "message": "잘못된 요청입니다.",
+                                                        "result": {
+                                                            "providerToken": "providerToken은 필수입니다."
                                                         }
                                                     }
                                                     """

--- a/src/main/java/com/umc/halo/domain/member/dto/MemberReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/member/dto/MemberReqDTO.java
@@ -7,15 +7,15 @@ public class MemberReqDTO {
 
     // 로그인
     public record Login(
-            @NotNull
+            @NotNull(message = "provider는 필수입니다.")
             String provider,
-            @NotBlank
+            @NotBlank(message = "providerToken은 필수입니다.")
             String providerToken
     ) {}
 
     // 토큰 재발급
     public record TokenReissue(
-            @NotBlank
+            @NotBlank(message = "refreshToken은 필수입니다.")
             String refreshToken
     ) {}
 }

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -57,7 +57,7 @@ public interface RecordControllerDocs {
                                     schema = @Schema(implementation = ApiResponse.class),
                                     examples = {
                                             @ExampleObject(
-                                                    name = "storybookChapterId 등 필수 요청값 누락",
+                                                    name = "storybookChapterId 누락",
                                                     value = """
                                                             {
                                                                 "isSuccess": false,

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -147,6 +147,45 @@ public interface RecordControllerDocs {
                                                                 }
                                                             }
                                                             """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "status 누락",
+                                                    value = """
+                                                            {
+                                                                "isSuccess": false,
+                                                                "code": "COMMON400_1",
+                                                                "message": "잘못된 요청입니다.",
+                                                                "result": {
+                                                                    "status": "status는 필수입니다."
+                                                                }
+                                                            }
+                                                            """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "answers[].chapterQuestionId 누락",
+                                                    value = """
+                                                            {
+                                                                "isSuccess": false,
+                                                                "code": "COMMON400_1",
+                                                                "message": "잘못된 요청입니다.",
+                                                                "result": {
+                                                                    "answers[0].chapterQuestionId": "chapterQuestionId는 필수입니다."
+                                                                }
+                                                            }
+                                                            """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "answers[].answer가 빈 값",
+                                                    value = """
+                                                            {
+                                                                "isSuccess": false,
+                                                                "code": "COMMON400_1",
+                                                                "message": "잘못된 요청입니다.",
+                                                                "result": {
+                                                                    "answers[0].answer": "답변 내용은 비어 있을 수 없습니다."
+                                                                }
+                                                            }
+                                                            """
                                             )
                                     }
                             )

--- a/src/main/java/com/umc/halo/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/code/GeneralErrorCode.java
@@ -23,6 +23,15 @@ public enum GeneralErrorCode implements BaseErrorCode {
 	// 403 Forbidden (권한 없음)
 	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403_1", "접근 권한이 없습니다."),
 
+	// 405 Method Not Allowed (지원하지 않는 HTTP 메소드)
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405_1", "지원하지 않는 HTTP 메소드입니다."),
+
+	// 409 Conflict (중복/충돌)
+	CONFLICT(HttpStatus.CONFLICT, "COMMON409_1", "이미 존재하는 데이터이거나 요청이 충돌합니다."),
+
+	// 415 Unsupported Media Type (지원하지 않는 Content-Type)
+	UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "COMMON415_1", "지원하지 않는 Content-Type입니다."),
+
 	// 500 Internal Server Error (서버 내부 에러)
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500_1", "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -39,8 +39,11 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException ex) {
         log.warn("[ConstraintViolationException] 경로/쿼리 파라미터 검증 실패: {}", ex.getMessage());
         Map<String, String> errors = new HashMap<>();
-        ex.getConstraintViolations().forEach(violation ->
-                errors.put(violation.getPropertyPath().toString(), violation.getMessage()));
+        ex.getConstraintViolations().forEach(violation -> {
+            String path = violation.getPropertyPath().toString();
+            String field = path.substring(path.lastIndexOf('.') + 1);
+            errors.put(field, violation.getMessage());
+        });
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -197,4 +197,21 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
                 .body(ApiResponse.onFailure(errorCode, errors));
     }
 
+    // 오버라이드 되지 않은 나머지 ResponseEntityExceptionHandler 예외
+    @Override
+    protected @Nullable ResponseEntity<Object> handleExceptionInternal(
+            Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        log.warn("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, ex.getMessage());
+
+        ApiResponse<Object> response = new ApiResponse<>(
+                false,
+                "UNHANDLED_" + ex.getClass().getSimpleName(),
+                "요청을 처리할 수 없습니다.",
+                null
+        );
+
+        return ResponseEntity.status(statusCode)
+                .headers(headers)
+                .body(response);
+    }
 }

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -29,6 +29,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ProjectException.class)
     public ResponseEntity<ApiResponse<Void>> handleProjectException(ProjectException ex) {
         BaseErrorCode errorCode = ex.getErrorCode();
+        log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage());
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.onFailure(errorCode, null));
     }
@@ -37,14 +38,13 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException ex) {
         log.warn("[ConstraintViolationException] 경로/쿼리 파라미터 검증 실패: {}", ex.getMessage());
-        String detail = ex.getConstraintViolations().stream()
-                .findFirst()
-                .map(ConstraintViolation::getMessage)
-                .orElse(ex.getMessage());
+        Map<String, String> errors = new HashMap<>();
+        ex.getConstraintViolations().forEach(violation ->
+                errors.put(violation.getPropertyPath().toString(), violation.getMessage()));
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
-                .body(ApiResponse.onFailure(errorCode, detail));
+                .body(ApiResponse.onFailure(errorCode, errors));
 
     }
 
@@ -87,7 +87,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleMethodArgumentNotValid(
             MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("@Valid 검증에 실패했습니다.");
+        log.warn("[MethodArgumentNotValidException] @Valid 검증 실패: {}", ex.getMessage());
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getFieldErrors().forEach(error -> {
             errors.put(error.getField(), error.getDefaultMessage());
@@ -102,7 +102,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleHttpMessageNotReadable(
             HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("JSON 파싱 실패: {}", ex.getMessage());
+        log.warn("[HttpMessageNotReadableException] JSON 파싱 실패: {}", ex.getMessage());
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
@@ -113,7 +113,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleMissingServletRequestParameter(
             MissingServletRequestParameterException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("필수 파라미터 누락: {}", ex.getMessage());
+        log.warn("[MissingServletRequestParameterException] 필수 파라미터 누락: {}", ex.getMessage());
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
@@ -124,7 +124,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleHttpMediaTypeNotSupported(
             HttpMediaTypeNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("지원하지 않는 Content-Type: {}", ex.getMessage());
+        log.warn("[HttpMediaTypeNotSupportedException] 지원하지 않는 Content-Type: {}", ex.getMessage());
 
         BaseErrorCode errorCode = GeneralErrorCode.UNSUPPORTED_MEDIA_TYPE;
         return ResponseEntity.status(errorCode.getStatus())
@@ -135,7 +135,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleHttpRequestMethodNotSupported(
             HttpRequestMethodNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("지원하지 않는 HTTP Method: {}", ex.getMessage());
+        log.warn("[HttpRequestMethodNotSupportedException] 지원하지 않는 HTTP Method: {}", ex.getMessage());
 
         BaseErrorCode errorCode = GeneralErrorCode.METHOD_NOT_ALLOWED;
         return ResponseEntity.status(errorCode.getStatus())
@@ -147,9 +147,9 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     protected @Nullable ResponseEntity<Object> handleTypeMismatch(
             TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         if (ex instanceof MethodArgumentTypeMismatchException matEx) {
-            log.warn("타입 불일치: parameter={}, value={}", matEx.getName(), matEx.getValue());
+            log.warn("[MethodArgumentTypeMismatchException] 타입 불일치: parameter={}, value={}", matEx.getName(), matEx.getValue());
         } else {
-            log.warn("타입 불일치: property={}", ex.getPropertyName());
+            log.warn("[TypeMismatchException] 타입 불일치: property={}", ex.getPropertyName());
         }
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
@@ -161,7 +161,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleNoResourceFoundException(
             NoResourceFoundException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("존재하지 않는 엔드포인트: {}", ex.getMessage());
+        log.warn("[NoResourceFoundException] 존재하지 않는 엔드포인트: {}", ex.getMessage());
 
         BaseErrorCode errorCode = GeneralErrorCode.NOT_FOUND;
         return ResponseEntity.status(errorCode.getStatus())
@@ -172,7 +172,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleHandlerMethodValidationException(
             HandlerMethodValidationException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("[HandlerMethodValidationException] 컨트롤러 파라미터 검증 실패");
+        log.warn("[HandlerMethodValidationException] 컨트롤러 파라미터 검증 실패: {}", ex.getMessage());
         Map<String, String> errors = new HashMap<>();
         ex.getParameterValidationResults().forEach(result -> {
             String parameterName = result.getMethodParameter().getParameterName();

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -210,8 +210,6 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
                 null
         );
 
-        return ResponseEntity.status(statusCode)
-                .headers(headers)
-                .body(response);
+        return super.handleExceptionInternal(ex, response, headers, statusCode, request);
     }
 }

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -4,16 +4,28 @@ import com.umc.halo.global.apiPayload.*;
 import com.umc.halo.global.apiPayload.code.*;
 import com.umc.halo.global.apiPayload.exception.*;
 import jakarta.validation.*;
+import lombok.extern.slf4j.*;
+import org.jspecify.annotations.*;
+import org.springframework.beans.*;
+import org.springframework.dao.*;
 import org.springframework.http.*;
+import org.springframework.http.converter.*;
+import org.springframework.validation.*;
+import org.springframework.web.*;
 import org.springframework.web.bind.*;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.*;
+import org.springframework.web.method.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.*;
+import org.springframework.web.servlet.resource.*;
 
 import java.util.*;
 
+@Slf4j
 @RestControllerAdvice
-public class GeneralExceptionAdvice {
+public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
-    //프로젝트에서 발생한 에러
+    // 프로젝트에서 발생한 에러
     @ExceptionHandler(ProjectException.class)
     public ResponseEntity<ApiResponse<Void>> handleProjectException(ProjectException ex) {
         BaseErrorCode errorCode = ex.getErrorCode();
@@ -21,40 +33,157 @@ public class GeneralExceptionAdvice {
                 .body(ApiResponse.onFailure(errorCode, null));
     }
 
-    //@Valid 검증 실패
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Map<String, String>>> handleMethodArgumentNotValidException(
-            MethodArgumentNotValidException ex) {
+    // @Validated 경로/쿼리 파라미터 검증
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException ex) {
+        log.warn("[ConstraintViolationException] 경로/쿼리 파라미터 검증 실패: {}", ex.getMessage());
+        String detail = ex.getConstraintViolations().stream()
+                .findFirst()
+                .map(ConstraintViolation::getMessage)
+                .orElse(ex.getMessage());
+
+        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, detail));
+
+    }
+
+    // 유니크 제약
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Object> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        log.warn("[DataIntegrityViolationException] DB 제약조건 위배: {}", ex.getMessage());
+
+        BaseErrorCode errorCode = GeneralErrorCode.CONFLICT;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    // ModelAttribute 검증 실패
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<Object> handleBindException(BindException ex) {
+        log.warn("[BindException] ModelAttribute 바인딩 혹은 검증 실패: {}", ex.getMessage());
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage()));
+
+        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, errors));
+    }
+
+    // 서버 내부 에러
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleUnexpectedException(Exception ex) {
+        log.error("[UnexpectedException] 서버 내부 에러: ", ex);
+
+        BaseErrorCode errorCode = GeneralErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, null));
+
+    }
+
+    // 오버라이드
+    // @Valid(DTO 검증 실패)
+    @Override
+    protected @Nullable ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("@Valid 검증에 실패했습니다.");
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getFieldErrors().forEach(error -> {
             errors.put(error.getField(), error.getDefaultMessage());
         });
 
-        BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
-        return ResponseEntity.status(code.getStatus())
-                .body(ApiResponse.onFailure(code, errors));
+        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, errors));
     }
 
-    // @Validated 검증 실패(경로/쿼리 파라미터)
-    @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ApiResponse<String>> handleConstraintViolationException(
-            ConstraintViolationException ex) {
-        String detail = ex.getConstraintViolations().stream()
-                .findFirst()
-                .map(ConstraintViolation::getMessage)
-                .orElse(null);
+    // JSON 파싱 실패
+    @Override
+    protected @Nullable ResponseEntity<Object> handleHttpMessageNotReadable(
+            HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("JSON 파싱 실패: {}", ex.getMessage());
 
-        BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
-        return ResponseEntity.status(code.getStatus())
-                .body(ApiResponse.onFailure(code, detail));
+        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, "요청 Body 형식이 잘못되었습니다."));
     }
 
-    //그 외
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<String>> handleException(Exception ex) {
-        BaseErrorCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;
-        return ResponseEntity.status(code.getStatus())
-                .body(ApiResponse.onFailure(code, ex.getMessage()));
+    // 쿼리 파라미터 누락
+    @Override
+    protected @Nullable ResponseEntity<Object> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("필수 파라미터 누락: {}", ex.getMessage());
+
+        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    // 잘못된 Content-Type
+    @Override
+    protected @Nullable ResponseEntity<Object> handleHttpMediaTypeNotSupported(
+            HttpMediaTypeNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("지원하지 않는 Content-Type: {}", ex.getMessage());
+
+        BaseErrorCode errorCode = GeneralErrorCode.UNSUPPORTED_MEDIA_TYPE;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    // 잘못된 Http 메소드
+    @Override
+    protected @Nullable ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+            HttpRequestMethodNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("지원하지 않는 HTTP Method: {}", ex.getMessage());
+
+        BaseErrorCode errorCode = GeneralErrorCode.METHOD_NOT_ALLOWED;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    // 타입 불일치
+    @Override
+    protected @Nullable ResponseEntity<Object> handleTypeMismatch(
+            TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        if (ex instanceof MethodArgumentTypeMismatchException matEx) {
+            log.warn("타입 불일치: parameter={}, value={}", matEx.getName(), matEx.getValue());
+        } else {
+            log.warn("타입 불일치: property={}", ex.getPropertyName());
+        }
+
+        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    // 존재하지 않는 엔드포인트
+    @Override
+    protected @Nullable ResponseEntity<Object> handleNoResourceFoundException(
+            NoResourceFoundException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("존재하지 않는 엔드포인트: {}", ex.getMessage());
+
+        BaseErrorCode errorCode = GeneralErrorCode.NOT_FOUND;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    // Validation 실패
+    @Override
+    protected @Nullable ResponseEntity<Object> handleHandlerMethodValidationException(
+            HandlerMethodValidationException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("[HandlerMethodValidationException] 컨트롤러 파라미터 검증 실패");
+        Map<String, String> errors = new HashMap<>();
+        ex.getParameterValidationResults().forEach(result -> {
+            String parameterName = result.getMethodParameter().getParameterName();
+            result.getResolvableErrors().forEach(error -> {
+                errors.put(parameterName, error.getDefaultMessage());
+            });
+        });
+
+        BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, errors));
     }
 
 }

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -98,6 +98,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
+                .headers(headers)
                 .body(ApiResponse.onFailure(errorCode, errors));
     }
 
@@ -109,6 +110,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
+                .headers(headers)
                 .body(ApiResponse.onFailure(errorCode, "요청 Body 형식이 잘못되었습니다."));
     }
 
@@ -120,6 +122,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
+                .headers(headers)
                 .body(ApiResponse.onFailure(errorCode, null));
     }
 
@@ -131,6 +134,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
         BaseErrorCode errorCode = GeneralErrorCode.UNSUPPORTED_MEDIA_TYPE;
         return ResponseEntity.status(errorCode.getStatus())
+                .headers(headers)
                 .body(ApiResponse.onFailure(errorCode, null));
     }
 
@@ -142,6 +146,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
         BaseErrorCode errorCode = GeneralErrorCode.METHOD_NOT_ALLOWED;
         return ResponseEntity.status(errorCode.getStatus())
+                .headers(headers)
                 .body(ApiResponse.onFailure(errorCode, null));
     }
 
@@ -157,6 +162,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
+                .headers(headers)
                 .body(ApiResponse.onFailure(errorCode, null));
     }
 
@@ -168,6 +174,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
         BaseErrorCode errorCode = GeneralErrorCode.NOT_FOUND;
         return ResponseEntity.status(errorCode.getStatus())
+                .headers(headers)
                 .body(ApiResponse.onFailure(errorCode, null));
     }
 
@@ -186,6 +193,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
+                .headers(headers)
                 .body(ApiResponse.onFailure(errorCode, errors));
     }
 

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -171,7 +171,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
                 .body(ApiResponse.onFailure(errorCode, null));
     }
 
-    // Validation 실패
+    // 컨트롤러 파라미터 검증 (클래스 레벨 @Validated 없을 때 스프링 기본 메소드 검증)
     @Override
     protected @Nullable ResponseEntity<Object> handleHandlerMethodValidationException(
             HandlerMethodValidationException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 에러핸들러 내 누락된 예외 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
  - `GeneralExceptionAdvice`: `ResponseEntityExceptionHandler`를 상속받아 스프링 표준 예외를                                        
    오버라이드로 처리하도록 리팩토링, 누락된 예외 핸들러 추가                                                                       
- BindException, MethodArgumentTypeMismatchException, HttpMessageNotReadableException,                                          
      MMissingServletRequestParameterException, HttpRequestMethodNotSupportedException,                                                   NoResourceFoundException, DataIntegrityViolationException, HandlerMethodValidationException                                   
      NoR 실패 응답에 필드별 상세 메시지(result) 포함                                                                              
 - 로그 추가: 4xx는 log.warn, 예상치 못한 500만 log.error
 - `GeneralErrorCode`: METHOD_NOT_ALLOWED(405), CONFLICT(409), UNSUPPORTED_MEDIA_TYPE(415) 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #54
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 405/409/415 등 요청 오류에 대해 공통 오류 코드와 응답 형식이 더 일관되게 제공됩니다.
  * 유효성·제약 위반 시 필드별/항목별 메시지를 모아 상세 오류로 반환하며, 무결성·바인딩·검증·예상치 못한 예외까지 통합 처리됩니다.
  * OpenAPI 문서의 400 응답 예시가 더 구체적으로 갱신되고, 토큰 재발급 입력값 검증 메시지도 상세화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->