### PR TITLE
[chore] 마이그레이션 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
     // S3
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:4.0.2")
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+
+    // Flyway
+    implementation 'org.springframework.boot:spring-boot-flyway'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,7 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 
     // Flyway
-    implementation 'org.springframework.boot:spring-boot-flyway'
-    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.springframework.boot:spring-boot-starter-flyway'
     implementation 'org.flywaydb:flyway-mysql'
 }
 

--- a/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/LocalDataSeeder.java
@@ -1,5 +1,6 @@
 package com.umc.halo.global.seed;
 
+import com.umc.halo.domain.member.repository.*;
 import lombok.*;
 import lombok.extern.slf4j.*;
 import org.springframework.boot.*;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.*;
 @Slf4j
 public class LocalDataSeeder implements CommandLineRunner {
 
+    private final MemberRepository memberRepository;
     private final MemberSeeder memberSeeder;
     private final ChapterSeeder chapterSeeder;
     private final StorybookSeeder storybookSeeder;
@@ -23,6 +25,11 @@ public class LocalDataSeeder implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
+
+        if (memberRepository.count() > 0) {
+            log.info("이미 시딩된 데이터가 있어 로컬 데이터 초기화를 스킵합니다.");
+            return;
+        }
 
         log.info("로컬 데이터 초기화");
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,6 +2,3 @@ spring:
   config:
     activate:
       on-profile: local
-  jpa:
-    hibernate:
-      ddl-auto: create-drop

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,10 +13,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     show-sql: true
     hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        format_sql: true
+      ddl-auto: validate
 
   cloud:
     aws:
@@ -27,6 +24,13 @@ spring:
         secret-key: ${S3_BUCKET_SECRET_KEY}
       region:
         static: ap-northeast-2
+
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 1
+    locations: classpath:db/migration
+    fail-on-missing-locations: true
 
 logging:
   level:

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,341 @@
+CREATE TABLE anniversary
+(
+    anniversary_id           BIGINT AUTO_INCREMENT NOT NULL,
+    created_at               datetime              NOT NULL,
+    updated_at               datetime              NOT NULL,
+    member_id                BIGINT                NOT NULL,
+    title                    VARCHAR(20)           NOT NULL,
+    anniversary_date         date                  NOT NULL,
+    is_repeated              BIT(1)                NOT NULL,
+    seven_days_alarm_enabled BIT(1)                NOT NULL,
+    day_alarm_enabled        BIT(1)                NOT NULL,
+    memo                     VARCHAR(255)          NULL,
+    CONSTRAINT pk_anniversary PRIMARY KEY (anniversary_id)
+);
+
+CREATE TABLE bgm
+(
+    bgm_id     BIGINT AUTO_INCREMENT NOT NULL,
+    created_at datetime              NOT NULL,
+    updated_at datetime              NOT NULL,
+    title      VARCHAR(50)           NOT NULL,
+    audio_url  VARCHAR(255)          NOT NULL,
+    image_url  VARCHAR(255)          NULL,
+    CONSTRAINT pk_bgm PRIMARY KEY (bgm_id)
+);
+
+CREATE TABLE chapter
+(
+    chapter_id        BIGINT AUTO_INCREMENT NOT NULL,
+    created_at        datetime              NOT NULL,
+    updated_at        datetime              NOT NULL,
+    title             VARCHAR(50)           NOT NULL,
+    image_url         VARCHAR(255)          NOT NULL,
+    guide             VARCHAR(255)          NULL,
+    short_description VARCHAR(255)          NOT NULL,
+    `description`     TEXT                  NULL,
+    image_description VARCHAR(255)          NOT NULL,
+    CONSTRAINT pk_chapter PRIMARY KEY (chapter_id)
+);
+
+CREATE TABLE chapter_question
+(
+    chapter_question_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at          datetime              NOT NULL,
+    updated_at          datetime              NOT NULL,
+    chapter_id          BIGINT                NOT NULL,
+    question_order      INT                   NOT NULL,
+    question            VARCHAR(255)          NOT NULL,
+    CONSTRAINT pk_chapter_question PRIMARY KEY (chapter_question_id)
+);
+
+CREATE TABLE common_anniversary
+(
+    common_anniversary_id    BIGINT AUTO_INCREMENT NOT NULL,
+    created_at               datetime              NOT NULL,
+    updated_at               datetime              NOT NULL,
+    title                    VARCHAR(20)           NOT NULL,
+    month                    INT                   NOT NULL,
+    day                      INT                   NOT NULL,
+    is_lunar                 BIT(1)                NOT NULL,
+    seven_days_alarm_enabled BIT(1)                NOT NULL,
+    day_alarm_enabled        BIT(1)                NOT NULL,
+    CONSTRAINT pk_common_anniversary PRIMARY KEY (common_anniversary_id)
+);
+
+CREATE TABLE member
+(
+    member_id            BIGINT AUTO_INCREMENT NOT NULL,
+    created_at           datetime              NOT NULL,
+    updated_at           datetime              NOT NULL,
+    name                 VARCHAR(10)           NULL,
+    provider             VARCHAR(255)          NULL,
+    provider_id          VARCHAR(255)          NULL,
+    gender               VARCHAR(255)          NULL,
+    birth_date           date                  NULL,
+    email                VARCHAR(255)          NULL,
+    refresh_token_hash   VARCHAR(64)           NULL,
+    onboarding_completed BIT(1)                NOT NULL,
+    onboarding_step      INT                   NULL,
+    CONSTRAINT pk_member PRIMARY KEY (member_id)
+);
+
+CREATE TABLE member_chapter
+(
+    member_chapter_id    BIGINT AUTO_INCREMENT NOT NULL,
+    created_at           datetime              NOT NULL,
+    updated_at           datetime              NOT NULL,
+    member_id            BIGINT                NOT NULL,
+    storybook_chapter_id BIGINT                NOT NULL,
+    scene_card_id        BIGINT                NULL,
+    emotion              VARCHAR(255)          NULL,
+    cover_type           VARCHAR(255)          NULL,
+    image_key            VARCHAR(255)          NULL,
+    completed_date       date                  NULL,
+    summary              TEXT                  NULL,
+    status               VARCHAR(255)          NOT NULL,
+    CONSTRAINT pk_member_chapter PRIMARY KEY (member_chapter_id)
+);
+
+CREATE TABLE member_chapter_answer
+(
+    member_chapter_answer_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at               datetime              NOT NULL,
+    updated_at               datetime              NOT NULL,
+    member_chapter_id        BIGINT                NOT NULL,
+    chapter_question_id      BIGINT                NOT NULL,
+    answer                   TEXT                  NOT NULL,
+    CONSTRAINT pk_member_chapter_answer PRIMARY KEY (member_chapter_answer_id)
+);
+
+CREATE TABLE member_setting
+(
+    member_setting_id                  BIGINT AUTO_INCREMENT NOT NULL,
+    created_at                         datetime              NOT NULL,
+    updated_at                         datetime              NOT NULL,
+    member_id                          BIGINT                NOT NULL,
+    bgm_id                             BIGINT                NULL,
+    bgm_enabled                        BIT(1)                NOT NULL,
+    bgm_volume                         INT                   NOT NULL,
+    regular_notification_enabled       BIT(1)                NOT NULL,
+    regular_notification_time          time                  NOT NULL,
+    today_chapter_notification_enabled BIT(1)                NOT NULL,
+    retention_notification_enabled     BIT(1)                NOT NULL,
+    anniversary_notification_enabled   BIT(1)                NOT NULL,
+    CONSTRAINT pk_member_setting PRIMARY KEY (member_setting_id)
+);
+
+CREATE TABLE member_storybook
+(
+    member_storybook_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at          datetime              NOT NULL,
+    updated_at          datetime              NOT NULL,
+    member_id           BIGINT                NOT NULL,
+    storybook_id        BIGINT                NOT NULL,
+    last_chapter_order  INT                   NOT NULL,
+    last_completed_date date                  NULL,
+    emotion             VARCHAR(255)          NULL,
+    CONSTRAINT pk_member_storybook PRIMARY KEY (member_storybook_id)
+);
+
+CREATE TABLE member_tag
+(
+    member_tag_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at    datetime              NOT NULL,
+    updated_at    datetime              NOT NULL,
+    tag_id        BIGINT                NOT NULL,
+    member_id     BIGINT                NOT NULL,
+    CONSTRAINT pk_member_tag PRIMARY KEY (member_tag_id)
+);
+
+CREATE TABLE member_term
+(
+    member_term_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at     datetime              NOT NULL,
+    updated_at     datetime              NOT NULL,
+    term_id        BIGINT                NOT NULL,
+    member_id      BIGINT                NOT NULL,
+    is_agreed      BIT(1)                NOT NULL,
+    CONSTRAINT pk_member_term PRIMARY KEY (member_term_id)
+);
+
+CREATE TABLE notification
+(
+    notification_id   BIGINT AUTO_INCREMENT NOT NULL,
+    created_at        datetime              NOT NULL,
+    updated_at        datetime              NOT NULL,
+    member_id         BIGINT                NOT NULL,
+    notification_type VARCHAR(255)          NOT NULL,
+    title             VARCHAR(100)          NOT NULL,
+    message           VARCHAR(255)          NOT NULL,
+    sent_at           datetime              NULL,
+    is_read           BIT(1)                NOT NULL,
+    CONSTRAINT pk_notification PRIMARY KEY (notification_id)
+);
+
+CREATE TABLE scene_card
+(
+    scene_card_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at    datetime              NOT NULL,
+    updated_at    datetime              NOT NULL,
+    chapter_id    BIGINT                NOT NULL,
+    image_url     VARCHAR(255)          NOT NULL,
+    CONSTRAINT pk_scene_card PRIMARY KEY (scene_card_id)
+);
+
+CREATE TABLE storybook
+(
+    storybook_id      BIGINT AUTO_INCREMENT NOT NULL,
+    created_at        datetime              NOT NULL,
+    updated_at        datetime              NOT NULL,
+    title             VARCHAR(50)           NOT NULL,
+    theme_order       INT                   NOT NULL,
+    short_description VARCHAR(255)          NOT NULL,
+    `description`     TEXT                  NOT NULL,
+    image_url         VARCHAR(255)          NOT NULL,
+    spine_color       VARCHAR(7)            NOT NULL,
+    CONSTRAINT pk_storybook PRIMARY KEY (storybook_id)
+);
+
+CREATE TABLE storybook_chapter
+(
+    storybook_chapter_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at           datetime              NOT NULL,
+    updated_at           datetime              NOT NULL,
+    storybook_id         BIGINT                NOT NULL,
+    chapter_id           BIGINT                NOT NULL,
+    chapter_order        INT                   NOT NULL,
+    CONSTRAINT pk_storybook_chapter PRIMARY KEY (storybook_chapter_id)
+);
+
+CREATE TABLE storybook_character
+(
+    storybook_character_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at             datetime              NOT NULL,
+    updated_at             datetime              NOT NULL,
+    storybook_id           BIGINT                NOT NULL,
+    name                   VARCHAR(10)           NOT NULL,
+    variant                VARCHAR(255)          NOT NULL,
+    image_url              VARCHAR(255)          NOT NULL,
+    CONSTRAINT pk_storybook_character PRIMARY KEY (storybook_character_id)
+);
+
+CREATE TABLE storybook_tag
+(
+    storybook_tag_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at       datetime              NOT NULL,
+    updated_at       datetime              NOT NULL,
+    tag_id           BIGINT                NOT NULL,
+    storybook_id     BIGINT                NOT NULL,
+    priority_level   VARCHAR(255)          NOT NULL,
+    phrase           VARCHAR(50)           NOT NULL,
+    CONSTRAINT pk_storybook_tag PRIMARY KEY (storybook_tag_id)
+);
+
+CREATE TABLE tag
+(
+    tag_id        BIGINT AUTO_INCREMENT NOT NULL,
+    created_at    datetime              NOT NULL,
+    updated_at    datetime              NOT NULL,
+    category      VARCHAR(255)          NOT NULL,
+    title         VARCHAR(20)           NOT NULL,
+    subtitle      VARCHAR(255)          NULL,
+    `description` VARCHAR(255)          NULL,
+    CONSTRAINT pk_tag PRIMARY KEY (tag_id)
+);
+
+CREATE TABLE term
+(
+    term_id           BIGINT AUTO_INCREMENT NOT NULL,
+    created_at        datetime              NOT NULL,
+    updated_at        datetime              NOT NULL,
+    title             VARCHAR(50)           NOT NULL,
+    short_description VARCHAR(100)          NOT NULL,
+    `description`     TEXT                  NOT NULL,
+    is_required       BIT(1)                NOT NULL,
+    CONSTRAINT pk_term PRIMARY KEY (term_id)
+);
+
+ALTER TABLE member_storybook
+    ADD CONSTRAINT uc_3d4b46baa4dcc738ed2e78c26 UNIQUE (member_id, storybook_id);
+
+ALTER TABLE member_tag
+    ADD CONSTRAINT uc_6453aa0fba1f2d179a5c0bb1c UNIQUE (tag_id, member_id);
+
+ALTER TABLE member_chapter
+    ADD CONSTRAINT uc_f1d860773275ce7753f2c41b6 UNIQUE (member_id, storybook_chapter_id);
+
+ALTER TABLE member
+    ADD CONSTRAINT uk_member_provider UNIQUE (provider, provider_id);
+
+ALTER TABLE member_term
+    ADD CONSTRAINT uk_member_term UNIQUE (member_id, term_id);
+
+ALTER TABLE storybook_tag
+    ADD CONSTRAINT uk_storybook_tag_storybook_tag UNIQUE (storybook_id, tag_id);
+
+ALTER TABLE anniversary
+    ADD CONSTRAINT FK_ANNIVERSARY_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+ALTER TABLE chapter_question
+    ADD CONSTRAINT FK_CHAPTER_QUESTION_ON_CHAPTER FOREIGN KEY (chapter_id) REFERENCES chapter (chapter_id);
+
+ALTER TABLE member_chapter_answer
+    ADD CONSTRAINT FK_MEMBER_CHAPTER_ANSWER_ON_CHAPTER_QUESTION FOREIGN KEY (chapter_question_id) REFERENCES chapter_question (chapter_question_id);
+
+ALTER TABLE member_chapter_answer
+    ADD CONSTRAINT FK_MEMBER_CHAPTER_ANSWER_ON_MEMBER_CHAPTER FOREIGN KEY (member_chapter_id) REFERENCES member_chapter (member_chapter_id);
+
+ALTER TABLE member_chapter
+    ADD CONSTRAINT FK_MEMBER_CHAPTER_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+ALTER TABLE member_chapter
+    ADD CONSTRAINT FK_MEMBER_CHAPTER_ON_SCENE_CARD FOREIGN KEY (scene_card_id) REFERENCES scene_card (scene_card_id);
+
+ALTER TABLE member_chapter
+    ADD CONSTRAINT FK_MEMBER_CHAPTER_ON_STORYBOOK_CHAPTER FOREIGN KEY (storybook_chapter_id) REFERENCES storybook_chapter (storybook_chapter_id);
+
+ALTER TABLE member_setting
+    ADD CONSTRAINT FK_MEMBER_SETTING_ON_BGM FOREIGN KEY (bgm_id) REFERENCES bgm (bgm_id);
+
+ALTER TABLE member_setting
+    ADD CONSTRAINT FK_MEMBER_SETTING_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+ALTER TABLE member_storybook
+    ADD CONSTRAINT FK_MEMBER_STORYBOOK_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+ALTER TABLE member_storybook
+    ADD CONSTRAINT FK_MEMBER_STORYBOOK_ON_STORYBOOK FOREIGN KEY (storybook_id) REFERENCES storybook (storybook_id);
+
+ALTER TABLE member_tag
+    ADD CONSTRAINT FK_MEMBER_TAG_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+ALTER TABLE member_tag
+    ADD CONSTRAINT FK_MEMBER_TAG_ON_TAG FOREIGN KEY (tag_id) REFERENCES tag (tag_id);
+
+ALTER TABLE member_term
+    ADD CONSTRAINT FK_MEMBER_TERM_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+ALTER TABLE member_term
+    ADD CONSTRAINT FK_MEMBER_TERM_ON_TERM FOREIGN KEY (term_id) REFERENCES term (term_id);
+
+ALTER TABLE notification
+    ADD CONSTRAINT FK_NOTIFICATION_ON_MEMBER FOREIGN KEY (member_id) REFERENCES member (member_id);
+
+ALTER TABLE scene_card
+    ADD CONSTRAINT FK_SCENE_CARD_ON_CHAPTER FOREIGN KEY (chapter_id) REFERENCES chapter (chapter_id);
+
+ALTER TABLE storybook_chapter
+    ADD CONSTRAINT FK_STORYBOOK_CHAPTER_ON_CHAPTER FOREIGN KEY (chapter_id) REFERENCES chapter (chapter_id);
+
+ALTER TABLE storybook_chapter
+    ADD CONSTRAINT FK_STORYBOOK_CHAPTER_ON_STORYBOOK FOREIGN KEY (storybook_id) REFERENCES storybook (storybook_id);
+
+ALTER TABLE storybook_character
+    ADD CONSTRAINT FK_STORYBOOK_CHARACTER_ON_STORYBOOK FOREIGN KEY (storybook_id) REFERENCES storybook (storybook_id);
+
+ALTER TABLE storybook_tag
+    ADD CONSTRAINT FK_STORYBOOK_TAG_ON_STORYBOOK FOREIGN KEY (storybook_id) REFERENCES storybook (storybook_id);
+
+ALTER TABLE storybook_tag
+    ADD CONSTRAINT FK_STORYBOOK_TAG_ON_TAG FOREIGN KEY (tag_id) REFERENCES tag (tag_id);

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -11,7 +11,9 @@ CREATE TABLE anniversary
     day_alarm_enabled        BIT(1)                NOT NULL,
     memo                     VARCHAR(255)          NULL,
     CONSTRAINT pk_anniversary PRIMARY KEY (anniversary_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE bgm
 (
@@ -22,7 +24,9 @@ CREATE TABLE bgm
     audio_url  VARCHAR(255)          NOT NULL,
     image_url  VARCHAR(255)          NULL,
     CONSTRAINT pk_bgm PRIMARY KEY (bgm_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE chapter
 (
@@ -36,7 +40,9 @@ CREATE TABLE chapter
     `description`     TEXT                  NULL,
     image_description VARCHAR(255)          NOT NULL,
     CONSTRAINT pk_chapter PRIMARY KEY (chapter_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE chapter_question
 (
@@ -47,7 +53,9 @@ CREATE TABLE chapter_question
     question_order      INT                   NOT NULL,
     question            VARCHAR(255)          NOT NULL,
     CONSTRAINT pk_chapter_question PRIMARY KEY (chapter_question_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE common_anniversary
 (
@@ -61,7 +69,9 @@ CREATE TABLE common_anniversary
     seven_days_alarm_enabled BIT(1)                NOT NULL,
     day_alarm_enabled        BIT(1)                NOT NULL,
     CONSTRAINT pk_common_anniversary PRIMARY KEY (common_anniversary_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE member
 (
@@ -78,7 +88,9 @@ CREATE TABLE member
     onboarding_completed BIT(1)                NOT NULL,
     onboarding_step      INT                   NULL,
     CONSTRAINT pk_member PRIMARY KEY (member_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE member_chapter
 (
@@ -95,7 +107,9 @@ CREATE TABLE member_chapter
     summary              TEXT                  NULL,
     status               VARCHAR(255)          NOT NULL,
     CONSTRAINT pk_member_chapter PRIMARY KEY (member_chapter_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE member_chapter_answer
 (
@@ -106,7 +120,9 @@ CREATE TABLE member_chapter_answer
     chapter_question_id      BIGINT                NOT NULL,
     answer                   TEXT                  NOT NULL,
     CONSTRAINT pk_member_chapter_answer PRIMARY KEY (member_chapter_answer_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE member_setting
 (
@@ -123,7 +139,9 @@ CREATE TABLE member_setting
     retention_notification_enabled     BIT(1)                NOT NULL,
     anniversary_notification_enabled   BIT(1)                NOT NULL,
     CONSTRAINT pk_member_setting PRIMARY KEY (member_setting_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE member_storybook
 (
@@ -136,7 +154,9 @@ CREATE TABLE member_storybook
     last_completed_date date                  NULL,
     emotion             VARCHAR(255)          NULL,
     CONSTRAINT pk_member_storybook PRIMARY KEY (member_storybook_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE member_tag
 (
@@ -146,7 +166,9 @@ CREATE TABLE member_tag
     tag_id        BIGINT                NOT NULL,
     member_id     BIGINT                NOT NULL,
     CONSTRAINT pk_member_tag PRIMARY KEY (member_tag_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE member_term
 (
@@ -157,7 +179,9 @@ CREATE TABLE member_term
     member_id      BIGINT                NOT NULL,
     is_agreed      BIT(1)                NOT NULL,
     CONSTRAINT pk_member_term PRIMARY KEY (member_term_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE notification
 (
@@ -171,7 +195,9 @@ CREATE TABLE notification
     sent_at           datetime              NULL,
     is_read           BIT(1)                NOT NULL,
     CONSTRAINT pk_notification PRIMARY KEY (notification_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE scene_card
 (
@@ -181,7 +207,9 @@ CREATE TABLE scene_card
     chapter_id    BIGINT                NOT NULL,
     image_url     VARCHAR(255)          NOT NULL,
     CONSTRAINT pk_scene_card PRIMARY KEY (scene_card_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE storybook
 (
@@ -195,7 +223,9 @@ CREATE TABLE storybook
     image_url         VARCHAR(255)          NOT NULL,
     spine_color       VARCHAR(7)            NOT NULL,
     CONSTRAINT pk_storybook PRIMARY KEY (storybook_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE storybook_chapter
 (
@@ -206,7 +236,9 @@ CREATE TABLE storybook_chapter
     chapter_id           BIGINT                NOT NULL,
     chapter_order        INT                   NOT NULL,
     CONSTRAINT pk_storybook_chapter PRIMARY KEY (storybook_chapter_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE storybook_character
 (
@@ -218,7 +250,9 @@ CREATE TABLE storybook_character
     variant                VARCHAR(255)          NOT NULL,
     image_url              VARCHAR(255)          NOT NULL,
     CONSTRAINT pk_storybook_character PRIMARY KEY (storybook_character_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE storybook_tag
 (
@@ -230,7 +264,9 @@ CREATE TABLE storybook_tag
     priority_level   VARCHAR(255)          NOT NULL,
     phrase           VARCHAR(50)           NOT NULL,
     CONSTRAINT pk_storybook_tag PRIMARY KEY (storybook_tag_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE tag
 (
@@ -242,7 +278,9 @@ CREATE TABLE tag
     subtitle      VARCHAR(255)          NULL,
     `description` VARCHAR(255)          NULL,
     CONSTRAINT pk_tag PRIMARY KEY (tag_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 CREATE TABLE term
 (
@@ -254,7 +292,9 @@ CREATE TABLE term
     `description`     TEXT                  NOT NULL,
     is_required       BIT(1)                NOT NULL,
     CONSTRAINT pk_term PRIMARY KEY (term_id)
-);
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
 
 ALTER TABLE member_storybook
     ADD CONSTRAINT uc_3d4b46baa4dcc738ed2e78c26 UNIQUE (member_id, storybook_id);

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -21,8 +21,8 @@ CREATE TABLE bgm
     created_at datetime              NOT NULL,
     updated_at datetime              NOT NULL,
     title      VARCHAR(50)           NOT NULL,
-    audio_url  VARCHAR(255)          NOT NULL,
-    image_url  VARCHAR(255)          NULL,
+    file_name  VARCHAR(255)          NOT NULL,
+    image_name VARCHAR(255)          NULL,
     CONSTRAINT pk_bgm PRIMARY KEY (bgm_id)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
  - `ddl-auto: update`/`create-drop` 기반 스키마 관리를 Flyway 마이그레이션 기반으로 전환 
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `build.gradle`: `spring-boot-flyway`, `flyway-core`, `flyway-mysql` 의존성 추가
- `application.yml`: `spring.flyway` 설정 추가(`enabled`, `baseline-on-migrate`, `baseline-version`, `locations`, `fail-on-missing-locations`), `ddl-auto`를 `update` → `validate`로 변경
- `application-local.yml`: local 프로필의 `ddl-auto` override 제거 (공통 설정 `validate` 상속)
- `db/migration/V1__init.sql`: 현재 엔티티 기준 baseline 마이그레이션 스크립트 신규 추가
- `LocalDataSeeder.java`: 이미 시딩된 데이터가 있으면 재시딩을 스킵하도록 가드 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #74
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 마이그레이션 네이밍 규칙: `V{버전}__{설명}.sql`, `baseline-version: 1`이라 신규 마이그레이션은 V2부터 시작

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * Flyway 마이그레이션으로 데이터베이스 스키마를 체계적으로 관리합니다.
  * 초기 스키마(테이블)와 주요 관계 제약조건이 자동으로 구성됩니다.
* **개선**
  * Hibernate 스키마 자동 변경은 비활성화하고, 정의된 스키마와의 일치 여부를 검증하도록 전환했습니다.
  * 로컬 환경 설정을 정리했습니다.
* **버그 수정**
  * 로컬 초기 데이터가 이미 존재하면 중복 생성 없이 건너뛰도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->