### PR TITLE
[feat] 알림 설정 수정 API 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
@@ -1,17 +1,17 @@
 package com.umc.halo.domain.setting.controller;
 
 import com.umc.halo.domain.setting.controller.docs.SettingControllerDocs;
+import com.umc.halo.domain.setting.dto.SettingReqDTO;
 import com.umc.halo.domain.setting.dto.SettingResDTO;
 import com.umc.halo.domain.setting.exception.code.SettingSuccessCode;
 import com.umc.halo.domain.setting.service.SettingService;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,5 +33,14 @@ public class SettingController implements SettingControllerDocs {
     public ApiResponse<SettingResDTO.Bgms> getBgms() {
         BaseSuccessCode code = SettingSuccessCode.BGM_LIST_GET_SUCCESS;
         return ApiResponse.onSuccess(code, settingService.getBgms());
+    }
+
+    @PutMapping("/v1/settings/notifications")
+    public ApiResponse<SettingResDTO.NotificationSettings> updateNotificationSettings(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid SettingReqDTO.UpdateNotificationSettings dto
+    ) {
+        BaseSuccessCode code = SettingSuccessCode.NOTIFICATION_SETTING_UPDATE_SUCCESS;
+        return ApiResponse.onSuccess(code, settingService.updateNotificationSettings(memberId, dto));
     }
 }

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -207,22 +207,6 @@ public interface SettingControllerDocs {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "regularNotificationTime에 유효하지 않은 날짜 포맷이 들어온 경우",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                        "isSuccess": false,
-                                        "code": "NOTIFICATION400_1",
-                                        "message": “정기 알림 시간 형식이 올바르지 않습니다.”,
-                                        "result": null
-                                    }
-                                    """
-                            )
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
                     description = "memberSetting이 생성되지 않음",
                     content = @Content(

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -178,7 +178,7 @@ public interface SettingControllerDocs {
                     1. Access Token으로 현재 회원을 인증합니다.
                     2. 회원의 알림 설정 정보를 조회합니다.
                     3. 요청한 알림 설정 값으로 회원의 설정을 수정합니다.
-                    4. 정기 알림이 활성화된 경우 전달받은 regularNotificationTime으로 시간을 수정합니다.
+                    4. 정기 알림 활성화 여부와 관계없이 항상 regularNotificationTime으로 시간을 수정합니다.
                     5. 수정된 알림 설정 정보를 반환합니다.
                     """
     )

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -1,5 +1,6 @@
 package com.umc.halo.domain.setting.controller.docs;
 
+import com.umc.halo.domain.setting.dto.SettingReqDTO;
 import com.umc.halo.domain.setting.dto.SettingResDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -8,7 +9,9 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "알림 API")
 public interface SettingControllerDocs {
@@ -152,4 +155,89 @@ public interface SettingControllerDocs {
             )
     })
     ApiResponse<SettingResDTO.Bgms> getBgms();
