### PR TITLE
[feat] 알림 설정 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/HaloServerApplication.java
+++ b/src/main/java/com/umc/halo/HaloServerApplication.java
@@ -9,7 +9,14 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 public class HaloServerApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(HaloServerApplication.class, args);
+        var context = SpringApplication.run(HaloServerApplication.class, args);
+
+        // ===== 임시: 테스트 토큰 (확인 후 삭제) =====
+        var jwtUtil = context.getBean(com.umc.halo.global.security.JwtUtil.class);
+        String token = jwtUtil.createAccessToken(3L);
+        System.out.println("===== 테스트 토큰 =====");
+        System.out.println(token);
+        System.out.println("=====================");
     }
 
 }

--- a/src/main/java/com/umc/halo/HaloServerApplication.java
+++ b/src/main/java/com/umc/halo/HaloServerApplication.java
@@ -9,14 +9,6 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 public class HaloServerApplication {
 
     public static void main(String[] args) {
-        var context = SpringApplication.run(HaloServerApplication.class, args);
-
-        // ===== 임시: 테스트 토큰 (확인 후 삭제) =====
-        var jwtUtil = context.getBean(com.umc.halo.global.security.JwtUtil.class);
-        String token = jwtUtil.createAccessToken(3L);
-        System.out.println("===== 테스트 토큰 =====");
-        System.out.println(token);
-        System.out.println("=====================");
+        SpringApplication.run(HaloServerApplication.class, args);
     }
-
 }

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -16,6 +16,8 @@ import com.umc.halo.domain.notification.repository.NotificationRepository;
 import com.umc.halo.domain.record.repository.MemberChapterAnswerRepository;
 import com.umc.halo.domain.record.repository.MemberChapterRepository;
 import com.umc.halo.domain.record.repository.MemberStorybookRepository;
+import com.umc.halo.domain.setting.converter.SettingConverter;
+import com.umc.halo.domain.setting.entity.MemberSetting;
 import com.umc.halo.domain.setting.repository.MemberSettingRepository;
 import com.umc.halo.domain.tag.repository.MemberTagRepository;
 import com.umc.halo.domain.term.repository.MemberTermRepository;
