### PR TITLE
[FEAT] 캘린더 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/CalendarController.java
@@ -28,7 +28,7 @@ public class CalendarController implements CalendarControllerDocs {
     // 월간
     @GetMapping
     public ApiResponse<CalendarMonthlyResDTO.MonthlyInfo> getMonthly(
-            @AuthenticationPrincipal Long memberId, @RequestParam int year, @RequestParam @Min(1) @Max(12) int month
+            @AuthenticationPrincipal Long memberId, @RequestParam int year, @RequestParam int month
     ) {
         BaseSuccessCode code = CalendarSuccessCode.MAIN_SUCCESS;
         return ApiResponse.onSuccess(code, calendarService.getMonthly(memberId, year, month));

--- a/src/main/java/com/umc/halo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/CalendarController.java
@@ -1,0 +1,45 @@
+package com.umc.halo.domain.calendar.controller;
+
+import com.umc.halo.domain.calendar.controller.docs.CalendarControllerDocs;
+import com.umc.halo.domain.calendar.dto.CalendarDailyResDTO;
+import com.umc.halo.domain.calendar.dto.CalendarMonthlyResDTO;
+import com.umc.halo.domain.calendar.exception.code.CalendarSuccessCode;
+import com.umc.halo.domain.calendar.service.CalendarService;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/calendar")
+public class CalendarController implements CalendarControllerDocs {
+
+    private final CalendarService calendarService;
+
+    // 월간
+    @GetMapping
+    public ApiResponse<CalendarMonthlyResDTO.MonthlyInfo> getMonthly(
+            @AuthenticationPrincipal Long memberId, @RequestParam int year, @RequestParam @Min(1) @Max(12) int month
+    ) {
+        BaseSuccessCode code = CalendarSuccessCode.MAIN_SUCCESS;
+        return ApiResponse.onSuccess(code, calendarService.getMonthly(memberId, year, month));
+    }
+
+    // 일별
+    @GetMapping("/{date}")
+    public ApiResponse<CalendarDailyResDTO.DailyInfo> getDaily(
+            @AuthenticationPrincipal Long memberId, @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        BaseSuccessCode code = CalendarSuccessCode.DAILY_SUCCESS;
+        return ApiResponse.onSuccess(code, calendarService.getDaily(memberId, date));
+    }
+}

--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -9,6 +9,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDate;
 
@@ -65,8 +68,8 @@ public interface CalendarControllerDocs {
     })
     ApiResponse<CalendarMonthlyResDTO.MonthlyInfo> getMonthly(
             @Parameter(hidden = true) Long memberId,
-            @Parameter(description = "조회 연도", example = "2025") int year,
-            @Parameter(description = "조회 월 (1~12)", example = "5") int month
+            @Parameter(description = "조회 연도", example = "2025") @RequestParam int year,
+            @Parameter(description = "조회 월 (1~12)", example = "5") @RequestParam @Min(1) @Max(12) int month
     );
 
     @Operation(

--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -1,0 +1,124 @@
+package com.umc.halo.domain.calendar.controller.docs;
+
+import com.umc.halo.domain.calendar.dto.CalendarDailyResDTO;
+import com.umc.halo.domain.calendar.dto.CalendarMonthlyResDTO;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.time.LocalDate;
+
+@Tag(name = "캘린더 API")
+public interface CalendarControllerDocs {
+
+    @Operation(
+            summary = "캘린더 메인 조회 API",
+            description = """
+                    # 캘린더 메인 조회
+                    
+                    ## 요청 형식
+                    - 헤더: Authorization: Bearer {JWT 토큰}
+                    - 쿼리 파라미터: year, month(1~12)
+                    
+                    선택한 월의 완료 페이지 수, 기록이 있는 날짜, 완성/진행 중 스토리북 통계를 조회합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "code": "CALENDAR200_1",
+                              "message": "캘린더 메인 조회를 성공했습니다.",
+                              "result": {
+                                "stats": { "completedPageCount": 30, "completedStorybookCount": 3, "inProgressStorybookCount": 2 },
+                                "recordedDays": [9, 10, 11, 19],
+                                "completedStorybooks": [
+                                  { "storybookId": 1, "spineColor": "#F0997B" },
+                                  { "storybookId": 2, "spineColor": "#FAC775" },
+                                  { "storybookId": 3, "spineColor": "#D3C7A9" }
+                                ]
+                              }
+                            }
+                            """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - JWT 토큰 미삽입/만료",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            { "isSuccess": false, "code": "AUTH401_1", "message": "토큰이 만료되었습니다.", "result": null }
+                            """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "토큰의 회원이 존재하지 않음 (탈퇴 등)",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            { "isSuccess": false, "code": "MEMBER404_1", "message": "존재하지 않는 회원입니다.", "result": null }
+                            """))
+            )
+    })
+    ApiResponse<CalendarMonthlyResDTO.MonthlyInfo> getMonthly(
+            @Parameter(hidden = true) Long memberId,
+            @Parameter(description = "조회 연도", example = "2025") int year,
+            @Parameter(description = "조회 월 (1~12)", example = "5") int month
+    );
+
+    @Operation(
+            summary = "일별 기록 조회 API",
+            description = """
+                    # 일별 기록 조회
+                    
+                    ## 요청 형식
+                    - 헤더: Authorization: Bearer {JWT 토큰}
+                    - 경로 변수: date (yyyy-MM-dd)
+                    
+                    특정 날짜에 완료한 스토리북과 기록한 장 목록을 조회합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "code": "CALENDAR200_2",
+                              "message": "일별 기록 조회를 성공했습니다.",
+                              "result": {
+                                "date": "2026-06-26",
+                                "storybooks": [
+                                  { "storybookId": 1, "title": "오래전 당신", "storybookImageUrl": "https://image1" }
+                                ],
+                                "chapters": [
+                                  { "storybookId": 101, "title": "오래 전 당신", "nextChapterOrder": 5 }
+                                ]
+                              }
+                            }
+                            """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 - JWT 토큰 미삽입/만료",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            { "isSuccess": false, "code": "AUTH401_1", "message": "토큰이 만료되었습니다.", "result": null }
+                            """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "토큰의 회원이 존재하지 않음 (탈퇴 등)",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            { "isSuccess": false, "code": "MEMBER404_1", "message": "존재하지 않는 회원입니다.", "result": null }
+                            """))
+            )
+    })
+    ApiResponse<CalendarDailyResDTO.DailyInfo> getDaily(
+            @Parameter(hidden = true) Long memberId,
+            @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-06-26") LocalDate date
+    );
+}