+
+    // 알림 설정 수정
+    @Operation(
+            summary = "알림 설정 수정 API",
+            description = """
+                    # 알림 설정 수정
+                    알림 설정을 수정합니다. (정기 알림/정기 알림 시간/전체 알림/오늘의 장 알림/리텐션 알림/기념일 알림)
+                    
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {Access Token}
+                    - **Body**
+                        - regularNotificationEnabled : 정기 알림 ON/OFF 여부
+                        - regularNotificationTime : 정기 알림 시간
+                        - todayChapterNotificationEnabled : 오늘의 장 알림 ON/OFF 여부
+                        - retentionNotificationEnabled : 리텐션 알림 ON/OFF 여부
+                        - anniversaryNotificationEnabled : 기념일 알림 ON/OFF 여부
+                    
+                    ## 동작 방식
+                    1. Access Token으로 현재 회원을 인증합니다.
+                    2. 회원의 알림 설정 정보를 조회합니다.
+                    3. 요청한 알림 설정 값으로 회원의 설정을 수정합니다.
+                    4. 정기 알림이 활성화된 경우 전달받은 regularNotificationTime으로 시간을 수정합니다.
+                    5. 수정된 알림 설정 정보를 반환합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공 예시",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": true,
+                                        "code": "NOTIFICATION200_2",
+                                        "message": "알림 설정을 성공적으로 수정했습니다.",
+                                        "result": {
+                                            "regularNotificationEnabled": true,
+                                            "regularNotificationTime": "10:00",
+                                            "todayChapterNotificationEnabled": true,
+                                            "retentionNotificationEnabled": false,
+                                            "anniversaryNotificationEnabled": true,
+                                            "isAllNotificationEnabled": false
+                                        }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "regularNotificationTime에 유효하지 않은 날짜 포맷이 들어온 경우",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "NOTIFICATION400_1",
+                                        "message": “정기 알림 시간 형식이 올바르지 않습니다.”,
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "memberSetting이 생성되지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "SETTING404_1",
+                                        "message": "설정을 찾을 수 없습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    ApiResponse<SettingResDTO.NotificationSettings> updateNotificationSettings(@AuthenticationPrincipal Long memberId, @RequestBody @Valid SettingReqDTO.UpdateNotificationSettings dto);
 }

--- a/src/main/java/com/umc/halo/domain/setting/dto/SettingReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/setting/dto/SettingReqDTO.java
@@ -12,6 +12,7 @@ public class SettingReqDTO {
             @NotNull
             Boolean regularNotificationEnabled,
 
+            @NotNull
             LocalTime regularNotificationTime,
 
             @NotNull

--- a/src/main/java/com/umc/halo/domain/setting/dto/SettingReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/setting/dto/SettingReqDTO.java
@@ -1,4 +1,26 @@
 package com.umc.halo.domain.setting.dto;
 
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.time.LocalTime;
+
 public class SettingReqDTO {
+
+    @Builder
+    public record UpdateNotificationSettings(
+            @NotNull
+            Boolean regularNotificationEnabled,
+
+            LocalTime regularNotificationTime,
+
+            @NotNull
+            Boolean todayChapterNotificationEnabled,
+
+            @NotNull
+            Boolean retentionNotificationEnabled,
+
+            @NotNull
+            Boolean anniversaryNotificationEnabled
+    ) {}
 }

--- a/src/main/java/com/umc/halo/domain/setting/entity/MemberSetting.java
+++ b/src/main/java/com/umc/halo/domain/setting/entity/MemberSetting.java
@@ -41,7 +41,7 @@ public class MemberSetting extends BaseEntity {
 
     @Column(name = "regular_notification_time", nullable = false)
     @Builder.Default
-    private LocalTime regularNotificationTime = LocalTime.of(21,0);
+    private LocalTime regularNotificationTime = LocalTime.of(9,0);
 
     @Column(name = "today_chapter_notification_enabled", nullable = false)
     @Builder.Default

--- a/src/main/java/com/umc/halo/domain/setting/entity/MemberSetting.java
+++ b/src/main/java/com/umc/halo/domain/setting/entity/MemberSetting.java
@@ -54,4 +54,18 @@ public class MemberSetting extends BaseEntity {
     @Column(name = "anniversary_notification_enabled", nullable = false)
     @Builder.Default
     private Boolean anniversaryNotificationEnabled = true;
+
+    public void updateNotificationSettings(
+            Boolean regularNotificationEnabled,
+            LocalTime regularNotificationTime,
+            Boolean todayChapterNotificationEnabled,
+            Boolean retentionNotificationEnabled,
+            Boolean anniversaryNotificationEnabled
+    ){
+        this.regularNotificationEnabled = regularNotificationEnabled;
+        this.regularNotificationTime = regularNotificationTime;
+        this.todayChapterNotificationEnabled = todayChapterNotificationEnabled;
+        this.retentionNotificationEnabled = retentionNotificationEnabled;
+        this.anniversaryNotificationEnabled = anniversaryNotificationEnabled;
+    }
 }

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -41,10 +41,6 @@ public class SettingService {
         MemberSetting memberSetting = memberSettingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
 
-        if (dto.regularNotificationEnabled() && dto.regularNotificationTime() == null) {
-            throw new SettingException(SettingErrorCode.INVALID_REGULAR_NOTIFICATION_TIME);
-        }
-
         memberSetting.updateNotificationSettings(
                 dto.regularNotificationEnabled(),
                 dto.regularNotificationTime(),

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -1,12 +1,14 @@
 package com.umc.halo.domain.setting.service;
 
 import com.umc.halo.domain.setting.converter.SettingConverter;
+import com.umc.halo.domain.setting.dto.SettingReqDTO;
 import com.umc.halo.domain.setting.dto.SettingResDTO;
 import com.umc.halo.domain.setting.entity.MemberSetting;
 import com.umc.halo.domain.setting.exception.SettingException;
 import com.umc.halo.domain.setting.exception.code.SettingErrorCode;
 import com.umc.halo.domain.setting.repository.BgmRepository;
 import com.umc.halo.domain.setting.repository.MemberSettingRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,5 +34,25 @@ public class SettingService {
     public SettingResDTO.Bgms getBgms() {
         List<SettingResDTO.BgmInfo> bgms = bgmRepository.findAll().stream().map(SettingConverter::toBgmInfo).toList();
         return SettingConverter.toBgms(bgms);
+    }
+
+    @Transactional
+    public SettingResDTO.NotificationSettings updateNotificationSettings(Long memberId, SettingReqDTO.UpdateNotificationSettings dto) {
+        MemberSetting memberSetting = memberSettingRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
+
+        if (dto.regularNotificationEnabled() && dto.regularNotificationTime() == null) {
+            throw new SettingException(SettingErrorCode.INVALID_REGULAR_NOTIFICATION_TIME);
+        }
+
+        memberSetting.updateNotificationSettings(
+                dto.regularNotificationEnabled(),
+                dto.regularNotificationTime(),
+                dto.todayChapterNotificationEnabled(),
+                dto.retentionNotificationEnabled(),
+                dto.anniversaryNotificationEnabled()
+        );
+
+        return SettingConverter.toNotificationSettings(memberSetting);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 알림 설정 수정 API 구현
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 변경된 ERD에 맞춰 MemberSetting 엔티티 수정
- 알림 설정 수정 관련 Request DTO 추가
- PUT /api/v1/settings/notifications 구현
- Swagger 문서 작성
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
<img width="801" height="675" alt="image" src="https://github.com/user-attachments/assets/c2d22137-1723-40f7-be38-7565478ca670" />
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [ ] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #73 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp


- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61?p=391ca1e217c080e6810ae2231055bb3d&pm=s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원이 정기 알림, 오늘의 챕터 알림, 보관 기한 알림, 기념일 알림 설정을 한 번에 수정할 수 있습니다(알림 설정 수정 API 추가).
  * 정기 알림은 사용 여부에 따라 알림 시간도 함께 설정할 수 있습니다.
  * 변경 결과를 즉시 확인할 수 있습니다.
* **버그 수정**
  * 필수 값 검증을 강화해 누락 시 오류가 발생하도록 개선했습니다.
  * 정기 알림 기본 시간이 오전 9시로 변경되었습니다.
* **문서**
  * 알림 설정 변경 요청 형식과 응답 예시를 Swagger로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->