### PR TITLE
[feat] 이미지 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,10 @@ dependencies {
 
     // Korean Lunar Calendar
     implementation 'com.github.usingsky:KoreanLunarCalendar:0.4.0'
+
+    // S3
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:4.0.2")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
@@ -65,6 +65,7 @@ public interface ChapterControllerDocs {
                                                                   ],
                                                                   "coverType": null,
                                                                   "imageUrl": null,
+                                                                  "imageKey": null,
                                                                   "sceneCardId": null,
                                                                   "emotion": null
                                                                 }
@@ -103,6 +104,7 @@ public interface ChapterControllerDocs {
                                                                   "answers": [],
                                                                   "coverType": null,
                                                                   "imageUrl": null,
+                                                                  "imageKey": null,
                                                                   "sceneCardId": null,
                                                                   "emotion": null
                                                                 }

--- a/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
@@ -22,6 +22,9 @@ public interface ChapterControllerDocs {
                     - 헤더: Authorization: Bearer {JWT 토큰}
                     - storybookId: 조회할 스토리북 ID
                     - chapterOrder: 조회할 장 순서 (1~10)
+
+                    ## 참고
+                    - 응답의 imageUrl은 매 요청마다 새로 발급되는 presigned GET URL이며, 발급 후 1시간 동안만 유효합니다. 캐싱하지 말고 응답받은 URL을 바로 사용해주세요.
                     """,
             responses = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
@@ -81,6 +81,7 @@ public class ChapterConverter {
                 .answers(answers.stream().map(ChapterConverter::toAnswer).toList())
                 .coverType(memberChapter.getCoverType())
                 .imageUrl(memberChapter.getImageUrl())
+                .imageKey(memberChapter.getImageKey())
                 .sceneCardId(sceneCard == null ? null : sceneCard.getId())
                 .emotion(memberChapter.getEmotion())
                 .build();

--- a/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
@@ -16,7 +16,8 @@ public class ChapterConverter {
             List<ChapterQuestion> questions,
             List<SceneCard> sceneCards,
             MemberChapter memberChapter,
-            List<MemberChapterAnswer> answers) {
+            List<MemberChapterAnswer> answers,
+            String imageUrl) {
 
         Chapter chapter = storybookChapter.getChapter();
 
@@ -41,7 +42,7 @@ public class ChapterConverter {
                 )
 
                 .draft(
-                        toDraft(memberChapter, answers)
+                        toDraft(memberChapter, answers, imageUrl)
                 )
                 .build();
     }
@@ -65,7 +66,8 @@ public class ChapterConverter {
 
     private static ChapterResDTO.TodayChapter.Draft toDraft(
             MemberChapter memberChapter,
-            List<MemberChapterAnswer> answers) {
+            List<MemberChapterAnswer> answers,
+            String imageUrl) {
         if (memberChapter == null) {
             return ChapterResDTO.TodayChapter.Draft.builder()
                     .status(ChapterResDTO.TodayChapter.DraftStatus.NONE)
@@ -80,7 +82,7 @@ public class ChapterConverter {
                 .status(ChapterResDTO.TodayChapter.DraftStatus.DRAFT)
                 .answers(answers.stream().map(ChapterConverter::toAnswer).toList())
                 .coverType(memberChapter.getCoverType())
-                .imageUrl(memberChapter.getImageUrl())
+                .imageUrl(imageUrl)
                 .imageKey(memberChapter.getImageKey())
                 .sceneCardId(sceneCard == null ? null : sceneCard.getId())
                 .emotion(memberChapter.getEmotion())

--- a/src/main/java/com/umc/halo/domain/content/chapter/dto/ChapterResDTO.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/dto/ChapterResDTO.java
@@ -48,6 +48,7 @@ public class ChapterResDTO {
                 List<Answer> answers,
                 CoverType coverType,
                 String imageUrl,
+                String imageKey,
                 Long sceneCardId,
                 Emotion emotion
         ) {

--- a/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
@@ -62,7 +62,7 @@ public class ChapterService {
 
         String imageUrl = null;
         // 사용자가 기록한 이미지 조회
-        if (memberChapter.getImageKey() != null) {
+        if (memberChapter != null && memberChapter.getImageKey() != null) {
             imageUrl = imageService.getImage(memberChapter.getImageKey());
         }
 

--- a/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
@@ -11,6 +11,7 @@ import com.umc.halo.domain.content.storybook.enums.*;
 import com.umc.halo.domain.content.storybook.exception.*;
 import com.umc.halo.domain.content.storybook.exception.code.*;
 import com.umc.halo.domain.content.storybook.repository.*;
+import com.umc.halo.domain.image.service.*;
 import com.umc.halo.domain.member.entity.*;
 import com.umc.halo.domain.member.exception.*;
 import com.umc.halo.domain.member.exception.code.*;
@@ -37,6 +38,7 @@ public class ChapterService {
     private final StorybookCharacterRepository storybookCharacterRepository;
     private final ChapterQuestionRepository chapterQuestionRepository;
     private final SceneCardRepository sceneCardRepository;
+    private final ImageService imageService;
 
     // 오늘의 장 조회
     public ChapterResDTO.TodayChapter getTodayChapter(Long memberId, Long storybookId, Integer chapterOrder) {
@@ -57,6 +59,12 @@ public class ChapterService {
 
         // memberChapter 조회
         MemberChapter memberChapter = memberChapterRepository.findByMemberAndStorybookChapter(member, storybookChapter);
+
+        String imageUrl = null;
+        // 사용자가 기록한 이미지 조회
+        if (memberChapter.getImageKey() != null) {
+            imageUrl = imageService.getImage(memberChapter.getImageKey());
+        }
 
         // memberStorybook이 있을 경우, 오늘 이미 완료했는지 검증
         memberStorybookOpt.ifPresent(ms -> {
@@ -95,7 +103,8 @@ public class ChapterService {
                 questions,
                 sceneCards,
                 memberChapter,
-                answers
+                answers,
+                imageUrl
         );
     }
 

--- a/src/main/java/com/umc/halo/domain/image/controller/ImageController.java
+++ b/src/main/java/com/umc/halo/domain/image/controller/ImageController.java
@@ -1,0 +1,28 @@
+package com.umc.halo.domain.image.controller;
+
+import com.umc.halo.domain.image.controller.docs.*;
+import com.umc.halo.domain.image.dto.*;
+import com.umc.halo.domain.image.exception.code.*;
+import com.umc.halo.domain.image.service.*;
+import com.umc.halo.global.apiPayload.*;
+import jakarta.validation.*;
+import lombok.*;
+import org.springframework.security.core.annotation.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ImageController implements ImageControllerDocs {
+
+    private final ImageService imageService;
+
+    @Override
+    @PostMapping("/v1/images/presigned-url")
+    public ApiResponse<ImageResDTO.CreatePresignedUrl> createPresignedUrl(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid ImageReqDTO.CreatePresignedUrl dto) {
+        ImageResDTO.CreatePresignedUrl result = imageService.createPresignedUrl(memberId, dto);
+        return ApiResponse.onSuccess(ImageSuccessCode.CREATE_PRESIGNED_URL, result);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/image/controller/docs/ImageControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/image/controller/docs/ImageControllerDocs.java
@@ -1,0 +1,112 @@
+package com.umc.halo.domain.image.controller.docs;
+
+import com.umc.halo.domain.image.dto.*;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.*;
+import io.swagger.v3.oas.annotations.responses.*;
+import io.swagger.v3.oas.annotations.tags.*;
+import org.springframework.security.core.annotation.*;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "이미지 API")
+public interface ImageControllerDocs {
+
+    // presigned URL 발급
+    @Operation(
+            summary = "presigned URL 발급 API",
+            description = """
+                    # presigned URL 발급
+                    이미지를 S3에 직접 업로드할 수 있는 presigned URL을 발급합니다. 실제 파일 업로드는 서버를 거치지 않고 클라이언트가 이 URL로 S3에 직접 PUT합니다.
+                    
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {Access Token}
+                    - **Body**
+                        - contentType : 업로드할 이미지의 MIME 타입 (image/png, image/jpeg, image/jpg, image/webp만 허용)
+                    
+                    ## 동작 방식
+                    1. Access Token으로 현재 회원을 인증합니다.
+                    2. contentType이 허용된 이미지 형식인지 검증합니다.
+                    3. 회원별로 구분되는 imageKey를 생성합니다.
+                    4. 5분간 유효한 presigned URL을 발급합니다.
+                    5. 클라이언트는 이 presignedUrl로 S3에 직접 PUT하여 이미지를 업로드합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "IMAGE200_1",
+                                        "message": "presigned URL을 성공적으로 발급했습니다.",
+                                        "result": {
+                                            "presignedUrl": "https://halo-bucket.s3.ap-northeast-2.amazonaws.com/images/1/9f1c2e3a-....png?X-Amz-Algorithm=...",
+                                            "imageUrl": "https://halo-bucket.s3.ap-northeast-2.amazonaws.com/images/1/9f1c2e3a-....png",
+                                            "imageKey": "images/1/9f1c2e3a-....png",
+                                            "expires": 300
+                                        }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "지원하지 않는 파일 형식",
+                                            value = """
+                                                    {
+                                                        "isSuccess": false,
+                                                        "code": "IMAGE400_1",
+                                                        "message": "지원하지 않는 파일 형식입니다.",
+                                                        "result": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "contentType이 비어있음",
+                                            value = """
+                                                    {
+                                                        "isSuccess": false,
+                                                        "code": "COMMON400_1",
+                                                        "message": "잘못된 요청입니다.",
+                                                        "result": {
+                                                            "contentType": "contentType을 입력해주세요."
+                                                        }
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_1",
+                                        "message": "토큰이 만료되었습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ApiResponse<ImageResDTO.CreatePresignedUrl> createPresignedUrl(
+            @Parameter(hidden = true) @AuthenticationPrincipal Long memberId,
+            @RequestBody ImageReqDTO.CreatePresignedUrl dto);
+}

