### PR TITLE
[refactor] ChapterService 내 중복 isCompletedToday제거

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
@@ -22,7 +22,6 @@ import lombok.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
 
-import java.time.*;
 import java.util.*;
 
 @Service
@@ -61,7 +60,7 @@ public class ChapterService {
 
         // memberStorybook이 있을 경우, 오늘 이미 완료했는지 검증
         memberStorybookOpt.ifPresent(ms -> {
-            if (isCompletedToday(ms)) {
+            if (ms.isCompletedToday()) {
                 throw new ChapterException(ChapterErrorCode.ALREADY_RECEIVED_TODAY);
             }
         });
@@ -98,12 +97,6 @@ public class ChapterService {
                 memberChapter,
                 answers
         );
-    }
-
-    // 오늘 이미 완료했는지 여부 (RecordService에서도 재사용)
-    public boolean isCompletedToday(MemberStorybook memberStorybook) {
-        LocalDate lastCompletedDate = memberStorybook.getLastCompletedDate();
-        return (lastCompletedDate != null) && lastCompletedDate.isEqual(LocalDate.now());
     }
 
     // 아직 열리지 않은 장(CHAPTER403_1) / 이미 완료한 장(CHAPTER403_2)인지 검증 (RecordService에서도 재사용)

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -18,9 +18,9 @@ import com.umc.halo.domain.record.enums.*;
 import com.umc.halo.domain.record.excption.*;
 import com.umc.halo.domain.record.excption.code.*;
 import com.umc.halo.domain.record.repository.*;
-import com.umc.halo.global.ai.event.ChapterCompletedEvent;
+import com.umc.halo.global.ai.event.*;
 import lombok.*;
-import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.*;
 import org.springframework.dao.*;
 import org.springframework.stereotype.*;
 import org.springframework.transaction.annotation.*;
@@ -63,7 +63,7 @@ public class RecordService {
         MemberChapter memberChapter = memberChapterRepository.findByMemberAndStorybookChapter(member, storybookChapter);
 
         // 오늘 이미 장을 완료했는지 검증
-        if (chapterService.isCompletedToday(memberStorybook)) {
+        if (memberStorybook.isCompletedToday()) {
             throw new RecordException(RecordErrorCode.ALREADY_COMPLETED_TODAY);
         }
 


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- ChapterService 내 중복 isCompletedToday제거
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- ChapterService 내 isCompletedToday 제거
- ChapterService, RecordService 에서 사용하던 isCompletedToday를 MemberStorybook의 isCompletedToday로 변경 
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #57
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 챕터 및 기록 작성 시 오늘 완료 여부를 확인하는 흐름을 개선했습니다.
  * 오늘 이미 완료한 챕터를 중복 처리하는 상황을 보다 일관되게 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->