### PR TITLE
[feat] 완료된 장 다시보기 API 상단 데이터 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -357,7 +357,11 @@ public interface RecordControllerDocs {
                                                       "message": "완료된 장을 성공적으로 조회했습니다.",
                                                       "result": {
                                                         "memberChapterId": 10,
-                                                        "title": "다시 쓰는 당신의 프로필",
+                                                        "storybookTitle": "오래 전 당신",
+                                                        "chapterTitle": "나와 같은 나이였던 시절",
+                                                        "chapterOrder": 1,
+                                                        "description": "부모님을 한 사람으로 바라보는 첫 장입니다. 지금의 내 나이였을 때 부모님은 어떤 하루를 살고 있었는지 돌아봅니다.",
+                                                        "chapterImageUrl": "https://example.com/chapter1.png",
                                                         "emotion": "HAPPY",
                                                         "coverType": "SCENE_CARD",
                                                         "imageUrl": null,

--- a/src/main/java/com/umc/halo/domain/record/converter/RecordConverter.java
+++ b/src/main/java/com/umc/halo/domain/record/converter/RecordConverter.java
@@ -21,10 +21,15 @@ public class RecordConverter {
 
     public static RecordResDTO.ReadChapterRecord toReadChapterRecord(MemberChapter memberChapter, List<RecordResDTO.ReadChapterRecord.Answer> answer) {
         CoverType coverType = memberChapter.getCoverType();
+        Chapter chapter = memberChapter.getStorybookChapter().getChapter();
 
         return RecordResDTO.ReadChapterRecord.builder()
                 .memberChapterId(memberChapter.getId())
-                .title(memberChapter.getStorybookChapter().getChapter().getTitle())
+                .storybookTitle(memberChapter.getStorybookChapter().getStorybook().getTitle())
+                .chapterTitle(chapter.getTitle())
+                .chapterOrder(memberChapter.getStorybookChapter().getChapterOrder())
+                .description(chapter.getDescription())
+                .chapterImageUrl(chapter.getImageUrl())
                 .emotion(memberChapter.getEmotion())
                 .coverType(coverType)
                 .imageUrl(coverType == CoverType.IMAGE ? memberChapter.getImageUrl() : null)

--- a/src/main/java/com/umc/halo/domain/record/dto/RecordResDTO.java
+++ b/src/main/java/com/umc/halo/domain/record/dto/RecordResDTO.java
@@ -21,7 +21,11 @@ public class RecordResDTO {
     @Builder
     public record ReadChapterRecord(
             Long memberChapterId,
-            String title,
+            String storybookTitle,
+            String chapterTitle,
+            Integer chapterOrder,
+            String description,
+            String chapterImageUrl,
             Emotion emotion,
             CoverType coverType,
             String imageUrl,


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 완료된 장 다시보기 API 상단 데이터 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- RecordDTO, RecordConverter: 완료된 장 다시보기에서 상단 데이터(스토리북 제목, 장 순서 등) 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="960" height="946" alt="image" src="https://github.com/user-attachments/assets/5b3c61ae-3673-4264-8e90-2591fe0e4ca4" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #63
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
- 완료된 장 조회 명세서: https://exuberant-light-1c4.notion.site/38fca1e217c0800a8f99c4ae5ac9ef5d?pvs=74
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 완료된 장 다시보기 화면에서 동화 제목과 장 제목을 구분해 제공합니다.
  * 장 순서, 설명, 장 이미지 등 상세 정보가 함께 표시됩니다.
  * 장 기록 조회 응답 형식이 확장되어 보다 풍부한 장 정보를 확인할 수 있습니다.
  * 기존 단일 제목 정보는 세분화된 제목 및 장 세부 정보로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->