### PR TITLE
[feat] BGM 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
@@ -28,4 +28,10 @@ public class SettingController implements SettingControllerDocs {
         BaseSuccessCode code = SettingSuccessCode.NOTIFICATION_SETTING_GET_SUCCESS;
         return ApiResponse.onSuccess(code, settingService.getNotificationSettings(memberId));
     }
+
+    @GetMapping("/v1/bgms")
+    public ApiResponse<SettingResDTO.Bgms> getBgms() {
+        BaseSuccessCode code = SettingSuccessCode.BGM_LIST_GET_SUCCESS;
+        return ApiResponse.onSuccess(code, settingService.getBgms());
+    }
 }

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -109,20 +109,20 @@ public interface SettingControllerDocs {
                                            {
                                              "bgmId": 1,
                                              "title": "산들바람1",
-                                             "audioUrl": "http://www.bgm-example1.com",
-                                             "imageUrl": "http://www.img-example1.com"
+                                             "fileName": "http://www.bgm-example1.com",
+                                             "imageName": "http://www.img-example1.com"
                                            },
                                            {
                                              "bgmId": 2,
                                              "title": "산들바람2",
-                                             "audioUrl": "http://www.bgm-example2.com",
-                                             "imageUrl": "http://www.img-example2.com"
+                                             "fileName": "http://www.bgm-example2.com",
+                                             "imageName": "http://www.img-example2.com"
                                            },
                                            {
                                              "bgmId": 3,
                                              "title": "산들바람3",
-                                             "audioUrl": "http://www.bgm-example3.com",
-                                             "imageUrl": "http://www.img-example3.com"
+                                             "fileName": "http://www.bgm-example3.com",
+                                             "imageName": "http://www.img-example3.com"
                                            },
                                            .
                                            .

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -74,4 +74,82 @@ public interface SettingControllerDocs {
             )
     })
     ApiResponse<SettingResDTO.NotificationSettings> getNotificationSettings(@Parameter(hidden = true) @AuthenticationPrincipal Long memberId);
