### PR TITLE
[feat] 기념일 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ java {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -45,6 +46,9 @@ dependencies {
 
     // OIDC ID Token
     implementation 'com.nimbusds:nimbus-jose-jwt:9.37.4'
+
+    // Korean Lunar Calendar
+    implementation 'com.github.usingsky:KoreanLunarCalendar:0.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
@@ -1,15 +1,14 @@
 package com.umc.halo.domain.notification.controller;
 
-import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.notification.controller.docs.AnniversaryControllerDocs;
 import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
 import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
 import com.umc.halo.domain.notification.exception.AnniversarySuccessCode;
 import com.umc.halo.domain.notification.service.AnniversaryService;
 import com.umc.halo.global.apiPayload.ApiResponse;
-import com.umc.halo.global.security.CurrentMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,43 +20,43 @@ public class AnniversaryController implements AnniversaryControllerDocs {
 
     @GetMapping
     public ApiResponse<AnniversaryResDTO.GetAnniversaries> getAnniversaries(
-            @CurrentMember Member member
+            @AuthenticationPrincipal Long memberId
     ) {
         return ApiResponse.onSuccess(
                 AnniversarySuccessCode.ANNIVERSARY_LIST_SUCCESS,
-                anniversaryService.getAnniversaries(member)
+                anniversaryService.getAnniversaries(memberId)
         );
     }
 
     @PostMapping
     public ApiResponse<AnniversaryResDTO.CreateAnniversary> createAnniversary(
-            @CurrentMember Member member,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody AnniversaryReqDTO.Create request
     ) {
         return ApiResponse.onSuccess(
                 AnniversarySuccessCode.ANNIVERSARY_CREATE_SUCCESS,
-                anniversaryService.createAnniversary(member, request)
+                anniversaryService.createAnniversary(memberId, request)
         );
     }
 
     @PatchMapping("/{anniversaryId}")
     public ApiResponse<AnniversaryResDTO.UpdateAnniversary> updateAnniversary(
-            @CurrentMember Member member,
+            @AuthenticationPrincipal Long memberId,
             @PathVariable Long anniversaryId,
             @Valid @RequestBody AnniversaryReqDTO.Update request
     ) {
         return ApiResponse.onSuccess(
                 AnniversarySuccessCode.ANNIVERSARY_UPDATE_SUCCESS,
-                anniversaryService.updateAnniversary(member, anniversaryId, request)
+                anniversaryService.updateAnniversary(memberId, anniversaryId, request)
         );
     }
 
     @DeleteMapping
     public ApiResponse<Void> deleteAnniversaries(
-            @CurrentMember Member member,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody AnniversaryReqDTO.Delete request
     ) {
-        anniversaryService.deleteAnniversaries(member, request.anniversaryIds());
+        anniversaryService.deleteAnniversaries(memberId, request.anniversaryIds());
         return ApiResponse.onSuccess(AnniversarySuccessCode.ANNIVERSARY_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
@@ -1,0 +1,63 @@
+package com.umc.halo.domain.notification.controller;
+
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.notification.controller.docs.AnniversaryControllerDocs;
+import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
+import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
+import com.umc.halo.domain.notification.exception.AnniversarySuccessCode;
+import com.umc.halo.domain.notification.service.AnniversaryService;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.security.CurrentMember;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/anniversary")
+@RequiredArgsConstructor
+public class AnniversaryController implements AnniversaryControllerDocs {
+
+    private final AnniversaryService anniversaryService;
+
+    @GetMapping
+    public ApiResponse<AnniversaryResDTO.GetAnniversaries> getAnniversaries(
+            @CurrentMember Member member
+    ) {
+        return ApiResponse.onSuccess(
+                AnniversarySuccessCode.ANNIVERSARY_LIST_SUCCESS,
+                anniversaryService.getAnniversaries(member)
+        );
+    }
+
+    @PostMapping
+    public ApiResponse<AnniversaryResDTO.CreateAnniversary> createAnniversary(
+            @CurrentMember Member member,
+            @Valid @RequestBody AnniversaryReqDTO.Create request
+    ) {
+        return ApiResponse.onSuccess(
+                AnniversarySuccessCode.ANNIVERSARY_CREATE_SUCCESS,
+                anniversaryService.createAnniversary(member, request)
+        );
+    }
+
+    @PatchMapping("/{anniversaryId}")
+    public ApiResponse<AnniversaryResDTO.UpdateAnniversary> updateAnniversary(
+            @CurrentMember Member member,
+            @PathVariable Long anniversaryId,
+            @Valid @RequestBody AnniversaryReqDTO.Update request
+    ) {
+        return ApiResponse.onSuccess(
+                AnniversarySuccessCode.ANNIVERSARY_UPDATE_SUCCESS,
+                anniversaryService.updateAnniversary(member, anniversaryId, request)
+        );
+    }
+
+    @DeleteMapping
+    public ApiResponse<Void> deleteAnniversaries(
+            @CurrentMember Member member,
+            @Valid @RequestBody AnniversaryReqDTO.Delete request
+    ) {
+        anniversaryService.deleteAnniversaries(member, request.anniversaryIds());
+        return ApiResponse.onSuccess(AnniversarySuccessCode.ANNIVERSARY_DELETE_SUCCESS);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -1,13 +1,12 @@
 package com.umc.halo.domain.notification.controller.docs;
 
-import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
 import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
 import com.umc.halo.global.apiPayload.ApiResponse;
-import com.umc.halo.global.security.CurrentMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -29,7 +28,7 @@ public interface AnniversaryControllerDocs {
                     4. 다가오는 기념일(upcomingAnniversaries), 내가 추가한 기념일(myAnniversaries), 기본 기념일(commonAnniversaries) 세 목록을 함께 반환합니다.
                     """)
     ApiResponse<AnniversaryResDTO.GetAnniversaries> getAnniversaries(
-            @CurrentMember Member member
+            @AuthenticationPrincipal Long memberId
     );
 
     @Operation(summary = "기념일 추가 API",
@@ -54,7 +53,7 @@ public interface AnniversaryControllerDocs {
                     3. 요청 값을 기반으로 기념일을 저장하고, 생성된 기념일의 ID를 반환합니다.
                     """)
     ApiResponse<AnniversaryResDTO.CreateAnniversary> createAnniversary(
-            @CurrentMember Member member,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody AnniversaryReqDTO.Create request
     );
 
@@ -81,7 +80,7 @@ public interface AnniversaryControllerDocs {
                     3. 검증을 통과하면 요청 값으로 기념일 정보를 갱신합니다.
                     """)
     ApiResponse<AnniversaryResDTO.UpdateAnniversary> updateAnniversary(
-            @CurrentMember Member member,
+            @AuthenticationPrincipal Long memberId,
             @PathVariable Long anniversaryId,
             @Valid @RequestBody AnniversaryReqDTO.Update request
     );
@@ -104,7 +103,7 @@ public interface AnniversaryControllerDocs {
                     3. 검증을 통과하면 요청한 기념일을 모두 삭제합니다. (부분 삭제는 지원하지 않으며, 검증 실패 시 전체가 실패합니다.)
                     """)
     ApiResponse<Void> deleteAnniversaries(
-            @CurrentMember Member member,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody AnniversaryReqDTO.Delete request
     );
 }

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -4,6 +4,10 @@ import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
 import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,21 +41,52 @@ public interface AnniversaryControllerDocs {
                     사용자가 새로운 기념일을 등록합니다.
 
                     **요청 형식**
-                    ```json
-                    {
-                      "title": "엄마랑 여행 가는 날",
-                      "anniversaryDate": "2026-06-27",
-                      "sevenDaysAlarmEnabled": true,
-                      "dayAlarmEnabled": true,
-                      "memo": "어머니랑 여행을 가기로 한 날, 처음으로 여행을 가기로 해서 너무 떨린다."
-                    }
-                    ```
+                    - title: 기념일명 (필수, 20자 이하)
+                    - anniversaryDate: 날짜 (필수)
+                    - sevenDaysAlarmEnabled: D-7 알림 여부 (필수)
+                    - dayAlarmEnabled: 당일 알림 여부 (필수)
+                    - memo: 메모 (선택, 255자 이하)
 
                     **동작 방식**
                     1. 기념일명, 날짜, 알림 설정을 필수로 입력받습니다.
                     2. 메모는 선택 입력이며 255자 이하로 제한됩니다.
                     3. 요청 값을 기반으로 기념일을 저장하고, 생성된 기념일의 ID를 반환합니다.
                     """)
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "201",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "ANNIVERSARY201_1",
+                                      "message": "기념일이 성공적으로 생성되었습니다.",
+                                      "result": {
+                                        "anniversaryId": 5
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
     ApiResponse<AnniversaryResDTO.CreateAnniversary> createAnniversary(
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody AnniversaryReqDTO.Create request
@@ -63,22 +98,68 @@ public interface AnniversaryControllerDocs {
                     사용자가 등록한 기념일 정보를 수정합니다.
 
                     **요청 형식**
-                    - Path Variable: `anniversaryId` (수정할 기념일 ID)
-                    ```json
-                    {
-                      "title": "엄마랑 여행 가는 날",
-                      "anniversaryDate": "2026-06-27",
-                      "sevenDaysAlarmEnabled": true,
-                      "dayAlarmEnabled": true,
-                      "memo": "어머니랑 여행을 가기로 한 날, 처음으로 여행을 가기로 해서 너무 떨린다."
-                    }
-                    ```
+                    - Path Variable: anniversaryId (수정할 기념일 ID)
+                    - title: 기념일명 (필수, 20자 이하)
+                    - anniversaryDate: 날짜 (필수)
+                    - sevenDaysAlarmEnabled: D-7 알림 여부 (필수)
+                    - dayAlarmEnabled: 당일 알림 여부 (필수)
+                    - memo: 메모 (선택, 255자 이하)
 
                     **동작 방식**
                     1. 요청한 기념일이 존재하는지 확인하고, 존재하지 않으면 404 예외를 반환합니다.
                     2. 해당 기념일이 로그인한 회원 소유인지 확인하고, 본인 소유가 아니면 403 예외를 반환합니다.
                     3. 검증을 통과하면 요청 값으로 기념일 정보를 갱신합니다.
                     """)
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "ANNIVERSARY200_2",
+                                      "message": "기념일이 성공적으로 수정되었습니다.",
+                                      "result": {
+                                        "anniversaryId": 5
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 기념일",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANNIVERSARY404_1",
+                                      "message": "존재하지 않는 일정입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "본인 소유가 아닌 기념일",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANNIVERSARY403_1",
+                                      "message": "해당 기념일에 대한 권한이 없습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
     ApiResponse<AnniversaryResDTO.UpdateAnniversary> updateAnniversary(
             @AuthenticationPrincipal Long memberId,
             @PathVariable Long anniversaryId,
@@ -91,17 +172,61 @@ public interface AnniversaryControllerDocs {
                     사용자가 등록한 기념일을 하나 이상 선택하여 한 번에 삭제합니다.
 
                     **요청 형식**
-                    ```json
-                    {
-                      "anniversaryIds": [1, 2, 5]
-                    }
-                    ```
+                    - anniversaryIds: 삭제할 기념일 ID 목록 (필수, 예: [1, 2, 5])
 
                     **동작 방식**
                     1. 요청한 ID 목록이 모두 존재하는지 확인하고, 하나라도 존재하지 않으면 404 예외를 반환합니다.
                     2. 요청한 ID가 모두 로그인한 회원 소유인지 확인하고, 하나라도 본인 소유가 아니면 403 예외를 반환합니다.
                     3. 검증을 통과하면 요청한 기념일을 모두 삭제합니다. (부분 삭제는 지원하지 않으며, 검증 실패 시 전체가 실패합니다.)
                     """)
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": true,
+                                      "code": "ANNIVERSARY200_3",
+                                      "message": "기념일이 성공적으로 삭제되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 기념일 포함",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANNIVERSARY404_1",
+                                      "message": "존재하지 않는 일정입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "본인 소유가 아닌 기념일 포함",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "ANNIVERSARY403_1",
+                                      "message": "해당 기념일에 대한 권한이 없습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
     ApiResponse<Void> deleteAnniversaries(
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody AnniversaryReqDTO.Delete request

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -37,7 +37,7 @@ public interface AnniversaryControllerDocs {
                     사용자가 새로운 기념일을 등록합니다.
 
                     **요청 형식**
-```json
+                    ```json
                     {
                       "title": "엄마랑 여행 가는 날",
                       "anniversaryDate": "2026-06-27",
@@ -45,7 +45,7 @@ public interface AnniversaryControllerDocs {
                       "dayAlarmEnabled": true,
                       "memo": "어머니랑 여행을 가기로 한 날, 처음으로 여행을 가기로 해서 너무 떨린다."
                     }
-```
+                    ```
 
                     **동작 방식**
                     1. 기념일명, 날짜, 알림 설정을 필수로 입력받습니다.
@@ -64,7 +64,7 @@ public interface AnniversaryControllerDocs {
 
                     **요청 형식**
                     - Path Variable: `anniversaryId` (수정할 기념일 ID)
-```json
+                    ```json
                     {
                       "title": "엄마랑 여행 가는 날",
                       "anniversaryDate": "2026-06-27",
@@ -72,7 +72,7 @@ public interface AnniversaryControllerDocs {
                       "dayAlarmEnabled": true,
                       "memo": "어머니랑 여행을 가기로 한 날, 처음으로 여행을 가기로 해서 너무 떨린다."
                     }
-```
+                    ```
 
                     **동작 방식**
                     1. 요청한 기념일이 존재하는지 확인하고, 존재하지 않으면 404 예외를 반환합니다.
@@ -91,11 +91,11 @@ public interface AnniversaryControllerDocs {
                     사용자가 등록한 기념일을 하나 이상 선택하여 한 번에 삭제합니다.
 
                     **요청 형식**
-```json
+                    ```json
                     {
                       "anniversaryIds": [1, 2, 5]
                     }
-```
+                    ```
 
                     **동작 방식**
                     1. 요청한 ID 목록이 모두 존재하는지 확인하고, 하나라도 존재하지 않으면 404 예외를 반환합니다.

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -1,0 +1,110 @@
+package com.umc.halo.domain.notification.controller.docs;
+
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
+import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.security.CurrentMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "기념일 API")
+public interface AnniversaryControllerDocs {
+
+    @Operation(summary = "기념일 목록 조회 API",
+            description = """
+                    ### 기념일 목록 조회
+                    마이페이지 내 기념일 관리 화면에서 사용자의 기념일 정보를 조회합니다.
+
+                    **요청 형식**
+                    - 별도의 요청 파라미터 없이 인증 토큰만으로 조회합니다.
+
+                    **동작 방식**
+                    1. 로그인한 회원이 등록한 기념일 목록을 조회합니다.
+                    2. 반복 여부(isRepeated)와 음력이 아닌 기본 기념일을 기준으로 다가오는 기념일의 D-day를 계산합니다.
+                    3. 음력 기반 기본 기념일(추석, 설날 등)은 연도별 환산 로직이 없어 D-day 계산 대상에서 제외되며, 기본 기념일 목록에는 그대로 노출됩니다.
+                    4. 다가오는 기념일(upcomingAnniversaries), 내가 추가한 기념일(myAnniversaries), 기본 기념일(commonAnniversaries) 세 목록을 함께 반환합니다.
+                    """)
+    ApiResponse<AnniversaryResDTO.GetAnniversaries> getAnniversaries(
+            @CurrentMember Member member
+    );
+
+    @Operation(summary = "기념일 추가 API",
+            description = """
+                    ### 기념일 추가
+                    사용자가 새로운 기념일을 등록합니다.
+
+                    **요청 형식**
+```json
+                    {
+                      "title": "엄마랑 여행 가는 날",
+                      "anniversaryDate": "2026-06-27",
+                      "sevenDaysAlarmEnabled": true,
+                      "dayAlarmEnabled": true,
+                      "memo": "어머니랑 여행을 가기로 한 날, 처음으로 여행을 가기로 해서 너무 떨린다."
+                    }
+```
+
+                    **동작 방식**
+                    1. 기념일명, 날짜, 알림 설정을 필수로 입력받습니다.
+                    2. 메모는 선택 입력이며 255자 이하로 제한됩니다.
+                    3. 요청 값을 기반으로 기념일을 저장하고, 생성된 기념일의 ID를 반환합니다.
+                    """)
+    ApiResponse<AnniversaryResDTO.CreateAnniversary> createAnniversary(
+            @CurrentMember Member member,
+            @Valid @RequestBody AnniversaryReqDTO.Create request
+    );
+
+    @Operation(summary = "기념일 수정 API",
+            description = """
+                    ### 기념일 수정
+                    사용자가 등록한 기념일 정보를 수정합니다.
+
+                    **요청 형식**
+                    - Path Variable: `anniversaryId` (수정할 기념일 ID)
+```json
+                    {
+                      "title": "엄마랑 여행 가는 날",
+                      "anniversaryDate": "2026-06-27",
+                      "sevenDaysAlarmEnabled": true,
+                      "dayAlarmEnabled": true,
+                      "memo": "어머니랑 여행을 가기로 한 날, 처음으로 여행을 가기로 해서 너무 떨린다."
+                    }
+```
+
+                    **동작 방식**
+                    1. 요청한 기념일이 존재하는지 확인하고, 존재하지 않으면 404 예외를 반환합니다.
+                    2. 해당 기념일이 로그인한 회원 소유인지 확인하고, 본인 소유가 아니면 403 예외를 반환합니다.
+                    3. 검증을 통과하면 요청 값으로 기념일 정보를 갱신합니다.
+                    """)
+    ApiResponse<AnniversaryResDTO.UpdateAnniversary> updateAnniversary(
+            @CurrentMember Member member,
+            @PathVariable Long anniversaryId,
+            @Valid @RequestBody AnniversaryReqDTO.Update request
+    );
+
+    @Operation(summary = "기념일 삭제 API",
+            description = """
+                    ### 기념일 삭제
+                    사용자가 등록한 기념일을 하나 이상 선택하여 한 번에 삭제합니다.
+
+                    **요청 형식**
+```json
+                    {
+                      "anniversaryIds": [1, 2, 5]
+                    }
+```
+
+                    **동작 방식**
+                    1. 요청한 ID 목록이 모두 존재하는지 확인하고, 하나라도 존재하지 않으면 404 예외를 반환합니다.
+                    2. 요청한 ID가 모두 로그인한 회원 소유인지 확인하고, 하나라도 본인 소유가 아니면 403 예외를 반환합니다.
+                    3. 검증을 통과하면 요청한 기념일을 모두 삭제합니다. (부분 삭제는 지원하지 않으며, 검증 실패 시 전체가 실패합니다.)
+                    """)
+    ApiResponse<Void> deleteAnniversaries(
+            @CurrentMember Member member,
+            @Valid @RequestBody AnniversaryReqDTO.Delete request
+    );
+}

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -23,8 +23,8 @@ public interface AnniversaryControllerDocs {
 
                     **동작 방식**
                     1. 로그인한 회원이 등록한 기념일 목록을 조회합니다.
-                    2. 반복 여부(isRepeated)와 음력이 아닌 기본 기념일을 기준으로 다가오는 기념일의 D-day를 계산합니다.
-                    3. 음력 기반 기본 기념일(추석, 설날 등)은 연도별 환산 로직이 없어 D-day 계산 대상에서 제외되며, 기본 기념일 목록에는 그대로 노출됩니다.
+                    2. 반복 여부(isRepeated)를 기준으로 다가오는 기념일의 D-day를 계산합니다.
+                    3. 음력 기반 기본 기념일(추석, 설날 등)은 KASI(한국천문연구원) 표준 기반 음력-양력 변환 라이브러리로 실제 양력 날짜를 계산하여 D-day에 반영합니다.
                     4. 다가오는 기념일(upcomingAnniversaries), 내가 추가한 기념일(myAnniversaries), 기본 기념일(commonAnniversaries) 세 목록을 함께 반환합니다.
                     """)
     ApiResponse<AnniversaryResDTO.GetAnniversaries> getAnniversaries(

--- a/src/main/java/com/umc/halo/domain/notification/converter/AnniversaryConverter.java
+++ b/src/main/java/com/umc/halo/domain/notification/converter/AnniversaryConverter.java
@@ -37,6 +37,15 @@ public class AnniversaryConverter {
                 .build();
     }
 
+    public static AnniversaryResDTO.Upcoming toUpcomingFromCommon(CommonAnniversary commonAnniversary, LocalDate nextOccurrence, LocalDate today) {
+        return AnniversaryResDTO.Upcoming.builder()
+                .anniversaryId(null)
+                .title(commonAnniversary.getTitle())
+                .anniversaryDate(nextOccurrence)
+                .dDay((int) ChronoUnit.DAYS.between(today, nextOccurrence))
+                .build();
+    }
+
     public static AnniversaryResDTO.MyAnniversary toMyAnniversary(Anniversary anniversary) {
         return AnniversaryResDTO.MyAnniversary.builder()
                 .anniversaryId(anniversary.getId())

--- a/src/main/java/com/umc/halo/domain/notification/converter/AnniversaryConverter.java
+++ b/src/main/java/com/umc/halo/domain/notification/converter/AnniversaryConverter.java
@@ -1,0 +1,86 @@
+package com.umc.halo.domain.notification.converter;
+
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
+import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
+import com.umc.halo.domain.notification.entity.Anniversary;
+import com.umc.halo.domain.notification.entity.CommonAnniversary;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+public class AnniversaryConverter {
+
+    private AnniversaryConverter() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static AnniversaryResDTO.GetAnniversaries toGetAnniversaries(
+            List<AnniversaryResDTO.Upcoming> upcomingAnniversaries,
+            List<AnniversaryResDTO.MyAnniversary> myAnniversaries,
+            List<AnniversaryResDTO.CommonAnniversaryInfo> commonAnniversaries
+    ) {
+        return AnniversaryResDTO.GetAnniversaries.builder()
+                .upcomingAnniversaries(upcomingAnniversaries)
+                .myAnniversaries(myAnniversaries)
+                .commonAnniversaries(commonAnniversaries)
+                .build();
+    }
+
+    public static AnniversaryResDTO.Upcoming toUpcoming(Anniversary anniversary, LocalDate nextOccurrence, LocalDate today) {
+        return AnniversaryResDTO.Upcoming.builder()
+                .anniversaryId(anniversary.getId())
+                .title(anniversary.getTitle())
+                .anniversaryDate(nextOccurrence)
+                .dDay((int) ChronoUnit.DAYS.between(today, nextOccurrence))
+                .build();
+    }
+
+    public static AnniversaryResDTO.MyAnniversary toMyAnniversary(Anniversary anniversary) {
+        return AnniversaryResDTO.MyAnniversary.builder()
+                .anniversaryId(anniversary.getId())
+                .title(anniversary.getTitle())
+                .anniversaryDate(anniversary.getAnniversaryDate())
+                .isRepeated(anniversary.getIsRepeated())
+                .sevenDaysAlarmEnabled(anniversary.getSevenDaysAlarmEnabled())
+                .dayAlarmEnabled(anniversary.getDayAlarmEnabled())
+                .memo(anniversary.getMemo())
+                .build();
+    }
+
+    public static AnniversaryResDTO.CommonAnniversaryInfo toCommonAnniversaryInfo(CommonAnniversary commonAnniversary) {
+        return AnniversaryResDTO.CommonAnniversaryInfo.builder()
+                .commonAnniversaryId(commonAnniversary.getId())
+                .title(commonAnniversary.getTitle())
+                .month(commonAnniversary.getMonth())
+                .day(commonAnniversary.getDay())
+                .isLunar(commonAnniversary.getIsLunar())
+                .sevenDaysAlarmEnabled(commonAnniversary.getSevenDaysAlarmEnabled())
+                .dayAlarmEnabled(commonAnniversary.getDayAlarmEnabled())
+                .build();
+    }
+
+    public static Anniversary toAnniversary(Member member, AnniversaryReqDTO.Create request) {
+        return Anniversary.builder()
+                .member(member)
+                .title(request.title())
+                .anniversaryDate(request.anniversaryDate())
+                .sevenDaysAlarmEnabled(request.sevenDaysAlarmEnabled())
+                .dayAlarmEnabled(request.dayAlarmEnabled())
+                .memo(request.memo())
+                .build();
+    }
+
+    public static AnniversaryResDTO.CreateAnniversary toCreateAnniversary(Anniversary anniversary) {
+        return AnniversaryResDTO.CreateAnniversary.builder()
+                .anniversaryId(anniversary.getId())
+                .build();
+    }
+
+    public static AnniversaryResDTO.UpdateAnniversary toUpdateAnniversary(Anniversary anniversary) {
+        return AnniversaryResDTO.UpdateAnniversary.builder()
+                .anniversaryId(anniversary.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryReqDTO.java
@@ -1,0 +1,53 @@
+package com.umc.halo.domain.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class AnniversaryReqDTO {
+
+    public record Create(
+            @NotBlank(message = "기념일명은 필수입니다.")
+            @Size(max = 20, message = "기념일명은 20자 이하로 입력해주세요.")
+            String title,
+
+            @NotNull(message = "날짜는 필수입니다.")
+            LocalDate anniversaryDate,
+
+            @NotNull(message = "D-7 알림 여부는 필수입니다.")
+            Boolean sevenDaysAlarmEnabled,
+
+            @NotNull(message = "당일 알림 여부는 필수입니다.")
+            Boolean dayAlarmEnabled,
+
+            @Size(max = 255, message = "메모는 255자 이하로 입력해주세요.")
+            String memo
+    ) {}
+
+    public record Update(
+            @NotBlank(message = "기념일명은 필수입니다.")
+            @Size(max = 20, message = "기념일명은 20자 이하로 입력해주세요.")
+            String title,
+
+            @NotNull(message = "날짜는 필수입니다.")
+            LocalDate anniversaryDate,
+
+            @NotNull(message = "D-7 알림 여부는 필수입니다.")
+            Boolean sevenDaysAlarmEnabled,
+
+            @NotNull(message = "당일 알림 여부는 필수입니다.")
+            Boolean dayAlarmEnabled,
+
+            @Size(max = 255, message = "메모는 255자 이하로 입력해주세요.")
+            String memo
+    ) {}
+
+    public record Delete(
+            @NotEmpty(message = "삭제할 기념일 ID 목록은 필수입니다.")
+            List<Long> anniversaryIds
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryResDTO.java
+++ b/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryResDTO.java
@@ -1,0 +1,60 @@
+package com.umc.halo.domain.notification.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class AnniversaryResDTO {
+
+    private AnniversaryResDTO() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    @Builder
+    public record GetAnniversaries(
+            List<Upcoming> upcomingAnniversaries,
+            List<MyAnniversary> myAnniversaries,
+            List<CommonAnniversaryInfo> commonAnniversaries
+    ) {}
+
+    @Builder
+    public record Upcoming(
+            Long anniversaryId,
+            String title,
+            LocalDate anniversaryDate,
+            Integer dDay
+    ) {}
+
+    @Builder
+    public record MyAnniversary(
+            Long anniversaryId,
+            String title,
+            LocalDate anniversaryDate,
+            Boolean isRepeated,
+            Boolean sevenDaysAlarmEnabled,
+            Boolean dayAlarmEnabled,
+            String memo
+    ) {}
+
+    @Builder
+    public record CommonAnniversaryInfo(
+            Long commonAnniversaryId,
+            String title,
+            Integer month,
+            Integer day,
+            Boolean isLunar,
+            Boolean sevenDaysAlarmEnabled,
+            Boolean dayAlarmEnabled
+    ) {}
+
+    @Builder
+    public record CreateAnniversary(
+            Long anniversaryId
+    ) {}
+
+    @Builder
+    public record UpdateAnniversary(
+            Long anniversaryId
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
@@ -1,7 +1,6 @@
 package com.umc.halo.domain.notification.entity;
 
 import com.umc.halo.domain.member.entity.*;
-import com.umc.halo.domain.notification.enums.*;
 import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
@@ -31,10 +30,6 @@ public class Anniversary extends BaseEntity {
     @Column(name = "anniversary_date", nullable = false)
     private LocalDate anniversaryDate;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Target target;
-
     @Column(name = "is_repeated", nullable = false)
     @Builder.Default
     private Boolean isRepeated = true;
@@ -49,4 +44,13 @@ public class Anniversary extends BaseEntity {
 
     @Column(length = 255)
     private String memo;
+
+    public void update(String title, LocalDate anniversaryDate, Boolean sevenDaysAlarmEnabled,
+                        Boolean dayAlarmEnabled, String memo) {
+        this.title = title;
+        this.anniversaryDate = anniversaryDate;
+        this.sevenDaysAlarmEnabled = sevenDaysAlarmEnabled;
+        this.dayAlarmEnabled = dayAlarmEnabled;
+        this.memo = memo;
+    }
 }

--- a/src/main/java/com/umc/halo/domain/notification/enums/Target.java
+++ b/src/main/java/com/umc/halo/domain/notification/enums/Target.java
@@ -1,7 +1,0 @@
-package com.umc.halo.domain.notification.enums;
-
-public enum Target {
-    MOTHER, // 어머니
-    FATHER, // 아버지
-    FAMILY  // 부모님
-}

--- a/src/main/java/com/umc/halo/domain/notification/exception/AnniversaryErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/AnniversaryErrorCode.java
@@ -1,0 +1,18 @@
+package com.umc.halo.domain.notification.exception;
+
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AnniversaryErrorCode implements BaseErrorCode {
+
+    ANNIVERSARY_NOT_FOUND(HttpStatus.NOT_FOUND, "ANNIVERSARY404_1", "존재하지 않는 일정입니다."),
+    ANNIVERSARY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ANNIVERSARY403_1", "해당 기념일에 대한 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/notification/exception/AnniversaryException.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/AnniversaryException.java
@@ -1,0 +1,10 @@
+package com.umc.halo.domain.notification.exception;
+
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+
+public class AnniversaryException extends ProjectException {
+
+    public AnniversaryException(AnniversaryErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/notification/exception/AnniversarySuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/AnniversarySuccessCode.java
@@ -12,7 +12,7 @@ public enum AnniversarySuccessCode implements BaseSuccessCode {
     ANNIVERSARY_LIST_SUCCESS(HttpStatus.OK, "ANNIVERSARY200_1", "기념일 목록 조회에 성공했습니다."),
     ANNIVERSARY_CREATE_SUCCESS(HttpStatus.CREATED, "ANNIVERSARY201_1", "기념일이 성공적으로 생성되었습니다."),
     ANNIVERSARY_UPDATE_SUCCESS(HttpStatus.OK, "ANNIVERSARY200_2", "기념일이 성공적으로 수정되었습니다."),
-    ANNIVERSARY_DELETE_SUCCESS(HttpStatus.OK, "ANNIVERSARY200_3", "일정이 성공적으로 삭제되었습니다.");
+    ANNIVERSARY_DELETE_SUCCESS(HttpStatus.OK, "ANNIVERSARY200_3", "기념일이 성공적으로 삭제되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/halo/domain/notification/exception/AnniversarySuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/AnniversarySuccessCode.java
@@ -1,0 +1,20 @@
+package com.umc.halo.domain.notification.exception;
+
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AnniversarySuccessCode implements BaseSuccessCode {
+
+    ANNIVERSARY_LIST_SUCCESS(HttpStatus.OK, "ANNIVERSARY200_1", "기념일 목록 조회에 성공했습니다."),
+    ANNIVERSARY_CREATE_SUCCESS(HttpStatus.CREATED, "ANNIVERSARY201_1", "기념일이 성공적으로 생성되었습니다."),
+    ANNIVERSARY_UPDATE_SUCCESS(HttpStatus.OK, "ANNIVERSARY200_2", "기념일이 성공적으로 수정되었습니다."),
+    ANNIVERSARY_DELETE_SUCCESS(HttpStatus.OK, "ANNIVERSARY200_3", "일정이 성공적으로 삭제되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/notification/repository/AnniversaryRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/AnniversaryRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface AnniversaryRepository extends JpaRepository<Anniversary, Long> {
 
     List<Anniversary> findAllByMemberOrderByAnniversaryDateAsc(Member member);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/AnniversaryRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/AnniversaryRepository.java
@@ -1,10 +1,12 @@
 package com.umc.halo.domain.notification.repository;
 
-import com.umc.halo.domain.notification.entity.*;
-import org.springframework.data.jpa.repository.*;
-import org.springframework.stereotype.*;
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.notification.entity.Anniversary;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@Repository
+import java.util.List;
+
 public interface AnniversaryRepository extends JpaRepository<Anniversary, Long> {
-    void deleteByMemberId(Long memberId);
+
+    List<Anniversary> findAllByMemberOrderByAnniversaryDateAsc(Member member);
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/CommonAnniversaryRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/CommonAnniversaryRepository.java
@@ -1,9 +1,7 @@
 package com.umc.halo.domain.notification.repository;
 
-import com.umc.halo.domain.notification.entity.*;
-import org.springframework.data.jpa.repository.*;
-import org.springframework.stereotype.*;
+import com.umc.halo.domain.notification.entity.CommonAnniversary;
+import org.springframework.data.jpa.repository.JpaRepository;
 
-@Repository
 public interface CommonAnniversaryRepository extends JpaRepository<CommonAnniversary, Long> {
 }

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -1,6 +1,9 @@
 package com.umc.halo.domain.notification.service;
 
 import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.member.exception.MemberException;
+import com.umc.halo.domain.member.exception.code.MemberErrorCode;
+import com.umc.halo.domain.member.repository.MemberRepository;
 import com.umc.halo.domain.notification.converter.AnniversaryConverter;
 import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
 import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
@@ -15,11 +18,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -27,9 +27,13 @@ public class AnniversaryService {
 
     private final AnniversaryRepository anniversaryRepository;
     private final CommonAnniversaryRepository commonAnniversaryRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public AnniversaryResDTO.GetAnniversaries getAnniversaries(Member member) {
+    public AnniversaryResDTO.GetAnniversaries getAnniversaries(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
         LocalDate today = LocalDate.now();
 
         List<Anniversary> myAnniversaryEntities = anniversaryRepository.findAllByMemberOrderByAnniversaryDateAsc(member);
@@ -62,7 +66,7 @@ public class AnniversaryService {
                     }
                     return AnniversaryConverter.toUpcoming(anniversary, nextOccurrence, today);
                 })
-                .filter(Objects::nonNull)
+                .filter(java.util.Objects::nonNull)
                 .toList();
 
         // 음력 기념일(추석, 설날 등)은 연도별 환산 로직이 없어 이번 PR에서는 다가오는 기념일 D-day 계산 대상에서 제외
@@ -75,12 +79,12 @@ public class AnniversaryService {
                             .anniversaryId(null)
                             .title(commonAnniversary.getTitle())
                             .anniversaryDate(nextOccurrence)
-                            .dDay((int) ChronoUnit.DAYS.between(today, nextOccurrence))
+                            .dDay((int) java.time.temporal.ChronoUnit.DAYS.between(today, nextOccurrence))
                             .build();
                 })
                 .toList();
 
-        return Stream.concat(upcomingFromMyAnniversaries.stream(), upcomingFromCommonAnniversaries.stream())
+        return java.util.stream.Stream.concat(upcomingFromMyAnniversaries.stream(), upcomingFromCommonAnniversaries.stream())
                 .sorted(Comparator.comparing(AnniversaryResDTO.Upcoming::dDay))
                 .toList();
     }
@@ -100,15 +104,21 @@ public class AnniversaryService {
     }
 
     @Transactional
-    public AnniversaryResDTO.CreateAnniversary createAnniversary(Member member, AnniversaryReqDTO.Create request) {
+    public AnniversaryResDTO.CreateAnniversary createAnniversary(Long memberId, AnniversaryReqDTO.Create request) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
         Anniversary anniversary = AnniversaryConverter.toAnniversary(member, request);
         Anniversary savedAnniversary = anniversaryRepository.save(anniversary);
         return AnniversaryConverter.toCreateAnniversary(savedAnniversary);
     }
 
     @Transactional
-    public AnniversaryResDTO.UpdateAnniversary updateAnniversary(Member member, Long anniversaryId, AnniversaryReqDTO.Update request) {
-        Anniversary anniversary = getOwnedAnniversary(member, anniversaryId);
+    public AnniversaryResDTO.UpdateAnniversary updateAnniversary(Long memberId, Long anniversaryId, AnniversaryReqDTO.Update request) {
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        Anniversary anniversary = getOwnedAnniversary(memberId, anniversaryId);
         anniversary.update(
                 request.title(),
                 request.anniversaryDate(),
@@ -120,7 +130,10 @@ public class AnniversaryService {
     }
 
     @Transactional
-    public void deleteAnniversaries(Member member, List<Long> anniversaryIds) {
+    public void deleteAnniversaries(Long memberId, List<Long> anniversaryIds) {
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
         List<Anniversary> anniversaries = anniversaryRepository.findAllById(anniversaryIds);
 
         if (anniversaries.size() != anniversaryIds.size()) {
@@ -128,7 +141,7 @@ public class AnniversaryService {
         }
 
         boolean hasUnauthorized = anniversaries.stream()
-                .anyMatch(anniversary -> !anniversary.getMember().getId().equals(member.getId()));
+                .anyMatch(anniversary -> !anniversary.getMember().getId().equals(memberId));
         if (hasUnauthorized) {
             throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_ACCESS_DENIED);
         }
@@ -136,10 +149,10 @@ public class AnniversaryService {
         anniversaryRepository.deleteAll(anniversaries);
     }
 
-    private Anniversary getOwnedAnniversary(Member member, Long anniversaryId) {
+    private Anniversary getOwnedAnniversary(Long memberId, Long anniversaryId) {
         Anniversary anniversary = anniversaryRepository.findById(anniversaryId)
                 .orElseThrow(() -> new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_NOT_FOUND));
-        if (!anniversary.getMember().getId().equals(member.getId())) {
+        if (!anniversary.getMember().getId().equals(memberId)) {
             throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_ACCESS_DENIED);
         }
         return anniversary;

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -1,5 +1,6 @@
 package com.umc.halo.domain.notification.service;
 
+import com.github.usingsky.calendar.KoreanLunarCalendar;
 import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.member.exception.MemberException;
 import com.umc.halo.domain.member.exception.code.MemberErrorCode;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -66,15 +68,15 @@ public class AnniversaryService {
                     }
                     return AnniversaryConverter.toUpcoming(anniversary, nextOccurrence, today);
                 })
-                .filter(java.util.Objects::nonNull)
+                .filter(Objects::nonNull)
                 .toList();
 
-        // 음력 기념일(추석, 설날 등)은 연도별 환산 로직이 없어 이번 PR에서는 다가오는 기념일 D-day 계산 대상에서 제외
-        // (기본 기념일 목록에는 그대로 노출됨)
         List<AnniversaryResDTO.Upcoming> upcomingFromCommonAnniversaries = commonAnniversaryEntities.stream()
-                .filter(commonAnniversary -> !Boolean.TRUE.equals(commonAnniversary.getIsLunar()))
                 .map(commonAnniversary -> {
                     LocalDate nextOccurrence = resolveNextOccurrence(commonAnniversary, today);
+                    if (nextOccurrence == null) {
+                        return null;
+                    }
                     return AnniversaryResDTO.Upcoming.builder()
                             .anniversaryId(null)
                             .title(commonAnniversary.getTitle())
@@ -82,6 +84,7 @@ public class AnniversaryService {
                             .dDay((int) java.time.temporal.ChronoUnit.DAYS.between(today, nextOccurrence))
                             .build();
                 })
+                .filter(Objects::nonNull)
                 .toList();
 
         return java.util.stream.Stream.concat(upcomingFromMyAnniversaries.stream(), upcomingFromCommonAnniversaries.stream())
@@ -99,8 +102,29 @@ public class AnniversaryService {
     }
 
     private LocalDate resolveNextOccurrence(CommonAnniversary commonAnniversary, LocalDate today) {
+        if (Boolean.TRUE.equals(commonAnniversary.getIsLunar())) {
+            return resolveNextLunarOccurrence(commonAnniversary, today);
+        }
         LocalDate thisYear = LocalDate.of(today.getYear(), commonAnniversary.getMonth(), commonAnniversary.getDay());
         return thisYear.isBefore(today) ? thisYear.plusYears(1) : thisYear;
+    }
+
+    private LocalDate resolveNextLunarOccurrence(CommonAnniversary commonAnniversary, LocalDate today) {
+        LocalDate thisYearSolar = convertLunarToSolar(today.getYear(), commonAnniversary.getMonth(), commonAnniversary.getDay());
+        if (thisYearSolar != null && !thisYearSolar.isBefore(today)) {
+            return thisYearSolar;
+        }
+        return convertLunarToSolar(today.getYear() + 1, commonAnniversary.getMonth(), commonAnniversary.getDay());
+    }
+
+    // 음력 날짜(윤달 아님)를 해당 연도의 양력 날짜로 변환. 지원 범위를 벗어나거나 변환 실패 시 null 반환
+    private LocalDate convertLunarToSolar(int lunarYear, int lunarMonth, int lunarDay) {
+        KoreanLunarCalendar calendar = KoreanLunarCalendar.getInstance();
+        boolean success = calendar.setLunarDate(lunarYear, lunarMonth, lunarDay, false);
+        if (!success) {
+            return null;
+        }
+        return LocalDate.of(calendar.getSolarYear(), calendar.getSolarMonth(), calendar.getSolarDay());
     }
 
     @Transactional

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -1,0 +1,147 @@
+package com.umc.halo.domain.notification.service;
+
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.notification.converter.AnniversaryConverter;
+import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
+import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
+import com.umc.halo.domain.notification.entity.Anniversary;
+import com.umc.halo.domain.notification.entity.CommonAnniversary;
+import com.umc.halo.domain.notification.exception.AnniversaryErrorCode;
+import com.umc.halo.domain.notification.exception.AnniversaryException;
+import com.umc.halo.domain.notification.repository.AnniversaryRepository;
+import com.umc.halo.domain.notification.repository.CommonAnniversaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class AnniversaryService {
+
+    private final AnniversaryRepository anniversaryRepository;
+    private final CommonAnniversaryRepository commonAnniversaryRepository;
+
+    @Transactional(readOnly = true)
+    public AnniversaryResDTO.GetAnniversaries getAnniversaries(Member member) {
+        LocalDate today = LocalDate.now();
+
+        List<Anniversary> myAnniversaryEntities = anniversaryRepository.findAllByMemberOrderByAnniversaryDateAsc(member);
+        List<CommonAnniversary> commonAnniversaryEntities = commonAnniversaryRepository.findAll();
+
+        List<AnniversaryResDTO.Upcoming> upcomingAnniversaries = buildUpcomingList(
+                myAnniversaryEntities, commonAnniversaryEntities, today);
+
+        List<AnniversaryResDTO.MyAnniversary> myAnniversaries = myAnniversaryEntities.stream()
+                .map(AnniversaryConverter::toMyAnniversary)
+                .toList();
+
+        List<AnniversaryResDTO.CommonAnniversaryInfo> commonAnniversaries = commonAnniversaryEntities.stream()
+                .map(AnniversaryConverter::toCommonAnniversaryInfo)
+                .toList();
+
+        return AnniversaryConverter.toGetAnniversaries(upcomingAnniversaries, myAnniversaries, commonAnniversaries);
+    }
+
+    private List<AnniversaryResDTO.Upcoming> buildUpcomingList(
+            List<Anniversary> myAnniversaryEntities,
+            List<CommonAnniversary> commonAnniversaryEntities,
+            LocalDate today
+    ) {
+        List<AnniversaryResDTO.Upcoming> upcomingFromMyAnniversaries = myAnniversaryEntities.stream()
+                .map(anniversary -> {
+                    LocalDate nextOccurrence = resolveNextOccurrence(anniversary, today);
+                    if (nextOccurrence == null) {
+                        return null;
+                    }
+                    return AnniversaryConverter.toUpcoming(anniversary, nextOccurrence, today);
+                })
+                .filter(Objects::nonNull)
+                .toList();
+
+        // 음력 기념일(추석, 설날 등)은 연도별 환산 로직이 없어 이번 PR에서는 다가오는 기념일 D-day 계산 대상에서 제외
+        // (기본 기념일 목록에는 그대로 노출됨)
+        List<AnniversaryResDTO.Upcoming> upcomingFromCommonAnniversaries = commonAnniversaryEntities.stream()
+                .filter(commonAnniversary -> !Boolean.TRUE.equals(commonAnniversary.getIsLunar()))
+                .map(commonAnniversary -> {
+                    LocalDate nextOccurrence = resolveNextOccurrence(commonAnniversary, today);
+                    return AnniversaryResDTO.Upcoming.builder()
+                            .anniversaryId(null)
+                            .title(commonAnniversary.getTitle())
+                            .anniversaryDate(nextOccurrence)
+                            .dDay((int) ChronoUnit.DAYS.between(today, nextOccurrence))
+                            .build();
+                })
+                .toList();
+
+        return Stream.concat(upcomingFromMyAnniversaries.stream(), upcomingFromCommonAnniversaries.stream())
+                .sorted(Comparator.comparing(AnniversaryResDTO.Upcoming::dDay))
+                .toList();
+    }
+
+    private LocalDate resolveNextOccurrence(Anniversary anniversary, LocalDate today) {
+        if (!Boolean.TRUE.equals(anniversary.getIsRepeated())) {
+            LocalDate date = anniversary.getAnniversaryDate();
+            return date.isBefore(today) ? null : date;
+        }
+        LocalDate thisYear = anniversary.getAnniversaryDate().withYear(today.getYear());
+        return thisYear.isBefore(today) ? thisYear.plusYears(1) : thisYear;
+    }
+
+    private LocalDate resolveNextOccurrence(CommonAnniversary commonAnniversary, LocalDate today) {
+        LocalDate thisYear = LocalDate.of(today.getYear(), commonAnniversary.getMonth(), commonAnniversary.getDay());
+        return thisYear.isBefore(today) ? thisYear.plusYears(1) : thisYear;
+    }
+
+    @Transactional
+    public AnniversaryResDTO.CreateAnniversary createAnniversary(Member member, AnniversaryReqDTO.Create request) {
+        Anniversary anniversary = AnniversaryConverter.toAnniversary(member, request);
+        Anniversary savedAnniversary = anniversaryRepository.save(anniversary);
+        return AnniversaryConverter.toCreateAnniversary(savedAnniversary);
+    }
+
+    @Transactional
+    public AnniversaryResDTO.UpdateAnniversary updateAnniversary(Member member, Long anniversaryId, AnniversaryReqDTO.Update request) {
+        Anniversary anniversary = getOwnedAnniversary(member, anniversaryId);
+        anniversary.update(
+                request.title(),
+                request.anniversaryDate(),
+                request.sevenDaysAlarmEnabled(),
+                request.dayAlarmEnabled(),
+                request.memo()
+        );
+        return AnniversaryConverter.toUpdateAnniversary(anniversary);
+    }
+
+    @Transactional
+    public void deleteAnniversaries(Member member, List<Long> anniversaryIds) {
+        List<Anniversary> anniversaries = anniversaryRepository.findAllById(anniversaryIds);
+
+        if (anniversaries.size() != anniversaryIds.size()) {
+            throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_NOT_FOUND);
+        }
+
+        boolean hasUnauthorized = anniversaries.stream()
+                .anyMatch(anniversary -> !anniversary.getMember().getId().equals(member.getId()));
+        if (hasUnauthorized) {
+            throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_ACCESS_DENIED);
+        }
+
+        anniversaryRepository.deleteAll(anniversaries);
+    }
+
+    private Anniversary getOwnedAnniversary(Member member, Long anniversaryId) {
+        Anniversary anniversary = anniversaryRepository.findById(anniversaryId)
+                .orElseThrow(() -> new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_NOT_FOUND));
+        if (!anniversary.getMember().getId().equals(member.getId())) {
+            throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_ACCESS_DENIED);
+        }
+        return anniversary;
+    }
+}

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -78,12 +78,7 @@ public class AnniversaryService {
                     if (nextOccurrence == null) {
                         return null;
                     }
-                    return AnniversaryResDTO.Upcoming.builder()
-                            .anniversaryId(null)
-                            .title(commonAnniversary.getTitle())
-                            .anniversaryDate(nextOccurrence)
-                            .dDay((int) java.time.temporal.ChronoUnit.DAYS.between(today, nextOccurrence))
-                            .build();
+                    return AnniversaryConverter.toUpcomingFromCommon(commonAnniversary, nextOccurrence, today);
                 })
                 .filter(Objects::nonNull)
                 .toList();

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.MonthDay;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -98,15 +99,16 @@ public class AnniversaryService {
             return date.isBefore(today) ? null : date;
         }
         LocalDate thisYear = anniversary.getAnniversaryDate().withYear(today.getYear());
-        return thisYear.isBefore(today) ? thisYear.plusYears(1) : thisYear;
+        return thisYear.isBefore(today) ? anniversary.getAnniversaryDate().withYear(today.getYear() + 1) : thisYear;
     }
 
     private LocalDate resolveNextOccurrence(CommonAnniversary commonAnniversary, LocalDate today) {
         if (Boolean.TRUE.equals(commonAnniversary.getIsLunar())) {
             return resolveNextLunarOccurrence(commonAnniversary, today);
         }
-        LocalDate thisYear = LocalDate.of(today.getYear(), commonAnniversary.getMonth(), commonAnniversary.getDay());
-        return thisYear.isBefore(today) ? thisYear.plusYears(1) : thisYear;
+        MonthDay monthDay = MonthDay.of(commonAnniversary.getMonth(), commonAnniversary.getDay());
+        LocalDate thisYear = monthDay.atYear(today.getYear());
+        return thisYear.isBefore(today) ? monthDay.atYear(today.getYear() + 1) : thisYear;
     }
 
     private LocalDate resolveNextLunarOccurrence(CommonAnniversary commonAnniversary, LocalDate today) {
@@ -158,9 +160,10 @@ public class AnniversaryService {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
-        List<Anniversary> anniversaries = anniversaryRepository.findAllById(anniversaryIds);
+        List<Long> distinctIds = anniversaryIds.stream().distinct().toList();
+        List<Anniversary> anniversaries = anniversaryRepository.findAllById(distinctIds);
 
-        if (anniversaries.size() != anniversaryIds.size()) {
+        if (anniversaries.size() != distinctIds.size()) {
             throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_NOT_FOUND);
         }
 

--- a/src/main/java/com/umc/halo/global/seed/NotificationSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/NotificationSeeder.java
@@ -62,14 +62,12 @@ public class NotificationSeeder {
                         .member(member.get("김하로"))
                         .title("아버지 생신")
                         .anniversaryDate(LocalDate.of(2026, 9, 12))
-                        .target(Target.FATHER)
                         .memo("아버지 생신! 열심히 준비해야겠다!")
                         .build(),
                 Anniversary.builder()
                         .member(member.get("이온"))
                         .title("어머니 생신")
                         .anniversaryDate(LocalDate.of(2026, 11, 20))
-                        .target(Target.MOTHER)
                         .memo("어머니 생신! 이번에는 더 특별히 준비해야지!")
                         .build()
         );

--- a/src/test/java/com/umc/halo/TokenGenerator.java
+++ b/src/test/java/com/umc/halo/TokenGenerator.java
@@ -1,0 +1,4 @@
+package com.umc.halo;
+
+public class TokenGenerator {
+}


### PR DESCRIPTION
## 📝 작업 내용
이번 PR에서 구현한 내용을 간단히 설명해주세요.

* 기념일 API 구현 (목록 조회, 추가, 수정, 삭제)

---
## 🔧 변경 사항
수정되거나 추가된 주요 파일/기능을 작성해주세요.

* 기념일 목록 조회: GET /api/v1/anniversary
* 기념일 추가: POST /api/v1/anniversary
* 기념일 수정: PATCH /api/v1/anniversary/{anniversaryId}
* 기념일 삭제(벌크): DELETE /api/v1/anniversary
* 관련 DTO / Converter / SuccessCode / ErrorCode 추가
* Anniversary 엔티티에서 대상(target) 필드 제거 (ERD 기준 재현님과 협의 후 확정)
* Swagger 문서 작성

---
## 🧪 테스트 결과
Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)

- 기념일 추가 (POST /anniversary) - 200 성공
<img width="674" height="1061" alt="스크린샷 2026-07-20 오전 12 50 29" src="https://github.com/user-attachments/assets/0c98cc16-fdd7-44c6-b325-9a4c37893141" />

- 기념일 목록 조회 (GET /anniversary) - 200 성공
 > 음력 기반 기념일(추석, 설날) 양력 변환 및 D-day 반영 확인 (2026 추석 → 09/25, 2027 설날 → 02/07)
<img width="674" height="1061" alt="스크린샷 2026-07-20 오전 12 51 09" src="https://github.com/user-attachments/assets/0ebade8d-e9eb-47ce-8329-c0c7dbafb548" />

- 기념일 수정 (PATCH /anniversary/{anniversaryId}) - 200 성공
<img width="674" height="1061" alt="스크린샷 2026-07-20 오전 12 52 17" src="https://github.com/user-attachments/assets/f2562e63-3163-45d6-a16d-de90b94ae312" />

- 기념일 삭제 (DELETE /anniversary) - 200 성공
<img width="674" height="1061" alt="스크린샷 2026-07-20 오전 12 52 43" src="https://github.com/user-attachments/assets/7002ae04-2438-4fc3-afed-32a3a7de0c59" />
<img width="674" height="1061" alt="스크린샷 2026-07-20 오전 12 53 04" src="https://github.com/user-attachments/assets/8cccb314-c379-4333-a5e9-47828e11c4f9" />

---
## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---
## 🔗 관련 이슈
close #59

📌 참고 사항
API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.

* API 명세서: 기념일 목록/추가/수정/삭제 노션 페이지
* ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp

* 다가오는 기념일 D-day 계산에서 음력 기반 기본 기념일(추석, 설날)은 KASI(한국천문연구원) 표준 기반 라이브러리(usingsky/KoreanLunarCalendar)로 실제 양력 날짜를 계산해 반영했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 기념일을 조회·등록·수정·삭제할 수 있는 API가 추가되었습니다.
  * 개인 기념일과 공용 기념일을 구분해 확인할 수 있습니다.
  * 다가오는 기념일의 남은 날짜(D-day)를 제공합니다.
  * 양력 및 음력 기념일을 지원합니다.
  * 7일 전 및 당일 알림 설정과 메모를 관리할 수 있습니다.

* **문서화**
  * 기념일 API의 요청 형식과 응답 예시가 OpenAPI 문서에 추가되었습니다.

* **오류 처리**
  * 존재하지 않거나 다른 회원의 기념일에 접근할 때 명확한 오류가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->