@@ -67,6 +69,10 @@ public class MemberService {
             try{
                 member = MemberConverter.toMember(provider, oidcUserInfo);
                 memberRepository.save(member);
+
+                MemberSetting memberSetting = SettingConverter.toMemberSetting(member);
+                memberSettingRepository.save(memberSetting);
+
                 isNewUser = true;
             } catch (DataIntegrityViolationException e) {
                 member = memberRepository.findByProviderAndProviderIdForUpdate(provider, oidcUserInfo.providerId()).orElseThrow(() -> e);

--- a/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
@@ -1,5 +1,6 @@
 package com.umc.halo.domain.setting.controller;
 
+import com.umc.halo.domain.setting.controller.docs.SettingControllerDocs;
 import com.umc.halo.domain.setting.dto.SettingResDTO;
 import com.umc.halo.domain.setting.exception.code.SettingSuccessCode;
 import com.umc.halo.domain.setting.service.SettingService;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
-public class SettingController {
+public class SettingController implements SettingControllerDocs {
 
     private final SettingService settingService;
 

--- a/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
@@ -1,0 +1,30 @@
+package com.umc.halo.domain.setting.controller;
+
+import com.umc.halo.domain.setting.dto.SettingResDTO;
+import com.umc.halo.domain.setting.exception.code.SettingSuccessCode;
+import com.umc.halo.domain.setting.service.SettingService;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class SettingController {
+
+    private final SettingService settingService;
+
+    @GetMapping("/v1/settings/notifications")
+    public ApiResponse<SettingResDTO.NotificationSettings> getNotificationSettings(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal Long memberId
+    ) {
+        BaseSuccessCode code = SettingSuccessCode.NOTIFICATION_SETTING_GET_SUCCESS;
+        return ApiResponse.onSuccess(code, settingService.getNotificationSettings(memberId));
+    }
+}

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -1,0 +1,4 @@
+package com.umc.halo.domain.setting.controller.docs;
+
+public interface SettingControllerDocs {
+}

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -1,4 +1,77 @@
 package com.umc.halo.domain.setting.controller.docs;
 
+import com.umc.halo.domain.setting.dto.SettingResDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@Tag(name = "알림 API")
 public interface SettingControllerDocs {
+
+    // 알림 설정 조회
+    @Operation(
+            summary = "알림 설정 조회 API",
+            description = """
+                    # 알림 설정 조회
+                    현재 알림 설정을 조회합니다. (정기 알림/정기 알림 시간/전체 알림/오늘의 장 알림/리텐션 알림/기념일 알림)
+                    
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {Access Token}
+                    
+                    ## 동작 방식
+                    1. Access Token으로 현재 회원을 인증합니다.
+                    2. 회원의 알림 설정 정보를 조회합니다.
+                    3. 전체 알림 활성화 여부(isAllNotificationEnabled)를 계산합니다.
+                    4. 알림 설정 정보를 반환합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "NOTIFICATION200_1",
+                                        "message": "알림 설정을 성공적으로 조회했습니다.",
+                                        "result": {
+                                            "regularNotificationEnabled": true,
+                                            "regularNotificationTime": "10:00",
+                                            "todayChapterNotificationEnabled": true,
+                                            "retentionNotificationEnabled": false,
+                                            "anniversaryNotificationEnabled": true,
+                                            "isAllNotificationEnabled": false
+                                        }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "memberSetting이 생성되지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "SETTING404_1",
+                                        "message": "설정을 찾을 수 없습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ApiResponse<SettingResDTO.NotificationSettings> getNotificationSettings(@Parameter(hidden = true) @AuthenticationPrincipal Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
+++ b/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
@@ -1,0 +1,25 @@
+package com.umc.halo.domain.setting.converter;
+
+import com.umc.halo.domain.setting.dto.SettingResDTO;
+import com.umc.halo.domain.setting.entity.MemberSetting;
+
+public class SettingConverter {
+
+    public static SettingResDTO.NotificationSetting toNotificationSetting(MemberSetting memberSetting
+    ) {
+        boolean isAllNotificationEnabled =
+                memberSetting.getRegularNotificationEnabled()
+                && memberSetting.getTodayChapterNotificationEnabled()
+                && memberSetting.getRetentionNotificationEnabled()
+                && memberSetting.getAnniversaryNotificationEnabled();
+
+        return SettingResDTO.NotificationSetting.builder()
+                .regularNotificationEnabled(memberSetting.getRegularNotificationEnabled())
+                .regularNotificationTime(memberSetting.getRegularNotificationTime())
+                .todayChapterNotificationEnabled(memberSetting.getTodayChapterNotificationEnabled())
+                .retentionNotificationEnabled(memberSetting.getRetentionNotificationEnabled())
+                .anniversaryNotificationEnabled(memberSetting.getAnniversaryNotificationEnabled())
+                .isAllNotificationEnabled(isAllNotificationEnabled)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
+++ b/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
@@ -1,25 +1,31 @@
 package com.umc.halo.domain.setting.converter;
 
+import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.setting.dto.SettingResDTO;
 import com.umc.halo.domain.setting.entity.MemberSetting;
 
 public class SettingConverter {
 
-    public static SettingResDTO.NotificationSetting toNotificationSetting(MemberSetting memberSetting
-    ) {
+    public static SettingResDTO.NotificationSettings toNotificationSettings(MemberSetting memberSetting) {
         boolean isAllNotificationEnabled =
                 memberSetting.getRegularNotificationEnabled()
                 && memberSetting.getTodayChapterNotificationEnabled()
                 && memberSetting.getRetentionNotificationEnabled()
                 && memberSetting.getAnniversaryNotificationEnabled();
 
-        return SettingResDTO.NotificationSetting.builder()
+        return SettingResDTO.NotificationSettings.builder()
                 .regularNotificationEnabled(memberSetting.getRegularNotificationEnabled())
                 .regularNotificationTime(memberSetting.getRegularNotificationTime())
                 .todayChapterNotificationEnabled(memberSetting.getTodayChapterNotificationEnabled())
                 .retentionNotificationEnabled(memberSetting.getRetentionNotificationEnabled())
                 .anniversaryNotificationEnabled(memberSetting.getAnniversaryNotificationEnabled())
                 .isAllNotificationEnabled(isAllNotificationEnabled)
+                .build();
+    }
+
+    public static MemberSetting toMemberSetting(Member member) {
+        return MemberSetting.builder()
+                .member(member)
                 .build();
     }
 }

--- a/src/main/java/com/umc/halo/domain/setting/dto/SettingReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/setting/dto/SettingReqDTO.java
@@ -1,0 +1,4 @@
+package com.umc.halo.domain.setting.dto;
+
+public class SettingReqDTO {
+}

--- a/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
+++ b/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
@@ -7,7 +7,7 @@ import java.time.LocalTime;
 public class SettingResDTO {
 
     @Builder
-    public record NotificationSetting(
+    public record NotificationSettings(
             Boolean regularNotificationEnabled,
             LocalTime regularNotificationTime,
             Boolean todayChapterNotificationEnabled,

--- a/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
+++ b/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
@@ -1,0 +1,18 @@
+package com.umc.halo.domain.setting.dto;
+
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+public class SettingResDTO {
+
+    @Builder
+    public record NotificationSetting(
+            Boolean regularNotificationEnabled,
+            LocalTime regularNotificationTime,
+            Boolean todayChapterNotificationEnabled,
+            Boolean retentionNotificationEnabled,
+            Boolean anniversaryNotificationEnabled,
+            Boolean isAllNotificationEnabled
+    ) {}
+}

--- a/src/main/java/com/umc/halo/domain/setting/exception/SettingException.java
+++ b/src/main/java/com/umc/halo/domain/setting/exception/SettingException.java
@@ -1,0 +1,10 @@
+package com.umc.halo.domain.setting.exception;
+
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+
+public class SettingException extends ProjectException {
+    public SettingException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/setting/exception/code/SettingErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/setting/exception/code/SettingErrorCode.java
@@ -1,12 +1,13 @@
 package com.umc.halo.domain.setting.exception.code;
 
+import com.umc.halo.global.apiPayload.code.BaseErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum SettingErrorCode {
+public enum SettingErrorCode implements BaseErrorCode {
 
     INVALID_REGULAR_NOTIFICATION_TIME(HttpStatus.BAD_REQUEST,
             "NOTIFICATION400_1",

--- a/src/main/java/com/umc/halo/domain/setting/exception/code/SettingErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/setting/exception/code/SettingErrorCode.java
@@ -23,7 +23,10 @@ public enum SettingErrorCode implements BaseErrorCode {
             "BGM 볼륨 값이 올바르지 않습니다."),
     BGM_NOT_FOUND(HttpStatus.NOT_FOUND,
             "BGM400_4",
-            "존재하지 않는 BGM입니다.")
+            "존재하지 않는 BGM입니다."),
+    SETTING_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "SETTING404_1",
+            "설정을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/umc/halo/domain/setting/exception/code/SettingErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/setting/exception/code/SettingErrorCode.java
@@ -1,0 +1,31 @@
+package com.umc.halo.domain.setting.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SettingErrorCode {
+
+    INVALID_REGULAR_NOTIFICATION_TIME(HttpStatus.BAD_REQUEST,
+            "NOTIFICATION400_1",
+            "정기 알림 시간 형식이 올바르지 않습니다."),
+    BGM_ENABLED_REQUIRED(HttpStatus.BAD_REQUEST,
+            "BGM400_1",
+            "BGM 사용 여부는 필수입니다."),
+    BGM_VOLUME_REQUIRED(HttpStatus.BAD_REQUEST,
+            "BGM400_2",
+            "BGM 볼륨은 필수입니다."),
+    INVALID_BGM_VOLUME(HttpStatus.BAD_REQUEST,
+            "BGM400_3",
+            "BGM 볼륨 값이 올바르지 않습니다."),
+    BGM_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "BGM400_4",
+            "존재하지 않는 BGM입니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/setting/exception/code/SettingSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/setting/exception/code/SettingSuccessCode.java
@@ -1,0 +1,31 @@
+package com.umc.halo.domain.setting.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SettingSuccessCode {
+
+    NOTIFICATION_SETTING_GET_SUCCESS(HttpStatus.OK,
+            "NOTIFICATION200_1",
+            "알림 설정을 성공적으로 조회했습니다."),
+    NOTIFICATION_SETTING_UPDATE_SUCCESS(HttpStatus.OK,
+            "NOTIFICATION200_2",
+            "알림 설정을 성공적으로 수정했습니다."),
+    BGM_SETTING_GET_SUCCESS(HttpStatus.OK,
+            "BGM200_1",
+            "BGM 설정 조회를 성공했습니다."),
+    BGM_SETTING_UPDATE_SUCCESS(HttpStatus.OK,
+            "BGM200_2",
+            "BGM 설정 수정을 성공했습니다."),
+    BGM_LIST_GET_SUCCESS(HttpStatus.OK,
+            "BGM200_3",
+            "BGM 목록 조회를 성공했습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/setting/exception/code/SettingSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/setting/exception/code/SettingSuccessCode.java
@@ -1,12 +1,13 @@
 package com.umc.halo.domain.setting.exception.code;
 
+import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum SettingSuccessCode {
+public enum SettingSuccessCode implements BaseSuccessCode {
 
     NOTIFICATION_SETTING_GET_SUCCESS(HttpStatus.OK,
             "NOTIFICATION200_1",

--- a/src/main/java/com/umc/halo/domain/setting/repository/MemberSettingRepository.java
+++ b/src/main/java/com/umc/halo/domain/setting/repository/MemberSettingRepository.java
@@ -4,8 +4,11 @@ import com.umc.halo.domain.setting.entity.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberSettingRepository extends JpaRepository<MemberSetting, Long> {
 
     void deleteByMemberId(Long memberId);
+    Optional<MemberSetting> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -1,0 +1,30 @@
+package com.umc.halo.domain.setting.service;
+
+import com.umc.halo.domain.member.exception.MemberException;
+import com.umc.halo.domain.member.exception.code.MemberErrorCode;
+import com.umc.halo.domain.setting.converter.SettingConverter;
+import com.umc.halo.domain.setting.dto.SettingResDTO;
+import com.umc.halo.domain.setting.entity.MemberSetting;
+import com.umc.halo.domain.setting.exception.SettingException;
+import com.umc.halo.domain.setting.exception.code.SettingErrorCode;
+import com.umc.halo.domain.setting.repository.BgmRepository;
+import com.umc.halo.domain.setting.repository.MemberSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SettingService {
+
+    private final MemberSettingRepository memberSettingRepository;
+    private final BgmRepository bgmRepository;
+
+    @Transactional(readOnly = true)
+    public SettingResDTO.NotificationSettings getNotificationSettings(Long memberId) {
+        MemberSetting memberSetting = memberSettingRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        return SettingConverter.toNotificationSettings(memberSetting);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -23,7 +23,7 @@ public class SettingService {
     @Transactional(readOnly = true)
     public SettingResDTO.NotificationSettings getNotificationSettings(Long memberId) {
         MemberSetting memberSetting = memberSettingRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new MemberException(SettingErrorCode.SETTING_NOT_FOUND));
 
         return SettingConverter.toNotificationSettings(memberSetting);
     }

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -1,7 +1,5 @@
 package com.umc.halo.domain.setting.service;
 
-import com.umc.halo.domain.member.exception.MemberException;
-import com.umc.halo.domain.member.exception.code.MemberErrorCode;
 import com.umc.halo.domain.setting.converter.SettingConverter;
 import com.umc.halo.domain.setting.dto.SettingResDTO;
 import com.umc.halo.domain.setting.entity.MemberSetting;
@@ -23,7 +21,7 @@ public class SettingService {
     @Transactional(readOnly = true)
     public SettingResDTO.NotificationSettings getNotificationSettings(Long memberId) {
         MemberSetting memberSetting = memberSettingRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new MemberException(SettingErrorCode.SETTING_NOT_FOUND));
+                .orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
 
         return SettingConverter.toNotificationSettings(memberSetting);
     }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 알림 설정 조회 API 구현
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- SettingErrorCode/SettingSuccessCode 추가
- SettingException 파일 추가
- 알림 설정 조회 관련 Request/Response DTO 추가
- 알림 설정 조회 관련 converter 추가
- GET /api/v1/settings/notifications 구현
- Swagger 문서화
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
<img width="967" height="526" alt="image" src="https://github.com/user-attachments/assets/05695b8d-30ea-4a5f-b79c-c230fb64a42f" />
<img width="965" height="467" alt="image" src="https://github.com/user-attachments/assets/015676ed-9f66-4893-80e0-4465ac244dbc" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [ ] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #61 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp


- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61?p=391ca1e217c08084b4ade373fe4d9f39&pm=s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 멤버의 알림 설정을 조회하는 API가 추가되었습니다(정기 알림 시간, 오늘의 챕터/보관/기념일 알림 상태 및 전체 활성 여부 포함).
  * 신규 회원 가입 시 기본 알림 설정이 자동으로 생성·저장됩니다.
* **문서**
  * 알림 설정 조회 API의 요청·응답 및 오류 사례가 API 문서에 추가되었습니다.
* **개선**
  * 알림 설정이 없는 경우 명확한 오류 응답을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->