--- a/src/main/java/com/umc/halo/domain/image/controller/docs/ImageControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/image/controller/docs/ImageControllerDocs.java
@@ -25,6 +25,7 @@ public interface ImageControllerDocs {
                         - Authorization: Bearer {Access Token}
                     - **Body**
                         - contentType : 업로드할 이미지의 MIME 타입 (image/png, image/jpeg, image/jpg, image/webp만 허용)
+                        - fileSize : 업로드할 이미지의 파일 크기(byte, 0보다 큰 값 필수)
                     
                     ## 동작 방식
                     1. Access Token으로 현재 회원을 인증합니다.
@@ -82,6 +83,32 @@ public interface ImageControllerDocs {
                                                         "message": "잘못된 요청입니다.",
                                                         "result": {
                                                             "contentType": "contentType을 입력해주세요."
+                                                        }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "fileSize 미입력",
+                                            value = """
+                                                    {
+                                                        "isSuccess": false,
+                                                        "code": "COMMON400_1",
+                                                        "message": "잘못된 요청입니다.",
+                                                        "result": {
+                                                            "fileSize": "fileSize를 입력해주세요."
+                                                        }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "fileSize가 0 이하",
+                                            value = """
+                                                    {
+                                                        "isSuccess": false,
+                                                        "code": "COMMON400_1",
+                                                        "message": "잘못된 요청입니다.",
+                                                        "result": {
+                                                            "fileSize": "fileSize는 0보다 커야 합니다."
                                                         }
                                                     }
                                                     """

--- a/src/main/java/com/umc/halo/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/umc/halo/domain/image/converter/ImageConverter.java
@@ -1,0 +1,36 @@
+package com.umc.halo.domain.image.converter;
+
+import com.umc.halo.domain.image.dto.*;
+import com.umc.halo.domain.image.enums.*;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.model.*;
+
+import java.time.*;
+
+public class ImageConverter {
+
+    public static PutObjectRequest toPutObjectRequest(String bucket, String imageKey, ImageContentType contentType) {
+        return PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(imageKey)
+                .contentType(contentType.getMimeType())
+                .build();
+    }
+
+    public static PutObjectPresignRequest toPutObjectPresignRequest(Duration expiration, PutObjectRequest putObjectRequest) {
+        return PutObjectPresignRequest.builder()
+                .signatureDuration(expiration)
+                .putObjectRequest(putObjectRequest)
+                .build();
+    }
+
+    public static ImageResDTO.CreatePresignedUrl toCreatePresignedUrl(
+            PresignedPutObjectRequest presignedPutObjectRequest, String imageKey, String imageUrl, Duration expiration) {
+        return ImageResDTO.CreatePresignedUrl.builder()
+                .presignedUrl(presignedPutObjectRequest.url().toString())
+                .imageKey(imageKey)
+                .imageUrl(imageUrl)
+                .expires((int) expiration.toSeconds())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/halo/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/umc/halo/domain/image/converter/ImageConverter.java
@@ -57,4 +57,18 @@ public class ImageConverter {
                 .key(imageKey)
                 .build();
     }
+
+    public static GetObjectRequest toGetObjectRequest(String bucket, String imageKey) {
+        return GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(imageKey)
+                .build();
+    }
+
+    public static GetObjectPresignRequest toGetObjectPresignRequest(Duration expiration, GetObjectRequest getObjectRequest) {
+        return GetObjectPresignRequest.builder()
+                .signatureDuration(expiration)
+                .getObjectRequest(getObjectRequest)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/halo/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/umc/halo/domain/image/converter/ImageConverter.java
@@ -9,11 +9,12 @@ import java.time.*;
 
 public class ImageConverter {
 
-    public static PutObjectRequest toPutObjectRequest(String bucket, String imageKey, ImageContentType contentType) {
+    public static PutObjectRequest toPutObjectRequest(String bucket, String imageKey, ImageContentType contentType, long fileSize) {
         return PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(imageKey)
                 .contentType(contentType.getMimeType())
+                .contentLength(fileSize)
                 .build();
     }
 
@@ -31,6 +32,29 @@ public class ImageConverter {
                 .imageKey(imageKey)
                 .imageUrl(imageUrl)
                 .expires((int) expiration.toSeconds())
+                .build();
+    }
+
+    public static CopyObjectRequest toCopyObjectRequest(String bucket, String imageKey, String finalKey) {
+        return CopyObjectRequest.builder()
+                .sourceBucket(bucket)
+                .sourceKey(imageKey)
+                .destinationBucket(bucket)
+                .destinationKey(finalKey)
+                .build();
+    }
+
+    public static DeleteObjectRequest toDeleteObjectRequest(String bucket, String imageKey) {
+        return DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(imageKey)
+                .build();
+    }
+
+    public static HeadObjectRequest toHeadObjectRequest(String bucket, String imageKey) {
+        return HeadObjectRequest.builder()
+                .bucket(bucket)
+                .key(imageKey)
                 .build();
     }
 }

--- a/src/main/java/com/umc/halo/domain/image/dto/ImageReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/image/dto/ImageReqDTO.java
@@ -5,7 +5,10 @@ import jakarta.validation.constraints.*;
 public class ImageReqDTO {
     public record CreatePresignedUrl(
             @NotBlank(message = "contentType을 입력해주세요.")
-            String contentType
+            String contentType,
+            @NotNull(message = "fileSize를 입력해주세요.")
+            @Positive(message = "fileSize는 0보다 커야 합니다.")
+            Long fileSize
     ) {
     }
 }

--- a/src/main/java/com/umc/halo/domain/image/dto/ImageReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/image/dto/ImageReqDTO.java
@@ -1,0 +1,11 @@
+package com.umc.halo.domain.image.dto;
+
+import jakarta.validation.constraints.*;
+
+public class ImageReqDTO {
+    public record CreatePresignedUrl(
+            @NotBlank(message = "contentType을 입력해주세요.")
+            String contentType
+    ) {
+    }
+}

--- a/src/main/java/com/umc/halo/domain/image/dto/ImageResDTO.java
+++ b/src/main/java/com/umc/halo/domain/image/dto/ImageResDTO.java
@@ -1,0 +1,15 @@
+package com.umc.halo.domain.image.dto;
+
+
+import lombok.*;
+
+public class ImageResDTO {
+    @Builder
+    public record CreatePresignedUrl(
+            String presignedUrl,
+            String imageUrl,
+            String imageKey,
+            Integer expires
+    ) {
+    }
+}

--- a/src/main/java/com/umc/halo/domain/image/enums/ImageContentType.java
+++ b/src/main/java/com/umc/halo/domain/image/enums/ImageContentType.java
@@ -1,0 +1,27 @@
+package com.umc.halo.domain.image.enums;
+
+import com.umc.halo.domain.image.exception.*;
+import com.umc.halo.domain.image.exception.code.*;
+import lombok.*;
+
+import java.util.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageContentType {
+
+    PNG("image/png", ".png"),
+    JPEG("image/jpeg", ".jpg"),
+    JPG("image/jpg", ".jpg"),
+    WEBP("image/webp", ".webp");
+
+    private final String mimeType;
+    private final String extension;
+
+    public static ImageContentType from(String mimeType) {
+        return Arrays.stream(values())
+                .filter(type -> type.getMimeType().equalsIgnoreCase(mimeType))
+                .findFirst()
+                .orElseThrow(() -> new ImageException(ImageErrorCode.INVALID_CONTENT_TYPE));
+    }
+}

--- a/src/main/java/com/umc/halo/domain/image/exception/ImageException.java
+++ b/src/main/java/com/umc/halo/domain/image/exception/ImageException.java
@@ -1,0 +1,10 @@
+package com.umc.halo.domain.image.exception;
+
+import com.umc.halo.global.apiPayload.code.*;
+import com.umc.halo.global.apiPayload.exception.*;
+
+public class ImageException extends ProjectException {
+    public ImageException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/umc/halo/domain/image/exception/code/ImageErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/image/exception/code/ImageErrorCode.java
@@ -1,0 +1,16 @@
+package com.umc.halo.domain.image.exception.code;
+
+import com.umc.halo.global.apiPayload.code.*;
+import lombok.*;
+import org.springframework.http.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode implements BaseErrorCode {
+
+    INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "IMAGE400_1", "지원하지 않는 파일 형식입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/image/exception/code/ImageErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/image/exception/code/ImageErrorCode.java
@@ -11,7 +11,7 @@ public enum ImageErrorCode implements BaseErrorCode {
     INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "IMAGE400_1", "지원하지 않는 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "IMAGE400_2", "이미지 용량이 제한을 초과했습니다.(최대 10MB)"),
     FORBIDDEN_IMAGE_KEY(HttpStatus.FORBIDDEN, "IMAGE403_1", "본인이 업로드한 이미지가 아닙니다."),
-    NOT_FOUND_IN_S3(HttpStatus.NOT_FOUND, "IMAGE404_3", "S3에 해당 이미지가 존재하지 않습니다.");
+    NOT_FOUND_IN_S3(HttpStatus.NOT_FOUND, "IMAGE404_1", "S3에 해당 이미지가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/halo/domain/image/exception/code/ImageErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/image/exception/code/ImageErrorCode.java
@@ -8,7 +8,10 @@ import org.springframework.http.*;
 @RequiredArgsConstructor
 public enum ImageErrorCode implements BaseErrorCode {
 
-    INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "IMAGE400_1", "지원하지 않는 파일 형식입니다.");
+    INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "IMAGE400_1", "지원하지 않는 파일 형식입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "IMAGE400_2", "이미지 용량이 제한을 초과했습니다.(최대 10MB)"),
+    FORBIDDEN_IMAGE_KEY(HttpStatus.FORBIDDEN, "IMAGE403_1", "본인이 업로드한 이미지가 아닙니다."),
+    NOT_FOUND_IN_S3(HttpStatus.NOT_FOUND, "IMAGE404_3", "S3에 해당 이미지가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/halo/domain/image/exception/code/ImageSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/image/exception/code/ImageSuccessCode.java
@@ -1,0 +1,16 @@
+package com.umc.halo.domain.image.exception.code;
+
+import com.umc.halo.global.apiPayload.code.*;
+import lombok.*;
+import org.springframework.http.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageSuccessCode implements BaseSuccessCode {
+
+    CREATE_PRESIGNED_URL(HttpStatus.OK, "IMAGE200_1", "presigned URL을 성공적으로 발급했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -102,6 +102,16 @@ public class ImageService {
         return new FinalizedImage(finalKey, buildImageUrl(finalKey));
     }
 
+    // imageKey로 조회용 presigned URL 발급
+    public String getImage(String imageKey) {
+        GetObjectRequest getObjectRequest = ImageConverter.toGetObjectRequest(bucket, imageKey);
+        GetObjectPresignRequest getObjectPresignRequest = ImageConverter.toGetObjectPresignRequest(EXPIRATION, getObjectRequest);
+        PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner.presignGetObject(getObjectPresignRequest);
+
+        return presignedGetObjectRequest.url().toString();
+
+    }
+
     public record FinalizedImage(String finalKey, String imageUrl) {
     }
 }

--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -65,8 +65,20 @@ public class ImageService {
     // DB에 저장시 
     public FinalizedImage finalizeImage(Long memberId, String imageKey) {
 
-        // pending/images 가 아닐 경우에도 통과
-        if (imageKey == null || !imageKey.startsWith(PENDING_PREFIX)) {
+        if (imageKey == null) {
+            return new FinalizedImage(null, null);
+        }
+
+        // 이미 finalize된 imageKey인 경우 소유권 및 실재 여부 확인
+        if (!imageKey.startsWith(PENDING_PREFIX)) {
+            if (!imageKey.startsWith("images/" + memberId + "/")) {
+                throw new ImageException(ImageErrorCode.FORBIDDEN_IMAGE_KEY);
+            }
+            try {
+                s3Client.headObject(ImageConverter.toHeadObjectRequest(bucket, imageKey));
+            } catch (NoSuchKeyException e) {
+                throw new ImageException(ImageErrorCode.NOT_FOUND_IN_S3);
+            }
             return new FinalizedImage(imageKey, buildImageUrl(imageKey));
         }
 

--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -1,0 +1,48 @@
+package com.umc.halo.domain.image.service;
+
+import com.umc.halo.domain.image.converter.*;
+import com.umc.halo.domain.image.dto.*;
+import com.umc.halo.domain.image.enums.*;
+import lombok.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.*;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.*;
+import software.amazon.awssdk.services.s3.presigner.model.*;
+
+import java.time.*;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private static final Duration EXPIRATION = Duration.ofMinutes(5);
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    public ImageResDTO.CreatePresignedUrl createPresignedUrl(
+            Long memberId, ImageReqDTO.CreatePresignedUrl dto) {
+
+        ImageContentType contentType = ImageContentType.from(dto.contentType());
+        String imageKey = generateImageKey(memberId, contentType);
+
+        PutObjectRequest putObjectRequest = ImageConverter.toPutObjectRequest(bucket, imageKey, contentType);
+        PutObjectPresignRequest putPresignRequest = ImageConverter.toPutObjectPresignRequest(EXPIRATION, putObjectRequest);
+        PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putPresignRequest);
+
+        String imageUrl = "https://%s.s3.%s.amazonaws.com/%s".formatted(bucket, region, imageKey);
+
+        return ImageConverter.toCreatePresignedUrl(presignedPutObjectRequest, imageKey, imageUrl, EXPIRATION);
+    }
+
+    private String generateImageKey(Long memberId, ImageContentType contentType) {
+        return "images/" + memberId + "/" + UUID.randomUUID() + contentType.getExtension();
+    }
+}

--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -21,6 +21,7 @@ import java.util.*;
 public class ImageService {
 
     private static final Duration EXPIRATION = Duration.ofMinutes(5);
+    private static final Duration READ_EXPIRATION = Duration.ofHours(1);
     private static final String PENDING_PREFIX = "pending/";
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
 
@@ -117,7 +118,7 @@ public class ImageService {
     // imageKey로 조회용 presigned URL 발급
     public String getImage(String imageKey) {
         GetObjectRequest getObjectRequest = ImageConverter.toGetObjectRequest(bucket, imageKey);
-        GetObjectPresignRequest getObjectPresignRequest = ImageConverter.toGetObjectPresignRequest(EXPIRATION, getObjectRequest);
+        GetObjectPresignRequest getObjectPresignRequest = ImageConverter.toGetObjectPresignRequest(READ_EXPIRATION, getObjectRequest);
         PresignedGetObjectRequest presignedGetObjectRequest = s3Presigner.presignGetObject(getObjectPresignRequest);
 
         return presignedGetObjectRequest.url().toString();

--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -3,9 +3,12 @@ package com.umc.halo.domain.image.service;
 import com.umc.halo.domain.image.converter.*;
 import com.umc.halo.domain.image.dto.*;
 import com.umc.halo.domain.image.enums.*;
+import com.umc.halo.domain.image.exception.*;
+import com.umc.halo.domain.image.exception.code.*;
 import lombok.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.*;
+import software.amazon.awssdk.services.s3.*;
 import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.*;
 import software.amazon.awssdk.services.s3.presigner.model.*;
@@ -18,8 +21,11 @@ import java.util.*;
 public class ImageService {
 
     private static final Duration EXPIRATION = Duration.ofMinutes(5);
+    private static final String PENDING_PREFIX = "pending/";
+    private static final long MAX_FILE_SIZE = 10 * 1024 * 1024;
 
     private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
@@ -27,22 +33,75 @@ public class ImageService {
     @Value("${spring.cloud.aws.region.static}")
     private String region;
 
+    // presigned Url 발급
     public ImageResDTO.CreatePresignedUrl createPresignedUrl(
             Long memberId, ImageReqDTO.CreatePresignedUrl dto) {
 
+        if (dto.fileSize() > MAX_FILE_SIZE) {
+            throw new ImageException(ImageErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
         ImageContentType contentType = ImageContentType.from(dto.contentType());
         String imageKey = generateImageKey(memberId, contentType);
+        String imageUrl = buildImageUrl(imageKey);
 
-        PutObjectRequest putObjectRequest = ImageConverter.toPutObjectRequest(bucket, imageKey, contentType);
+        PutObjectRequest putObjectRequest = ImageConverter.toPutObjectRequest(bucket, imageKey, contentType, dto.fileSize());
         PutObjectPresignRequest putPresignRequest = ImageConverter.toPutObjectPresignRequest(EXPIRATION, putObjectRequest);
         PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putPresignRequest);
-
-        String imageUrl = "https://%s.s3.%s.amazonaws.com/%s".formatted(bucket, region, imageKey);
 
         return ImageConverter.toCreatePresignedUrl(presignedPutObjectRequest, imageKey, imageUrl, EXPIRATION);
     }
 
+    // imageKey 발급 (presigned URL 발급시, pending/images/)
     private String generateImageKey(Long memberId, ImageContentType contentType) {
-        return "images/" + memberId + "/" + UUID.randomUUID() + contentType.getExtension();
+        return PENDING_PREFIX + "images/" + memberId + "/" + UUID.randomUUID() + contentType.getExtension();
+    }
+
+    // imageUrl 생성
+    private String buildImageUrl(String imageKey) {
+        return "https://%s.s3.%s.amazonaws.com/%s".formatted(bucket, region, imageKey);
+    }
+
+    // DB에 저장시 
+    public FinalizedImage finalizeImage(Long memberId, String imageKey) {
+
+        // pending/images 가 아닐 경우에도 통과
+        if (imageKey == null || !imageKey.startsWith(PENDING_PREFIX)) {
+            return new FinalizedImage(imageKey, buildImageUrl(imageKey));
+        }
+
+        // 자신의 imageKey가 아닐 경우
+        if (!imageKey.startsWith(PENDING_PREFIX + "images/" + memberId + "/")) {
+            throw new ImageException(ImageErrorCode.FORBIDDEN_IMAGE_KEY);
+        }
+
+        // 실제로 업로드된 파일인지 확인
+        HeadObjectResponse headObjectResponse;
+        try {
+            headObjectResponse = s3Client.headObject(ImageConverter.toHeadObjectRequest(bucket, imageKey));
+        } catch (NoSuchKeyException e) {
+            throw new ImageException(ImageErrorCode.NOT_FOUND_IN_S3);
+        }
+
+        // 실제 용량이 제한 이내인지 확인
+        if (headObjectResponse.contentLength() > MAX_FILE_SIZE) {
+            throw new ImageException(ImageErrorCode.FILE_SIZE_EXCEEDED);
+        }
+
+        // pending/images -> images
+        String finalKey = imageKey.substring("pending/".length());
+
+        // pending/images -> images 복제
+        CopyObjectRequest copyObjectRequest = ImageConverter.toCopyObjectRequest(bucket, imageKey, finalKey);
+        s3Client.copyObject(copyObjectRequest);
+
+        // pending/images 삭제
+        DeleteObjectRequest deleteObjectRequest = ImageConverter.toDeleteObjectRequest(bucket, imageKey);
+        s3Client.deleteObject(deleteObjectRequest);
+
+        return new FinalizedImage(finalKey, buildImageUrl(finalKey));
+    }
+
+    public record FinalizedImage(String finalKey, String imageUrl) {
     }
 }

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -316,7 +316,7 @@ public interface RecordControllerDocs {
                                                     value = """
                                                             {
                                                                 "isSuccess": false,
-                                                                "code": "IMAGE404_3",
+                                                                "code": "IMAGE404_1",
                                                                 "message": "S3에 해당 이미지가 존재하지 않습니다.",
                                                                 "result": null
                                                             }

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -186,6 +186,17 @@ public interface RecordControllerDocs {
                                                                 }
                                                             }
                                                             """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "이미지 용량 제한 초과",
+                                                    value = """
+                                                            {
+                                                                "isSuccess": false,
+                                                                "code": "IMAGE400_2",
+                                                                "message": "이미지 용량이 제한을 초과했습니다.(최대 10MB)",
+                                                                "result": null
+                                                            }
+                                                            """
                                             )
                                     }
                             )
@@ -208,7 +219,7 @@ public interface RecordControllerDocs {
                     ),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "403",
-                            description = "아직 열리지 않았거나 이미 완료한 장",
+                            description = "아직 열리지 않았거나 이미 완료한 장 / 본인이 업로드한 이미지가 아님",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ApiResponse.class),
@@ -234,13 +245,24 @@ public interface RecordControllerDocs {
                                                                 "result": null
                                                             }
                                                             """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "본인이 업로드한 이미지가 아님(imageKey)",
+                                                    value = """
+                                                            {
+                                                                "isSuccess": false,
+                                                                "code": "IMAGE403_1",
+                                                                "message": "본인이 업로드한 이미지가 아닙니다.",
+                                                                "result": null
+                                                            }
+                                                            """
                                             )
                                     }
                             )
                     ),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "404",
