### PR TITLE
[fix] 홈 화면 & 스토리북 상세 수정

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/storybook/controller/docs/StorybookControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/controller/docs/StorybookControllerDocs.java
@@ -28,7 +28,7 @@ public interface StorybookControllerDocs {
 
                     **동작 방식**
                     1. 인증된 회원의 진행 중인 스토리북들을 조회합니다.
-                    2. 대표 스토리북(가장 최근에 진행 중인 것)의 진행 정보를 계산합니다.
+                    2. 진행 중인 스토리북 전체의 제목/진행 상황을 리스트로 계산합니다.
                     3. 전체 스토리북의 책장 상태(NOT_STARTED/IN_PROGRESS/COMPLETED)를 계산합니다.
                     4. 진행 중인 스토리북이 하나도 없으면 추천 스토리북을 함께 조회합니다.
                     5. 계산된 홈 화면 상태(homeStatus)와 함께 결과를 반환합니다.
@@ -49,14 +49,22 @@ public interface StorybookControllerDocs {
                                       "result": {
                                         "homeStatus": "MULTIPLE_IN_PROGRESS",
                                         "memberName": "김하로님",
-                                        "representativeStorybook": {
-                                          "storybookId": 3,
-                                          "title": "가족의 온도",
-                                          "currentChapterTitle": "나와 같은 나이였던 시절",
-                                          "currentChapterOrder": 1,
-                                          "todayAvailable": true
-                                        },
-                                        "otherInProgressCount": 1,
+                                        "inProgressStorybooks": [
+                                          {
+                                            "storybookId": 3,
+                                            "title": "가족의 온도",
+                                            "currentChapterOrder": 1,
+                                            "totalChapterCount": 10,
+                                            "todayAvailable": true
+                                          },
+                                          {
+                                            "storybookId": 4,
+                                            "title": "취향이 닿는 날",
+                                            "currentChapterOrder": 3,
+                                            "totalChapterCount": 10,
+                                            "todayAvailable": true
+                                          }
+                                        ],
                                         "bookshelf": [
                                           {
                                             "storybookId": 1,
@@ -178,6 +186,7 @@ public interface StorybookControllerDocs {
                     2. 회원의 장별 완료 여부를 조회합니다.
                     3. member_storybook의 lastCompletedDate로 오늘 완료 여부를 확인합니다.
                     4. 각 장의 상태(COMPLETED/TODAY/TODAY_LOCKED/LOCKED)를 계산하여 반환합니다.
+                    5. 완료한 장 수를 기준으로 전체 진행률(%)을 계산하여 함께 반환합니다.
                     """
     )
     @ApiResponses(value = {
@@ -197,6 +206,8 @@ public interface StorybookControllerDocs {
                                         "title": "취향이 닿는 날",
                                         "description": "좋아하는 것과 싫어하는 것을 하나씩 나누며, 서로의 취향이 닿는 순간들을 발견하는 이야기입니다.",
                                         "imageUrl": "https://example.com/storybook4.png",
+                                        "completedChapterCount": 1,
+                                        "progressPercentage": 10,
                                         "chapters": [
                                           {
                                             "chapterOrder": 1,

--- a/src/main/java/com/umc/halo/domain/content/storybook/converter/StorybookConverter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/converter/StorybookConverter.java
@@ -30,12 +30,15 @@ public class StorybookConverter {
     }
 
     public static StorybookResDTO.GetStorybookDetail toStorybookDetail(
-            Storybook storybook, List<StorybookResDTO.ChapterInfo> chapterInfos) {
+            Storybook storybook, List<StorybookResDTO.ChapterInfo> chapterInfos,
+            int completedChapterCount, int progressPercentage) {
         return StorybookResDTO.GetStorybookDetail.builder()
                 .storybookId(storybook.getId())
                 .title(storybook.getTitle())
                 .description(storybook.getDescription())
                 .imageUrl(storybook.getImageUrl())
+                .completedChapterCount(completedChapterCount)
+                .progressPercentage(progressPercentage)
                 .chapters(chapterInfos)
                 .build();
     }

--- a/src/main/java/com/umc/halo/domain/content/storybook/converter/StorybookConverter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/converter/StorybookConverter.java
@@ -126,13 +126,13 @@ public class StorybookConverter {
                 .build();
     }
 
-    public static StorybookResDTO.RepresentativeStorybook toRepresentativeStorybook(
-            Storybook representative, String chapterTitle, Integer chapterOrder, boolean todayAvailable) {
-        return StorybookResDTO.RepresentativeStorybook.builder()
-                .storybookId(representative.getId())
-                .title(representative.getTitle())
-                .currentChapterTitle(chapterTitle)
-                .currentChapterOrder(chapterOrder)
+    public static StorybookResDTO.InProgressStorybook toInProgressStorybook(
+            Storybook storybook, Integer currentChapterOrder, boolean todayAvailable) {
+        return StorybookResDTO.InProgressStorybook.builder()
+                .storybookId(storybook.getId())
+                .title(storybook.getTitle())
+                .currentChapterOrder(currentChapterOrder)
+                .totalChapterCount(10)
                 .todayAvailable(todayAvailable)
                 .build();
     }
@@ -150,15 +150,13 @@ public class StorybookConverter {
     public static StorybookResDTO.GetHome toHome(
             HomeStatus homeStatus,
             String memberName,
-            StorybookResDTO.RepresentativeStorybook representativeStorybook,
-            int otherInProgressCount,
+            List<StorybookResDTO.InProgressStorybook> inProgressStorybooks,
             List<StorybookResDTO.BookshelfItem> bookshelf,
             List<StorybookResDTO.RecommendedStorybook> recommendedStorybooks) {
         return StorybookResDTO.GetHome.builder()
                 .homeStatus(homeStatus)
                 .memberName(memberName)
-                .representativeStorybook(representativeStorybook)
-                .otherInProgressCount(otherInProgressCount)
+                .inProgressStorybooks(inProgressStorybooks)
                 .bookshelf(bookshelf)
                 .recommendedStorybooks(recommendedStorybooks)
                 .build();

--- a/src/main/java/com/umc/halo/domain/content/storybook/dto/StorybookResDTO.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/dto/StorybookResDTO.java
@@ -80,6 +80,8 @@ public class StorybookResDTO {
             String title,
             String description,
             String imageUrl,
+            int completedChapterCount,
+            int progressPercentage,
             List<ChapterInfo> chapters
     ) {}
 

--- a/src/main/java/com/umc/halo/domain/content/storybook/dto/StorybookResDTO.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/dto/StorybookResDTO.java
@@ -19,18 +19,17 @@ public class StorybookResDTO {
     public record GetHome(
             HomeStatus homeStatus,
             String memberName,
-            RepresentativeStorybook representativeStorybook,
-            int otherInProgressCount,
+            List<InProgressStorybook> inProgressStorybooks,
             List<BookshelfItem> bookshelf,
             List<RecommendedStorybook> recommendedStorybooks
     ) {}
 
     @Builder
-    public record RepresentativeStorybook(
+    public record InProgressStorybook(
             Long storybookId,
             String title,
-            String currentChapterTitle,
             Integer currentChapterOrder,
+            int totalChapterCount,
             boolean todayAvailable
     ) {}
 

--- a/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
@@ -252,36 +252,23 @@ public class StorybookService {
                 .toList();
 
         HomeStatus homeStatus;
-        StorybookResDTO.RepresentativeStorybook representativeStorybook = null;
-        int otherInProgressCount = 0;
+        List<StorybookResDTO.InProgressStorybook> inProgressStorybooks = new ArrayList<>();
 
         if (activeStorybooks.isEmpty()) {
             homeStatus = HomeStatus.NO_STORYBOOK;
         } else {
-            Storybook representative = activeStorybooks.get(0);
-            StorybookStatus repStatus = statusMap.get(representative);
-            MemberStorybook repMemberStorybook = memberStorybookMap.get(representative.getId());
-
-            Integer chapterOrder = repMemberStorybook.getLastChapterOrder();
-            String chapterTitle = storybookChapterRepository
-                    .findByStorybook_IdAndChapterOrder(representative.getId(), chapterOrder)
-                    .map(sc -> sc.getChapter().getTitle())
-                    .orElse(null);
-
-            representativeStorybook = StorybookConverter.toRepresentativeStorybook(
-                    representative, chapterTitle, chapterOrder, repStatus == StorybookStatus.IN_PROGRESS);
-
-            otherInProgressCount = activeStorybooks.size() - 1;
-
             boolean allTodayDone = activeStorybooks.stream()
                     .allMatch(sb -> statusMap.get(sb) == StorybookStatus.TODAY_DONE);
 
-            if (allTodayDone) {
-                homeStatus = HomeStatus.ALL_COMPLETED_TODAY;
-            } else if (activeStorybooks.size() == 1) {
-                homeStatus = HomeStatus.IN_PROGRESS;
-            } else {
-                homeStatus = HomeStatus.MULTIPLE_IN_PROGRESS;
+            homeStatus = allTodayDone ? HomeStatus.ALL_COMPLETED_TODAY
+                    : activeStorybooks.size() == 1 ? HomeStatus.IN_PROGRESS
+                    : HomeStatus.MULTIPLE_IN_PROGRESS;
+
+            for (Storybook sb : activeStorybooks) {
+                MemberStorybook memberStorybook = memberStorybookMap.get(sb.getId());
+                Integer chapterOrder = memberStorybook.getLastChapterOrder();
+                boolean todayAvailable = statusMap.get(sb) == StorybookStatus.IN_PROGRESS;
+                inProgressStorybooks.add(StorybookConverter.toInProgressStorybook(sb, chapterOrder, todayAvailable));
             }
         }
 
@@ -300,8 +287,7 @@ public class StorybookService {
         return StorybookConverter.toHome(
                 homeStatus,
                 member.getName() + "님",
-                representativeStorybook,
-                otherInProgressCount,
+                inProgressStorybooks,
                 bookshelf,
                 recommendedStorybooks
         );

--- a/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
@@ -101,7 +101,10 @@ public class StorybookService {
             chapterInfos.add(StorybookConverter.toChapterInfo(sc, status));
         }
 
-        return StorybookConverter.toStorybookDetail(storybook, chapterInfos);
+        int completedChapterCount = completedChapterIds.size();
+        int progressPercentage = completedChapterCount * 10;
+
+        return StorybookConverter.toStorybookDetail(storybook, chapterInfos, completedChapterCount, progressPercentage);
     }
 
     @Transactional


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- Figma(메인화면, 스토리북 목차&상세) 기준으로 홈 화면과 스토리북 상세 API 응답 구조를 수정했습니다.

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 'StorybookResDTO': 'RepresentativeStorybook' 제거, 'InProgressStorybook' 추가 / 'GetStorybookDetail'에 'completedChapterCount', 'progressPercentage' 필드 추가
- 'StorybookConverter': 'toRepresentativeStorybook()' 제거, 'toInProgressStorybook()' 추가 / 'toStorybookDetail()' 진행률 파라미터 추가
- 'StorybookService': 'getHome()' - 진행중 스토리북 전체를 리스트로 반환하도록 변경 / 'getStorybookDetail()' - 완료 장 수 기반 진행률 계산 추가
- 'StorybookControllerDocs': 'getHome', 'getStorybookDetail' Swagger 설명 및 예시 JSON 갱신
 
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 'GET /api/v1/home': NO_STORYBOOK / IN_PROGRESS / MULTIPLE_IN_PROGRESS / ALL_COMPLETED_TODAY 전체 상태 정상 확인
<img width="868" height="1061" alt="스크린샷 2026-07-21 오전 12 43 29" src="https://github.com/user-attachments/assets/c4590d24-b743-47cf-be29-0a0b5cb3a79f" />
<img width="868" height="1061" alt="스크린샷 2026-07-21 오전 12 48 40" src="https://github.com/user-attachments/assets/c7e4f07a-4cee-45fc-b421-f465c1cd4119" />

- 'GET /api/v1/storybooks/{storybookId}': 0%(진행중), 30%(진행중), 100%(완료) 케이스 각각 'completedChapterCount', 'progressPercentage', 장별 status(COMPLETED/TODAY_LOCKED/LOCKED) 정상 확인
<img width="865" height="1061" alt="스크린샷 2026-07-21 오전 12 52 02" src="https://github.com/user-attachments/assets/9c7733fd-1fd4-4278-a826-bf2f3c257b6c" />
<img width="865" height="1061" alt="스크린샷 2026-07-21 오전 12 52 24" src="https://github.com/user-attachments/assets/c4fa6255-226f-4496-a9fd-01737b2927bb" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #67
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- API 명세서: 스토리북 상세 / 홈화면 조회 노션 페이지
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 홈 화면에서 진행 중인 스토리북을 목록으로 확인할 수 있습니다.
  - 각 스토리북의 현재 챕터, 전체 챕터 수, 오늘 이용 가능 여부를 제공합니다.
  - 스토리북 상세 화면에 완료한 챕터 수와 전체 진행률을 표시합니다.

- **문서**
  - 홈 조회 및 스토리북 상세 조회 API의 응답 예시와 처리 설명을 최신 형식에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->