+
+    // BGM 목록 조회
+    @Operation(
+            summary = "BGM 목록 조회 API",
+            description = """
+                    # BGM 목록 조회
+                    내장으로 다운로드받은 BGM 목록을 조회합니다.
+                    
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {Access Token}
+                    
+                    ## 동작 방식
+                    1. 서버에 등록된 BGM 메타데이터를 조회합니다.
+                    2. 각 BGM의 제목, 파일명, 이미지 정보를 반환합니다.
+                    3. 클라이언트는 fileName을 이용하여 앱에 내장된 BGM을 재생합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                       "isSuccess": true,
+                                       "code": "BGM200_3",
+                                       "message": "BGM 목록 조회를 성공했습니다.",
+                                       "result": {
+                                         "bgms": [
+                                           {
+                                             "bgmId": 1,
+                                             "title": "산들바람1",
+                                             "audioUrl": "http://www.bgm-example1.com",
+                                             "imageUrl": "http://www.img-example1.com"
+                                           },
+                                           {
+                                             "bgmId": 2,
+                                             "title": "산들바람2",
+                                             "audioUrl": "http://www.bgm-example2.com",
+                                             "imageUrl": "http://www.img-example2.com"
+                                           },
+                                           {
+                                             "bgmId": 3,
+                                             "title": "산들바람3",
+                                             "audioUrl": "http://www.bgm-example3.com",
+                                             "imageUrl": "http://www.img-example3.com"
+                                           },
+                                           .
+                                           .
+                                           .
+                                         ]
+                                       }
+                                     }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_1",
+                                        "message": "토큰이 만료되었습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ApiResponse<SettingResDTO.Bgms> getBgms();
 }

--- a/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
+++ b/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
@@ -37,7 +37,7 @@ public class SettingConverter {
                 .bgmId(bgm.getId())
                 .title(bgm.getTitle())
                 .fileName(bgm.getFileName())
-                .imgName(bgm.getImageName())
+                .imageName(bgm.getImageName())
                 .build();
     }
 

--- a/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
+++ b/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
@@ -2,7 +2,10 @@ package com.umc.halo.domain.setting.converter;
 
 import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.setting.dto.SettingResDTO;
+import com.umc.halo.domain.setting.entity.Bgm;
 import com.umc.halo.domain.setting.entity.MemberSetting;
+
+import java.util.List;
 
 public class SettingConverter {
 
@@ -26,6 +29,21 @@ public class SettingConverter {
     public static MemberSetting toMemberSetting(Member member) {
         return MemberSetting.builder()
                 .member(member)
+                .build();
+    }
+
+    public static SettingResDTO.BgmInfo toBgmInfo(Bgm bgm) {
+        return SettingResDTO.BgmInfo.builder()
+                .bgmId(bgm.getId())
+                .title(bgm.getTitle())
+                .fileName(bgm.getFileName())
+                .imgName(bgm.getImageName())
+                .build();
+    }
+
+    public static SettingResDTO.Bgms toBgms(List<SettingResDTO.BgmInfo> bgms) {
+        return SettingResDTO.Bgms.builder()
+                .bgms(bgms)
                 .build();
     }
 }

--- a/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
+++ b/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
@@ -22,7 +22,7 @@ public class SettingResDTO {
             Long bgmId,
             String title,
             String fileName,
-            String imgName
+            String imageName
     ) {}
 
     @Builder

--- a/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
+++ b/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
@@ -3,6 +3,7 @@ package com.umc.halo.domain.setting.dto;
 import lombok.Builder;
 
 import java.time.LocalTime;
+import java.util.List;
 
 public class SettingResDTO {
 
@@ -14,5 +15,18 @@ public class SettingResDTO {
             Boolean retentionNotificationEnabled,
             Boolean anniversaryNotificationEnabled,
             Boolean isAllNotificationEnabled
+    ) {}
+
+    @Builder
+    public record BgmInfo(
+            Long bgmId,
+            String title,
+            String fileName,
+            String imgName
+    ) {}
+
+    @Builder
+    public record Bgms(
+            List<BgmInfo> bgms
     ) {}
 }

--- a/src/main/java/com/umc/halo/domain/setting/entity/Bgm.java
+++ b/src/main/java/com/umc/halo/domain/setting/entity/Bgm.java
@@ -20,9 +20,9 @@ public class Bgm extends BaseEntity {
     @Column(length = 50, nullable = false)
     private String title;
 
-    @Column(name = "audio_url", length = 255, nullable = false)
-    private String audioUrl;
+    @Column(name = "file_name", length = 255, nullable = false)
+    private String fileName;
 
-    @Column(name = "image_url", length = 255)
-    private String imageUrl;
+    @Column(name = "image_name", length = 255)
+    private String imageName;
 }

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class SettingService {
@@ -24,5 +26,11 @@ public class SettingService {
                 .orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
 
         return SettingConverter.toNotificationSettings(memberSetting);
+    }
+
+    @Transactional(readOnly = true)
+    public SettingResDTO.Bgms getBgms() {
+        List<SettingResDTO.BgmInfo> bgms = bgmRepository.findAll().stream().map(SettingConverter::toBgmInfo).toList();
+        return SettingConverter.toBgms(bgms);
     }
 }

--- a/src/main/java/com/umc/halo/global/seed/SettingSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/SettingSeeder.java
@@ -26,13 +26,13 @@ public class SettingSeeder {
         List<Bgm> bgms = List.of(
                 Bgm.builder()
                         .title("산들 바람")
-                        .audioUrl("https://example.com/bgm1.mp3")
-                        .imageUrl("https://example.com/bgm1.png")
+                        .fileName("https://example.com/bgm1.mp3")
+                        .imageName("https://example.com/bgm1.png")
                         .build(),
                 Bgm.builder()
                         .title("따뜻한 오후")
-                        .audioUrl("https://example.com/bgm2.mp3")
-                        .imageUrl("https://example.com/bgm2.png")
+                        .fileName("https://example.com/bgm2.mp3")
+                        .imageName("https://example.com/bgm2.png")
                         .build()
         );
 


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- BGM 목록 조회 API 구현
- BGM 엔티티 수정
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 변경된 ERD에 맞추어 BGM 엔티티 수정
- BGM 목록 조회 관련 Request/Response DTO 추가
- BGM 목록 조회 관련 Converter 추가
- GET /api/v1/bgms 구현
- Swagger 문서 작성
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
<img width="960" height="593" alt="image" src="https://github.com/user-attachments/assets/faedecc4-91b1-4a61-ab13-bd68906b22fe" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [ ] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #70 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp
- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61?p=393ca1e217c080108ca5da75c6d032a1&pm=s
- BGM이 앱 내장 방식으로 변경 -> BGM 목록 조회 API는 필요없을 가능성 큼 (앱 내장 방식으로 변경 확정 시 API 삭제 예정)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * BGM 목록을 조회할 수 있는 GET API(`/v1/bgms`)가 추가되었습니다.
  * 각 BGM의 ID, 제목, 파일명, 이미지명을 확인할 수 있습니다.
* **개선**
  * BGM 정보가 오디오·이미지 URL 대신 파일명 기반으로 제공되도록 응답이 개선되었습니다.
  * 관련 API 문서와 응답 예시가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->