-                            description = "존재하지 않는 회원 / 장 / 장 질문 / 장면 카드",
+                            description = "존재하지 않는 회원 / 장 / 장 질문 / 장면 카드 / S3 이미지",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ApiResponse.class),
@@ -285,6 +307,17 @@ public interface RecordControllerDocs {
                                                                 "isSuccess": false,
                                                                 "code": "CHAPTER404_3",
                                                                 "message": "존재하지 않는 장면 카드입니다.",
+                                                                "result": null
+                                                            }
+                                                            """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "S3에 해당 이미지가 존재하지 않음(imageKey)",
+                                                    value = """
+                                                            {
+                                                                "isSuccess": false,
+                                                                "code": "IMAGE404_3",
+                                                                "message": "S3에 해당 이미지가 존재하지 않습니다.",
                                                                 "result": null
                                                             }
                                                             """

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -374,6 +374,9 @@ public interface RecordControllerDocs {
                     ## 요청 형식
                     - 헤더: Authorization: Bearer {JWT 토큰}
                     - memberChapterId: 사용자 장 ID (path variable)
+
+                    ## 참고
+                    - 응답의 imageUrl은 매 요청마다 새로 발급되는 presigned GET URL이며, 발급 후 1시간 동안만 유효합니다. 캐싱하지 말고 응답받은 URL을 바로 사용해주세요.
                     """,
             responses = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/umc/halo/domain/record/converter/RecordConverter.java