--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -52,6 +52,18 @@ public interface CalendarControllerDocs {
                             """))
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "파라미터 검증 실패 (month가 1~12 범위를 벗어남 등)",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": false,
+                              "code": "COMMON400_1",
+                              "message": "잘못된 요청입니다.",
+                              "result": { "month": "12 이하여야 합니다" }
+                            }
+                            """))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "401",
                     description = "인증 실패 - JWT 토큰 미삽입/만료",
                     content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
@@ -118,15 +130,9 @@ public interface CalendarControllerDocs {
                     content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
                             { "isSuccess": false, "code": "MEMBER404_1", "message": "존재하지 않는 회원입니다.", "result": null }
                             """))
-            ),
+            )
 
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "파라미터 검증 실패 (month 범위 초과 등)",
-                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
-                            { "isSuccess": false, "code": "COMMON400_1", "message": "잘못된 요청입니다.", "result": null }
-                            """))
-            ),
+
     })
     ApiResponse<CalendarDailyResDTO.DailyInfo> getDaily(
             @Parameter(hidden = true) Long memberId,

--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -118,7 +118,15 @@ public interface CalendarControllerDocs {
                     content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
                             { "isSuccess": false, "code": "MEMBER404_1", "message": "존재하지 않는 회원입니다.", "result": null }
                             """))
-            )
+            ),
+
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "파라미터 검증 실패 (month 범위 초과 등)",
+                    content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                            { "isSuccess": false, "code": "COMMON400_1", "message": "잘못된 요청입니다.", "result": null }
+                            """))
+            ),
     })
     ApiResponse<CalendarDailyResDTO.DailyInfo> getDaily(
             @Parameter(hidden = true) Long memberId,

--- a/src/main/java/com/umc/halo/domain/calendar/converter/CalendarConverter.java
+++ b/src/main/java/com/umc/halo/domain/calendar/converter/CalendarConverter.java
@@ -1,0 +1,66 @@
+package com.umc.halo.domain.calendar.converter;
+
+import com.umc.halo.domain.calendar.dto.CalendarDailyResDTO;
+import com.umc.halo.domain.calendar.dto.CalendarMonthlyResDTO;
+import com.umc.halo.domain.content.storybook.entity.Storybook;
+
+import java.util.List;
+
+public class CalendarConverter {
+
+    // 월별
+    public static CalendarMonthlyResDTO.Stats toStats(
+            int completedPageCount, int completedStorybookCount, int inProgressStorybookCount) {
+        return CalendarMonthlyResDTO.Stats.builder()
+                .completedPageCount(completedPageCount)
+                .completedStorybookCount(completedStorybookCount)
+                .inProgressStorybookCount(inProgressStorybookCount)
+                .build();
+    }
+
+    public static CalendarMonthlyResDTO.CompletedStorybook toCompletedStorybook(Storybook storybook) {
+        return CalendarMonthlyResDTO.CompletedStorybook.builder()
+                .storybookId(storybook.getId())
+                .spineColor(storybook.getSpineColor())
+                .build();
+    }
+
+    public static CalendarMonthlyResDTO.MonthlyInfo toMonthlyInfo(
+            CalendarMonthlyResDTO.Stats stats,
+            List<Integer> recordedDays,
+            List<CalendarMonthlyResDTO.CompletedStorybook> completedStorybooks) {
+        return CalendarMonthlyResDTO.MonthlyInfo.builder()
+                .stats(stats)
+                .recordedDays(recordedDays)
+                .completedStorybooks(completedStorybooks)
+                .build();
+    }
+
+    // 일별
+    public static CalendarDailyResDTO.StorybookInfo toStorybookInfo(Storybook storybook) {
+        return CalendarDailyResDTO.StorybookInfo.builder()
+                .storybookId(storybook.getId())
+                .title(storybook.getTitle())
+                .storybookImageUrl(storybook.getImageUrl())
+                .build();
+    }
+
+    public static CalendarDailyResDTO.ChapterInfo toChapterInfo(Storybook storybook, Integer nextChapterOrder) {
+        return CalendarDailyResDTO.ChapterInfo.builder()
+                .storybookId(storybook.getId())
+                .title(storybook.getTitle())
+                .nextChapterOrder(nextChapterOrder)
+                .build();
+    }
+
+    public static CalendarDailyResDTO.DailyInfo toDailyInfo(
+            String date,
+            List<CalendarDailyResDTO.StorybookInfo> storybooks,
+            List<CalendarDailyResDTO.ChapterInfo> chapters) {
+        return CalendarDailyResDTO.DailyInfo.builder()
+                .date(date)
+                .storybooks(storybooks)
+                .chapters(chapters)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/halo/domain/calendar/dto/CalendarDailyResDTO.java
+++ b/src/main/java/com/umc/halo/domain/calendar/dto/CalendarDailyResDTO.java
@@ -1,0 +1,28 @@
+package com.umc.halo.domain.calendar.dto;
+
+import lombok.Builder;
+import java.util.List;
+
+public class CalendarDailyResDTO {
+
+    @Builder
+    public record DailyInfo(
+            String date,
+            List<StorybookInfo> storybooks,
+            List<ChapterInfo> chapters
+    ) {}
+
+    @Builder
+    public record StorybookInfo(
+            Long storybookId,
+            String title,
+            String storybookImageUrl
+    ) {}
+
+    @Builder
+    public record ChapterInfo(
+            Long storybookId,
+            String title,
+            Integer nextChapterOrder
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/calendar/dto/CalendarMonthlyResDTO.java
+++ b/src/main/java/com/umc/halo/domain/calendar/dto/CalendarMonthlyResDTO.java
@@ -1,0 +1,27 @@
+package com.umc.halo.domain.calendar.dto;
+
+import lombok.Builder;
+import java.util.List;
+
+public class CalendarMonthlyResDTO {
+
+    @Builder
+    public record MonthlyInfo(
+            Stats stats,
+            List<Integer> recordedDays,
+            List<CompletedStorybook> completedStorybooks
+    ) {}
+
+    @Builder
+    public record Stats(
+            Integer completedPageCount,
+            Integer completedStorybookCount,
+            Integer inProgressStorybookCount
+    ) {}
+
+    @Builder
+    public record CompletedStorybook(
+            Long storybookId,
+            String spineColor
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/calendar/exception/code/CalendarSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/calendar/exception/code/CalendarSuccessCode.java
@@ -1,0 +1,23 @@
+package com.umc.halo.domain.calendar.exception.code;
+
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CalendarSuccessCode implements BaseSuccessCode {
+
+    MAIN_SUCCESS(HttpStatus.OK,
+            "CALENDAR200_1",
+            "캘린더 메인 조회를 성공했습니다."),
+    DAILY_SUCCESS(HttpStatus.OK,
+            "CALENDAR200_2",
+            "일별 기록 조회를 성공했습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
@@ -1,0 +1,118 @@
+package com.umc.halo.domain.calendar.service;
+
+import com.umc.halo.domain.calendar.converter.CalendarConverter;
+import com.umc.halo.domain.calendar.dto.CalendarDailyResDTO;
+import com.umc.halo.domain.calendar.dto.CalendarMonthlyResDTO;
+import com.umc.halo.domain.content.storybook.entity.Storybook;
+import com.umc.halo.domain.member.entity.Member;
+import com.umc.halo.domain.member.exception.MemberException;
+import com.umc.halo.domain.member.exception.code.MemberErrorCode;
+import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.domain.record.entity.MemberChapter;
+import com.umc.halo.domain.record.entity.MemberStorybook;
+import com.umc.halo.domain.record.enums.Status;
+import com.umc.halo.domain.record.repository.MemberChapterRepository;
+import com.umc.halo.domain.record.repository.MemberStorybookRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+
+    private static final int TOTAL_CHAPTER_COUNT = 10;
+
+    private final MemberRepository memberRepository;
+    private final MemberChapterRepository memberChapterRepository;
+    private final MemberStorybookRepository memberStorybookRepository;
+    //월간
+    @Transactional(readOnly = true)
+    public CalendarMonthlyResDTO.MonthlyInfo getMonthly(Long memberId, int year, int month) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        List<MemberChapter> completedChapters = memberChapterRepository
+                .findByMemberAndStatusAndCompletedDateBetween(member, Status.COMPLETED, startDate, endDate);
+
+        int completedPageCount = completedChapters.size();
+
+        List<Integer> recordedDays = completedChapters.stream()
+                .map(mc -> mc.getCompletedDate().getDayOfMonth())
+                .distinct()
+                .sorted()
+                .toList();
+
+        List<MemberStorybook> memberStorybooks = memberStorybookRepository
+                .findAllByMemberWithStorybook(member);
+
+        List<CalendarMonthlyResDTO.CompletedStorybook> completedStorybooks = memberStorybooks.stream()
+                .filter(ms -> ms.getLastChapterOrder() == TOTAL_CHAPTER_COUNT)
+                .filter(ms -> ms.getLastCompletedDate() != null
+                        && !ms.getLastCompletedDate().isBefore(startDate)
+                        && !ms.getLastCompletedDate().isAfter(endDate))
+                .map(ms -> CalendarConverter.toCompletedStorybook(ms.getStorybook()))
+                .toList();
+
+        int completedStorybookCount = completedStorybooks.size();
+
+        int inProgressStorybookCount = (int) memberStorybooks.stream()
+                .filter(ms -> ms.getLastChapterOrder() < TOTAL_CHAPTER_COUNT)
+                .count();
+
+        CalendarMonthlyResDTO.Stats stats = CalendarConverter.toStats(
+                completedPageCount, completedStorybookCount, inProgressStorybookCount);
+
+        return CalendarConverter.toMonthlyInfo(stats, recordedDays, completedStorybooks);
+    }
+
+    // 일별
+    @Transactional(readOnly = true)
+    public CalendarDailyResDTO.DailyInfo getDaily(Long memberId, LocalDate date) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        List<MemberChapter> dayChapters = memberChapterRepository
+                .findDailyWithStorybook(member, Status.COMPLETED, date).stream()
+                .sorted(Comparator.comparing(MemberChapter::getId).reversed())
+                .toList();
+
+        Map<Long, MemberStorybook> progressByStorybookId = memberStorybookRepository
+                .findAllByMemberWithStorybook(member).stream()
+                .collect(Collectors.toMap(ms -> ms.getStorybook().getId(), Function.identity()));
+
+        List<CalendarDailyResDTO.StorybookInfo> storybooks = new ArrayList<>();
+        List<CalendarDailyResDTO.ChapterInfo> chapters = new ArrayList<>();
+
+        for (MemberChapter mc : dayChapters) {
+            Storybook storybook = mc.getStorybookChapter().getStorybook();
+            int chapterOrderOfDay = mc.getStorybookChapter().getChapterOrder();
+
+            if (chapterOrderOfDay == TOTAL_CHAPTER_COUNT) {
+                storybooks.add(CalendarConverter.toStorybookInfo(storybook));
+            } else {
+                MemberStorybook ms = progressByStorybookId.get(storybook.getId());
+                int lastOrder = (ms != null) ? ms.getLastChapterOrder() : chapterOrderOfDay;
+                int nextChapterOrder = Math.min(lastOrder + 1, TOTAL_CHAPTER_COUNT);
+                chapters.add(CalendarConverter.toChapterInfo(storybook, nextChapterOrder));
+            }
+        }
+
+        return CalendarConverter.toDailyInfo(date.toString(), storybooks, chapters);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
@@ -71,6 +71,9 @@ public class CalendarService {
 
         int inProgressStorybookCount = (int) memberStorybooks.stream()
                 .filter(ms -> ms.getLastChapterOrder() < TOTAL_CHAPTER_COUNT)
+                .filter(ms -> ms.getLastCompletedDate() != null
+                        && !ms.getLastCompletedDate().isBefore(startDate)
+                        && !ms.getLastCompletedDate().isAfter(endDate))
                 .count();
 
         CalendarMonthlyResDTO.Stats stats = CalendarConverter.toStats(
@@ -88,7 +91,7 @@ public class CalendarService {
 
         List<MemberChapter> dayChapters = memberChapterRepository
                 .findDailyWithStorybook(member, Status.COMPLETED, date).stream()
-                .sorted(Comparator.comparing(MemberChapter::getId).reversed())
+                .sorted(Comparator.comparing(MemberChapter::getUpdatedAt).reversed())
                 .toList();
 
         Map<Long, MemberStorybook> progressByStorybookId = memberStorybookRepository

--- a/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
@@ -38,7 +38,6 @@ public class CalendarService {
     //월간
     @Transactional(readOnly = true)
     public CalendarMonthlyResDTO.MonthlyInfo getMonthly(Long memberId, int year, int month) {
-
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberChapterRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberChapterRepository.java
@@ -5,7 +5,9 @@ import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.record.entity.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
-
+import com.umc.halo.domain.record.enums.Status;
+import org.springframework.data.repository.query.Param;
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
@@ -16,4 +18,17 @@ public interface MemberChapterRepository extends JpaRepository<MemberChapter, Lo
     MemberChapter findByMemberAndStorybookChapter(Member member, StorybookChapter storybookChapter);
 
     void deleteByMemberId(Long memberId);
+
+    //월별 입니다!
+    List<MemberChapter> findByMemberAndStatusAndCompletedDateBetween(
+            Member member, Status status, LocalDate startDate, LocalDate endDate);
+    //일별 입니다
+    @Query("select mc from MemberChapter mc " +
+            "join fetch mc.storybookChapter sc " +
+            "join fetch sc.storybook " +
+            "where mc.member = :member and mc.status = :status and mc.completedDate = :date")
+    List<MemberChapter> findDailyWithStorybook(
+            @Param("member") Member member,
+            @Param("status") Status status,
+            @Param("date") LocalDate date);
 }

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberStorybookRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberStorybookRepository.java
@@ -5,7 +5,7 @@ import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.record.entity.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
-
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,4 +21,9 @@ public interface MemberStorybookRepository extends JpaRepository<MemberStorybook
     Optional<MemberStorybook> findByStorybookAndMember(Storybook storybook, Member member);
 
     void deleteByMemberId(Long memberId);
+
+    @Query("select ms from MemberStorybook ms " +
+            "join fetch ms.storybook " +
+            "where ms.member = :member")
+    List<MemberStorybook> findAllByMemberWithStorybook(@Param("member") Member member);
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 캘린더 API 2종 구현 (월간 캘린더 조회, 일별 기록 조회)
- 자체 엔티티 없는 조회 전용 도메인. record·storybook 데이터를 읽어 집계
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `domain/calendar` 신규: Controller/Docs, Service, Converter, DTO 2종, CalendarSuccessCode
- `GET /api/v1/calendar?year=&month=` — 완료 페이지 수, 기록 날짜, 완성/진행중 스토리북 통계
- `GET /api/v1/calendar/{date}` — 해당 날짜 완료 스토리북 및 장 기록
- **(타 도메인)** record 레포에 조회 메서드 추가 — 기존 코드 미변경, 추가만
  - `MemberChapterRepository`: `findByMemberAndStatusAndCompletedDateBetween`, `findDailyWithStorybook`
  - `MemberStorybookRepository`: `findAllByMemberWithStorybook`
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 월별 조회 
<img width="1290" height="598" alt="image" src="https://github.com/user-attachments/assets/a800bcc7-5307-4ded-ab0c-2ea3ee2fd68d" />

- 일별 조회
<img width="1262" height="478" alt="image" src="https://github.com/user-attachments/assets/8c2da897-ec62-4da0-a784-20d49d5c6b71" />



---

## ✅ 확인 사항

- [X ] 서버 정상 기동 확인
- [ X] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [ X] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #62
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- API 명세서: 캘린더 메인 조회 / 일별 기록 조회


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 요약
* **새로운 기능**
  * 회원 캘린더 조회 API 추가: 월별 및 일별 기록을 조회할 수 있습니다.
  * 월별: 완료 페이지 수, 완료/진행 중 스토리북 수, 기록된 날짜, 완료 스토리북 정보 제공.
  * 일별: 해당 날짜의 스토리북(제목/이미지)과 챕터 정보 제공(진행 중은 다음 챕터도 포함).
* **개선 사항**
  * 월/일 응답 형식을 새 DTO로 구조화하고, 성공 응답 코드/메시지를 표준화했습니다.
  * API 문서 스펙 및 입력 제약(월 범위 등)을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->