### PR TITLE
[chore] Dockerfile 작성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+build/*
+!build/libs/*.jar
+
+.gradle/
+.git/
+.idea/
+*.log
+
+.env
+.env.*

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 .DS_Store
+
+### env ###
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# halo-server 런타임 이미지 (JDK 21, Amazon Corretto AL2023)
+FROM amazoncorretto:21-al2023
+
+# 서버 시간대를 KST로 고정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 비루트 계정 생성 (AL2023 미니멀 이미지엔 shadow-utils가 빠져 있어 먼저 설치)
+RUN dnf install -y shadow-utils && dnf clean all && \
+    groupadd halo && useradd -g halo -M halo
+
+# CI에서 --build-arg 로 실제 jar 경로를 넘겨줄 수 있도록 기본값만 지정
+ARG JAR_FILE=build/libs/*.jar
+
+WORKDIR /app
+
+COPY --chown=halo:halo ${JAR_FILE} app.jar
+
+USER halo
+
+EXPOSE 8080
+ENV JVM_OPTS="-Xms512m -Xmx1024m -XX:+UseG1GC -XX:MaxMetaspaceSize=256m -Duser.timezone=Asia/Seoul"
+
+# exec 로 java 를 PID 1 로 만들어 SIGTERM(docker stop)이 graceful shutdown 되게 함
+ENTRYPOINT ["sh", "-c", "exec java $JVM_OPTS -jar app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -62,3 +62,8 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+// Docker 빌드 시 plain.jar와의 COPY 충돌을 방지하기 위해 일반 JAR 생성 비활성화
+tasks.named('jar') {
+    enabled = false
+}


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 앱 배포용 Docker 런타임 이미지 구성

- GitHub Actions에서 `./gradlew bootJar`로 미리 빌드한 jar를 받아 실행만 하는 Dockerfile 작성
- Corretto 21 (Amazon Linux 2023) 베이스, 비루트 유저(halo) 실행, KST 타임존 고정
- EC2 소형 인스턴스(MySQL/Nginx 동시 운영 가정) 기준 JVM 힙/GC 옵션 설정
- SIGTERM 시 graceful shutdown 되도록 `exec java`로 PID 1 실행
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `Dockerfile`: 런타임 이미지 정의
- `.dockerignore` : 빌드 컨텍스트에서 `build/*`(jar 제외), `.git`, `.env*` 등 제외
- `build.gradle`: `bootJar`와 별개로 생성되는 plain jar를 비활성화 (`tasks.named('jar') { enabled = false }`), Dockerfile의 `COPY build/libs/*.jar` 글롭이 jar 2개에 매칭돼 빌드가 깨지는 문제 방지
- `.gitignore`: `.env`, `.env.*` 추가 — 로컬 DB 비밀번호/JWT 시크릿/S3 키가 든 `.env.local`이 그동안 gitignore 대상이 아니었던 걸 발견해서 같이 수정
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #78
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Docker 빌드 중 중복 JAR 파일로 인해 발생할 수 있는 COPY 충돌을 방지했습니다.
  * 불필요한 기본 JAR 생성을 비활성화해 빌드 안정성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->