+++ b/src/main/java/com/umc/halo/domain/record/converter/RecordConverter.java
@@ -19,7 +19,7 @@ public class RecordConverter {
                 .build();
     }
 
-    public static RecordResDTO.ReadChapterRecord toReadChapterRecord(MemberChapter memberChapter, List<RecordResDTO.ReadChapterRecord.Answer> answer) {
+    public static RecordResDTO.ReadChapterRecord toReadChapterRecord(MemberChapter memberChapter, List<RecordResDTO.ReadChapterRecord.Answer> answer, String imageUrl) {
         CoverType coverType = memberChapter.getCoverType();
         Chapter chapter = memberChapter.getStorybookChapter().getChapter();
 
@@ -32,7 +32,7 @@ public class RecordConverter {
                 .chapterImageUrl(chapter.getImageUrl())
                 .emotion(memberChapter.getEmotion())
                 .coverType(coverType)
-                .imageUrl(coverType == CoverType.IMAGE ? memberChapter.getImageUrl() : null)
+                .imageUrl(coverType == CoverType.IMAGE ? imageUrl : null)
                 .sceneCardImageUrl(coverType == CoverType.SCENE_CARD ? memberChapter.getSceneCard().getImageUrl() : null)
                 .answers(answer)
                 .completedDate(memberChapter.getCompletedDate())
@@ -47,7 +47,7 @@ public class RecordConverter {
     }
 
     public static MemberChapter toMemberChapter(Member member, StorybookChapter storybookChapter, SceneCard sceneCard,
-                                                 RecordReqDTO.WriteChapterRecord recordReqDTO, String imageUrl, String imageKey) {
+                                                RecordReqDTO.WriteChapterRecord recordReqDTO, String imageUrl, String imageKey) {
         return MemberChapter.builder()
                 .member(member)
                 .storybookChapter(storybookChapter)

--- a/src/main/java/com/umc/halo/domain/record/converter/RecordConverter.java
+++ b/src/main/java/com/umc/halo/domain/record/converter/RecordConverter.java
@@ -46,14 +46,15 @@ public class RecordConverter {
                 .build();
     }
 
-    public static MemberChapter toMemberChapter(Member member, StorybookChapter storybookChapter, SceneCard sceneCard, RecordReqDTO.WriteChapterRecord recordReqDTO) {
+    public static MemberChapter toMemberChapter(Member member, StorybookChapter storybookChapter, SceneCard sceneCard,
+                                                 RecordReqDTO.WriteChapterRecord recordReqDTO, String imageUrl, String imageKey) {
         return MemberChapter.builder()
                 .member(member)
                 .storybookChapter(storybookChapter)
                 .sceneCard(sceneCard)
                 .coverType(recordReqDTO.coverType())
-                .imageUrl(recordReqDTO.imageUrl())
-                .imageKey(recordReqDTO.imageKey())
+                .imageUrl(imageUrl)
+                .imageKey(imageKey)
                 .status(recordReqDTO.status())
                 .emotion(recordReqDTO.emotion())
                 .completedDate(recordReqDTO.status() == Status.COMPLETED ? LocalDate.now() : null)

--- a/src/main/java/com/umc/halo/domain/record/converter/RecordConverter.java
+++ b/src/main/java/com/umc/halo/domain/record/converter/RecordConverter.java
@@ -47,13 +47,12 @@ public class RecordConverter {
     }
 
     public static MemberChapter toMemberChapter(Member member, StorybookChapter storybookChapter, SceneCard sceneCard,
-                                                RecordReqDTO.WriteChapterRecord recordReqDTO, String imageUrl, String imageKey) {
+                                                RecordReqDTO.WriteChapterRecord recordReqDTO, String imageKey) {
         return MemberChapter.builder()
                 .member(member)
                 .storybookChapter(storybookChapter)
                 .sceneCard(sceneCard)
                 .coverType(recordReqDTO.coverType())
-                .imageUrl(imageUrl)
                 .imageKey(imageKey)
                 .status(recordReqDTO.status())
                 .emotion(recordReqDTO.emotion())

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberChapter.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberChapter.java
@@ -46,9 +46,6 @@ public class MemberChapter extends BaseEntity {
     @Column(name = "cover_type")
     private CoverType coverType;
 
-    @Column(name = "image_url", length = 255)
-    private String imageUrl;
-
     @Column(name = "image_key", length = 255)
     private String imageKey;
 
@@ -63,13 +60,12 @@ public class MemberChapter extends BaseEntity {
     private Status status;
 
     public void updateRecord(StorybookChapter storybookChapter, SceneCard sceneCard, Emotion emotion,
-                             CoverType coverType, String imageUrl, String imageKey, Status status) {
+                             CoverType coverType, String imageKey, Status status) {
 
         this.storybookChapter = storybookChapter;
         this.sceneCard = sceneCard;
         this.emotion = emotion;
         this.coverType = coverType;
-        this.imageUrl = imageUrl;
         this.imageKey = imageKey;
         this.status = status;
         this.completedDate = (status == Status.COMPLETED) ? LocalDate.now() : null;

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -129,20 +129,19 @@ public class RecordService {
             }
         }
 
-        String imageUrl = finalizedImage != null ? finalizedImage.imageUrl() : null;
         String imageKey = finalizedImage != null ? finalizedImage.finalKey() : null;
 
         // MemberChapter 없으면 생성, 있으면 수정
         if (memberChapter == null) {
             try {
-                memberChapter = RecordConverter.toMemberChapter(member, storybookChapter, sceneCard, recordReqDTO, imageUrl, imageKey);
+                memberChapter = RecordConverter.toMemberChapter(member, storybookChapter, sceneCard, recordReqDTO, imageKey);
                 memberChapterRepository.save(memberChapter);
             } catch (DataIntegrityViolationException e) {
                 throw new RecordException(RecordErrorCode.DUPLICATE_MEMBER_CHAPTER);
             }
         } else {
             memberChapter.updateRecord(storybookChapter, sceneCard, recordReqDTO.emotion(),
-                    recordReqDTO.coverType(), imageUrl, imageKey, recordReqDTO.status());
+                    recordReqDTO.coverType(), imageKey, recordReqDTO.status());
         }
 
         final MemberChapter resolvedMemberChapter = memberChapter;

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -75,7 +75,7 @@ public class RecordService {
                 storybookChapter.getChapterOrder(), memberChapter, memberStorybook);
 
         // CoverType 확인
-        ImageService.FinalizedImage finalizedImage = null;
+        String imageKey = null;
         if (recordReqDTO.coverType() != null) {
             if (recordReqDTO.coverType() == CoverType.IMAGE) {
                 if (recordReqDTO.sceneCardId() != null) {
@@ -84,7 +84,12 @@ public class RecordService {
                 if ((recordReqDTO.imageUrl() == null) || (recordReqDTO.imageKey() == null)) {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
                 }
-                finalizedImage = imageService.finalizeImage(memberId, recordReqDTO.imageKey());
+                // 기존 기록의 imageKey와 동일하면 그대로 사용
+                if (memberChapter != null && recordReqDTO.imageKey().equals(memberChapter.getImageKey())) {
+                    imageKey = memberChapter.getImageKey();
+                } else {
+                    imageKey = imageService.finalizeImage(memberId, recordReqDTO.imageKey()).finalKey();
+                }
             } else {
                 if ((recordReqDTO.imageKey() != null) || (recordReqDTO.imageUrl() != null)) {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
@@ -128,8 +133,6 @@ public class RecordService {
                 throw new ChapterException(ChapterErrorCode.UNMATCHED_SCENE_CARD);
             }
         }
-
-        String imageKey = finalizedImage != null ? finalizedImage.finalKey() : null;
 
         // MemberChapter 없으면 생성, 있으면 수정
         if (memberChapter == null) {

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -7,6 +7,7 @@ import com.umc.halo.domain.content.chapter.repository.*;
 import com.umc.halo.domain.content.chapter.service.*;
 import com.umc.halo.domain.content.storybook.entity.*;
 import com.umc.halo.domain.content.storybook.repository.*;
+import com.umc.halo.domain.image.service.*;
 import com.umc.halo.domain.member.entity.*;
 import com.umc.halo.domain.member.exception.*;
 import com.umc.halo.domain.member.exception.code.*;
@@ -41,6 +42,7 @@ public class RecordService {
     private final ChapterQuestionRepository chapterQuestionRepository;
     private final ChapterService chapterService;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final ImageService imageService;
 
     @Transactional
     public RecordResDTO.WriteChapterRecord writeChapterRecord(Long memberId, RecordReqDTO.WriteChapterRecord recordReqDTO) {
@@ -73,6 +75,7 @@ public class RecordService {
                 storybookChapter.getChapterOrder(), memberChapter, memberStorybook);
 
         // CoverType 확인
+        ImageService.FinalizedImage finalizedImage = null;
         if (recordReqDTO.coverType() != null) {
             if (recordReqDTO.coverType() == CoverType.IMAGE) {
                 if (recordReqDTO.sceneCardId() != null) {
@@ -81,6 +84,7 @@ public class RecordService {
                 if ((recordReqDTO.imageUrl() == null) || (recordReqDTO.imageKey() == null)) {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
                 }
+                finalizedImage = imageService.finalizeImage(memberId, recordReqDTO.imageKey());
             } else {
                 if ((recordReqDTO.imageKey() != null) || (recordReqDTO.imageUrl() != null)) {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
@@ -125,17 +129,20 @@ public class RecordService {
             }
         }
 
+        String imageUrl = finalizedImage != null ? finalizedImage.imageUrl() : null;
+        String imageKey = finalizedImage != null ? finalizedImage.finalKey() : null;
+
         // MemberChapter 없으면 생성, 있으면 수정
         if (memberChapter == null) {
             try {
-                memberChapter = RecordConverter.toMemberChapter(member, storybookChapter, sceneCard, recordReqDTO);
+                memberChapter = RecordConverter.toMemberChapter(member, storybookChapter, sceneCard, recordReqDTO, imageUrl, imageKey);
                 memberChapterRepository.save(memberChapter);
             } catch (DataIntegrityViolationException e) {
                 throw new RecordException(RecordErrorCode.DUPLICATE_MEMBER_CHAPTER);
             }
         } else {
             memberChapter.updateRecord(storybookChapter, sceneCard, recordReqDTO.emotion(),
-                    recordReqDTO.coverType(), recordReqDTO.imageUrl(), recordReqDTO.imageKey(), recordReqDTO.status());
+                    recordReqDTO.coverType(), imageUrl, imageKey, recordReqDTO.status());
         }
 
         final MemberChapter resolvedMemberChapter = memberChapter;

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -98,6 +98,10 @@ public class RecordService {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
                 }
             }
+        } else {
+            if ((recordReqDTO.sceneCardId() != null) || (recordReqDTO.imageKey() != null) || (recordReqDTO.imageUrl() != null)) {
+                throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
+            }
         }
 
         // COMPLETED 상태일 경우 필수값 검증

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -214,6 +214,12 @@ public class RecordService {
         MemberChapter memberChapter = memberChapterRepository.findById(memberChapterId)
                 .orElseThrow(() -> new RecordException(RecordErrorCode.NOT_FOUND_MEMBER_CHAPTER));
 
+        // 사용자가 기록한 이미지 조회
+        String imageUrl = null;
+        if (memberChapter.getCoverType() == CoverType.IMAGE) {
+            imageUrl = imageService.getImage(memberChapter.getImageKey());
+        }
+
         // member의 memberChapter인지 검증
         if (!memberChapter.getMember().getId().equals(member.getId())) {
             throw new RecordException(RecordErrorCode.NOT_FOUND_MEMBER_CHAPTER);
@@ -230,6 +236,6 @@ public class RecordService {
                 .map(RecordConverter::toAnswer)
                 .toList();
 
-        return RecordConverter.toReadChapterRecord(memberChapter, answerList);
+        return RecordConverter.toReadChapterRecord(memberChapter, answerList, imageUrl);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,16 @@ spring:
       hibernate:
         format_sql: true
 
+  cloud:
+    aws:
+      s3:
+        bucket: ${S3_BUCKET_NAME}
+      credentials:
+        accessKey: ${S3_BUCKET_ACCESS_KEY}
+        secretKey: ${S3_BUCKET_SECRET_KEY}
+      region:
+        static: ap-northeast-2
+
 logging:
   level:
     root: info
@@ -43,3 +53,4 @@ google:
 gemini:
   api-key: ${GEMINI_API_KEY}
   model: gemini-flash-lite-latest
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,8 +23,8 @@ spring:
       s3:
         bucket: ${S3_BUCKET_NAME}
       credentials:
-        accessKey: ${S3_BUCKET_ACCESS_KEY}
-        secretKey: ${S3_BUCKET_SECRET_KEY}
+        access-key: ${S3_BUCKET_ACCESS_KEY}
+        secret-key: ${S3_BUCKET_SECRET_KEY}
       region:
         static: ap-northeast-2
 


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 이미지 API 구현(업로드용 presigned-url 발급)
- 개인 사진 조회 시 presigned-url 발급 로직 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- ImageService, ImageConverter 등: 이미지 업로드용 presigned-url 발급 API 구현
- RecordService, ChapterService 등: 조회용 presigned-url 로직 추가
- MemberChapter: 이미지 url 컬럼 제거
- ChapterResDTO: 오늘의 장 조회시 이미지 key 반환 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #60
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- API 명세서: presignedUrl 발급


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 인증이 필요한 이미지 업로드용 presigned URL 발급 API를 추가했습니다.
  * PNG/JPEG/JPG/WEBP 포맷과 최대 10MB 업로드를 지원하며, 업로드/조회는 S3 기반으로 처리됩니다.
  * 챕터 커버 이미지를 기존 `imageUrl` 대신 `imageKey`로 저장·조회하고, 읽기 응답에 `imageKey`가 포함됩니다.
* **문서**
  * presigned URL 발급/조회 및 오류 케이스(형식, 용량 초과, 권한, 미존재) API 문서 예시를 보강했습니다.
  * presigned GET URL은 요청마다 새로 발급되며 1시간 내 사용 및 캐싱 금지를 안내했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->