### PR TITLE
[docs] Swagger 문서 양식 통일

### DIFF
--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -22,12 +22,23 @@ public interface CalendarControllerDocs {
             summary = "캘린더 메인 조회 API",
             description = """
                     # 캘린더 메인 조회
-                    
-                    ## 요청 형식
-                    - 헤더: Authorization: Bearer {JWT 토큰}
-                    - 쿼리 파라미터: year, month(1~12)
-                    
+
                     선택한 월의 완료 페이지 수, 기록이 있는 날짜, 완성/진행 중 스토리북 통계를 조회합니다.
+
+                    ## 요청 형식
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+                    - **Query Parameter**
+                        - year : 조회 연도
+                        - month : 조회 월 (1~12)
+
+                    ## 동작 방식
+                    1. 인증된 회원을 조회합니다.
+                    2. 요청한 연/월(year, month)의 시작일~종료일 범위를 계산합니다.
+                    3. 해당 기간에 완료(COMPLETED)된 장 기록을 조회하여 완료 페이지 수(completedPageCount)와 기록이 있는 날짜(recordedDays)를 계산합니다.
+                    4. 회원의 전체 스토리북 진행 정보 중 해당 기간 내 마지막 장 순서(lastChapterOrder)가 10(전체 장 수)인 스토리북을 완성 스토리북(completedStorybooks)으로 집계합니다.
+                    5. 해당 기간 내 lastChapterOrder가 10 미만인 스토리북 수를 진행 중 스토리북 수(inProgressStorybookCount)로 집계합니다.
+                    6. 계산된 통계와 완성 스토리북 목록을 반환합니다.
                     """
     )
     @ApiResponses(value = {
@@ -88,12 +99,22 @@ public interface CalendarControllerDocs {
             summary = "일별 기록 조회 API",
             description = """
                     # 일별 기록 조회
-                    
-                    ## 요청 형식
-                    - 헤더: Authorization: Bearer {JWT 토큰}
-                    - 경로 변수: date (yyyy-MM-dd)
-                    
+
                     특정 날짜에 완료한 스토리북과 기록한 장 목록을 조회합니다.
+
+                    ## 요청 형식
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+                    - **Path Variable**
+                        - date : 조회할 날짜 (yyyy-MM-dd)
+
+                    ## 동작 방식
+                    1. 인증된 회원을 조회합니다.
+                    2. 요청한 날짜(date)에 완료(COMPLETED)된 장 기록을 최신 수정순으로 조회합니다.
+                    3. 각 기록의 스토리북별 진행 상태를 계산합니다.
+                    4. 완료한 장이 마지막 장(10번째)이면 완성 스토리북(storybooks) 목록에 추가합니다.
+                    5. 그 외의 경우 다음에 읽을 장 순서(nextChapterOrder)를 계산하여 진행 중 장(chapters) 목록에 추가합니다.
+                    6. 완성 스토리북과 진행 중 장 목록을 함께 반환합니다.
                     """
     )
     @ApiResponses(value = {

--- a/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
@@ -17,11 +17,22 @@ public interface ChapterControllerDocs {
             summary = "오늘의 장 조회 API",
             description = """
                     # 오늘의 장 조회
-                    
+
                     ## 요청 형식
-                    - 헤더: Authorization: Bearer {JWT 토큰}
-                    - storybookId: 조회할 스토리북 ID
-                    - chapterOrder: 조회할 장 순서 (1~10)
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+                    - **Path Variable**
+                        - storybookId : 조회할 스토리북 ID
+                        - chapterOrder : 조회할 장 순서 (1~10)
+
+                    ## 동작 방식
+                    1. storybookId와 chapterOrder로 장을 조회합니다. 존재하지 않으면 404(CHAPTER404_1)를 반환합니다.
+                    2. 회원의 스토리북 진행 정보(MemberStorybook)를 조회합니다.
+                    3. 오늘 이미 이 스토리북의 장을 완료했다면 403(CHAPTER403_3)을 반환합니다.
+                    4. 진행 중인 장 순서를 기준으로 요청한 장에 접근 가능한지 검증합니다. 아직 열리지 않은 장이면 403(CHAPTER403_1), 이미 완료한 장이면 403(CHAPTER403_2)을 반환합니다.
+                    5. 스토리북의 캐릭터(ORIGINAL/IMAGE_CHOICE), 질문 목록, 장면 카드를 함께 조회합니다.
+                    6. 임시저장(draft) 답변이 있으면 함께 조회하고, imageKey가 있으면 presigned imageUrl을 새로 발급합니다.
+                    7. 오늘의 장 정보를 반환합니다.
 
                     ## 참고
                     - 응답의 imageUrl은 매 요청마다 새로 발급되는 presigned GET URL이며, 발급 후 1시간 동안만 유효합니다. 캐싱하지 말고 응답받은 URL을 바로 사용해주세요.

--- a/src/main/java/com/umc/halo/domain/content/storybook/controller/docs/StorybookControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/controller/docs/StorybookControllerDocs.java
@@ -86,6 +86,36 @@ public interface StorybookControllerDocs {
                                     }
                                     """)
                     )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
             )
     })
     ApiResponse<StorybookResDTO.GetHome> getHome(
@@ -162,6 +192,36 @@ public interface StorybookControllerDocs {
                                     }
                                     """)
                     )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
             )
     })
     ApiResponse<StorybookResDTO.GetStorybookList> getStorybookList(
@@ -179,7 +239,7 @@ public interface StorybookControllerDocs {
                     - **Header**
                         - Authorization: Bearer {accessToken}
                     - **Path Variable**
-                        - storybookId: 조회할 스토리북 ID
+                        - storybookId : 조회할 스토리북 ID
 
                     ## 동작 방식
                     1. storybookId로 스토리북을 조회합니다. 존재하지 않으면 404(STORYBOOK404_1)를 반환합니다.
@@ -232,18 +292,49 @@ public interface StorybookControllerDocs {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "존재하지 않는 스토리북",
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": false,
-                                      "code": "STORYBOOK404_1",
-                                      "message": "존재하지 않는 스토리북입니다.",
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
                                       "result": null
                                     }
                                     """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원 또는 스토리북",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 회원",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "MEMBER404_1",
+                                                      "message": "존재하지 않는 회원입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 스토리북",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "STORYBOOK404_1",
+                                                      "message": "존재하지 않는 스토리북입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             )
     })
@@ -263,7 +354,7 @@ public interface StorybookControllerDocs {
                     - **Header**
                         - Authorization: Bearer {accessToken}
                     - **Path Variable**
-                        - storybookId: 시작할 스토리북 ID
+                        - storybookId : 시작할 스토리북 ID
 
                     ## 동작 방식
                     1. storybookId로 스토리북을 조회합니다. 존재하지 않으면 404(STORYBOOK404_1)를 반환합니다.
@@ -295,18 +386,80 @@ public interface StorybookControllerDocs {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "409",
-                    description = "이미 진행중이거나 이미 완료한 스토리북",
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": false,
-                                      "code": "STORYBOOK409_1",
-                                      "message": "이미 시작한 스토리북입니다.",
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
                                       "result": null
                                     }
                                     """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원 또는 스토리북",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 회원",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "MEMBER404_1",
+                                                      "message": "존재하지 않는 회원입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 스토리북",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "STORYBOOK404_1",
+                                                      "message": "존재하지 않는 스토리북입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 진행중이거나 이미 완료한 스토리북",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "이미 진행 중인 스토리북",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "STORYBOOK409_1",
+                                                      "message": "이미 시작한 스토리북입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "이미 완료한 스토리북",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "STORYBOOK409_2",
+                                                      "message": "이미 완료한 스토리북은 다시 시작할 수 없습니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             )
     })
@@ -363,6 +516,36 @@ public interface StorybookControllerDocs {
                                           }
                                         ]
                                       }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
+                                      "result": null
                                     }
                                     """)
                     )

--- a/src/main/java/com/umc/halo/domain/content/storybook/controller/docs/StorybookControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/controller/docs/StorybookControllerDocs.java
@@ -18,15 +18,15 @@ public interface StorybookControllerDocs {
     @Operation(
             summary = "홈 화면 조회 API",
             description = """
-                    ### 홈 화면 조회
+                    # 홈 화면 조회
 
                     로그인한 회원의 진행 중인 스토리북 현황, 책장 목록, 추천 스토리북과 홈 화면 상태를 조회합니다.
 
-                    **요청 형식**
-                    - Header
+                    ## 요청 형식
+                    - **Header**
                         - Authorization: Bearer {accessToken}
 
-                    **동작 방식**
+                    ## 동작 방식
                     1. 인증된 회원의 진행 중인 스토리북들을 조회합니다.
                     2. 진행 중인 스토리북 전체의 제목/진행 상황을 리스트로 계산합니다.
                     3. 전체 스토리북의 책장 상태(NOT_STARTED/IN_PROGRESS/COMPLETED)를 계산합니다.
@@ -95,15 +95,15 @@ public interface StorybookControllerDocs {
     @Operation(
             summary = "스토리북 목록 조회 API",
             description = """
-                    ### 스토리북 목록 조회
+                    # 스토리북 목록 조회
 
                     로그인한 회원의 스토리북 목록과 진행 상태, 상황별 추천 5개 카테고리를 조회합니다.
 
-                    **요청 형식**
-                    - Header
+                    ## 요청 형식
+                    - **Header**
                         - Authorization: Bearer {accessToken}
 
-                    **동작 방식**
+                    ## 동작 방식
                     1. 전체 스토리북을 테마 순서대로 조회합니다.
                     2. 회원별 진행 상태(NOT_STARTED/IN_PROGRESS/TODAY_DONE/COMPLETED)를 계산합니다.
                     3. 회원이 온보딩에서 선택한 목적 태그를 기준으로 상황별 추천 카테고리를 구성합니다.
@@ -171,17 +171,17 @@ public interface StorybookControllerDocs {
     @Operation(
             summary = "스토리북 상세 조회 API",
             description = """
-                    ### 스토리북 상세 조회
+                    # 스토리북 상세 조회
 
                     스토리북 상세 정보와 10개 장 목록(진행 상태 포함)을 조회합니다.
 
-                    **요청 형식**
-                    - Header
+                    ## 요청 형식
+                    - **Header**
                         - Authorization: Bearer {accessToken}
-                    - Path Variable
+                    - **Path Variable**
                         - storybookId: 조회할 스토리북 ID
 
-                    **동작 방식**
+                    ## 동작 방식
                     1. storybookId로 스토리북을 조회합니다. 존재하지 않으면 404(STORYBOOK404_1)를 반환합니다.
                     2. 회원의 장별 완료 여부를 조회합니다.
                     3. member_storybook의 lastCompletedDate로 오늘 완료 여부를 확인합니다.
@@ -255,17 +255,17 @@ public interface StorybookControllerDocs {
     @Operation(
             summary = "스토리북 시작하기 API",
             description = """
-                    ### 스토리북 시작하기
+                    # 스토리북 시작하기
 
                     선택한 스토리북을 시작합니다.
 
-                    **요청 형식**
-                    - Header
+                    ## 요청 형식
+                    - **Header**
                         - Authorization: Bearer {accessToken}
-                    - Path Variable
+                    - **Path Variable**
                         - storybookId: 시작할 스토리북 ID
 
-                    **동작 방식**
+                    ## 동작 방식
                     1. storybookId로 스토리북을 조회합니다. 존재하지 않으면 404(STORYBOOK404_1)를 반환합니다.
                     2. 이미 시작한 스토리북인지 확인합니다.
                     3. 완료까지 한 경우 409(STORYBOOK409_2), 진행 중인 경우 409(STORYBOOK409_1)를 반환합니다.
@@ -318,15 +318,15 @@ public interface StorybookControllerDocs {
     @Operation(
             summary = "추천 스토리북 조회 API",
             description = """
-                    ### 추천 스토리북 조회
+                    # 추천 스토리북 조회
 
                     온보딩 시 선택한 목적 태그를 기반으로 추천 스토리북 2개를 조회합니다.
 
-                    **요청 형식**
-                    - Header
+                    ## 요청 형식
+                    - **Header**
                         - Authorization: Bearer {accessToken}
 
-                    **동작 방식**
+                    ## 동작 방식
                     1. 회원이 온보딩에서 선택한 목적 태그를 조회합니다.
                     2. 태그와 매칭되는 스토리북을 우선순위(PRIMARY > SECONDARY) 순으로 정렬합니다.
                     3. 매칭된 스토리북이 2개 미만이면 테마 순서를 기준으로 나머지를 채웁니다.

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -19,13 +19,15 @@ public interface AnniversaryControllerDocs {
 
     @Operation(summary = "기념일 목록 조회 API",
             description = """
-                    ### 기념일 목록 조회
+                    # 기념일 목록 조회
+
                     마이페이지 내 기념일 관리 화면에서 사용자의 기념일 정보를 조회합니다.
 
-                    **요청 형식**
-                    - 별도의 요청 파라미터 없이 인증 토큰만으로 조회합니다.
+                    ## 요청 형식
+                    - **Header**
+                        - Authorization: Bearer {accessToken}
 
-                    **동작 방식**
+                    ## 동작 방식
                     1. 로그인한 회원이 등록한 기념일 목록을 조회합니다.
                     2. 반복 여부(isRepeated)를 기준으로 다가오는 기념일의 D-day를 계산합니다.
                     3. 음력 기반 기본 기념일(추석, 설날 등)은 KASI(한국천문연구원) 표준 기반 음력-양력 변환 라이브러리로 실제 양력 날짜를 계산하여 D-day에 반영합니다.
@@ -37,17 +39,22 @@ public interface AnniversaryControllerDocs {
 
     @Operation(summary = "기념일 추가 API",
             description = """
-                    ### 기념일 추가
+                    # 기념일 추가
+
                     사용자가 새로운 기념일을 등록합니다.
 
-                    **요청 형식**
-                    - title: 기념일명 (필수, 20자 이하)
-                    - anniversaryDate: 날짜 (필수)
-                    - sevenDaysAlarmEnabled: D-7 알림 여부 (필수)
-                    - dayAlarmEnabled: 당일 알림 여부 (필수)
-                    - memo: 메모 (선택, 255자 이하)
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {accessToken}
+                    - **Body**
+                        - title : 기념일명 (필수, 20자 이하)
+                        - anniversaryDate : 날짜 (필수)
+                        - sevenDaysAlarmEnabled : D-7 알림 여부 (필수)
+                        - dayAlarmEnabled : 당일 알림 여부 (필수)
+                        - memo : 메모 (선택, 255자 이하)
 
-                    **동작 방식**
+                    ## 동작 방식
                     1. 기념일명, 날짜, 알림 설정을 필수로 입력받습니다.
                     2. 메모는 선택 입력이며 255자 이하로 제한됩니다.
                     3. 요청 값을 기반으로 기념일을 저장하고, 생성된 기념일의 ID를 반환합니다.
@@ -94,18 +101,24 @@ public interface AnniversaryControllerDocs {
 
     @Operation(summary = "기념일 수정 API",
             description = """
-                    ### 기념일 수정
+                    # 기념일 수정
+
                     사용자가 등록한 기념일 정보를 수정합니다.
 
-                    **요청 형식**
-                    - Path Variable: anniversaryId (수정할 기념일 ID)
-                    - title: 기념일명 (필수, 20자 이하)
-                    - anniversaryDate: 날짜 (필수)
-                    - sevenDaysAlarmEnabled: D-7 알림 여부 (필수)
-                    - dayAlarmEnabled: 당일 알림 여부 (필수)
-                    - memo: 메모 (선택, 255자 이하)
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {accessToken}
+                    - **Path Variable**
+                        - anniversaryId : 수정할 기념일 ID
+                    - **Body**
+                        - title : 기념일명 (필수, 20자 이하)
+                        - anniversaryDate : 날짜 (필수)
+                        - sevenDaysAlarmEnabled : D-7 알림 여부 (필수)
+                        - dayAlarmEnabled : 당일 알림 여부 (필수)
+                        - memo : 메모 (선택, 255자 이하)
 
-                    **동작 방식**
+                    ## 동작 방식
                     1. 요청한 기념일이 존재하는지 확인하고, 존재하지 않으면 404 예외를 반환합니다.
                     2. 해당 기념일이 로그인한 회원 소유인지 확인하고, 본인 소유가 아니면 403 예외를 반환합니다.
                     3. 검증을 통과하면 요청 값으로 기념일 정보를 갱신합니다.
@@ -168,13 +181,18 @@ public interface AnniversaryControllerDocs {
 
     @Operation(summary = "기념일 삭제 API",
             description = """
-                    ### 기념일 삭제
+                    # 기념일 삭제
+
                     사용자가 등록한 기념일을 하나 이상 선택하여 한 번에 삭제합니다.
 
-                    **요청 형식**
-                    - anniversaryIds: 삭제할 기념일 ID 목록 (필수, 예: [1, 2, 5])
+                    ## 요청 형식
+                    - **Header**
+                        - Content-Type: application/json
+                        - Authorization: Bearer {accessToken}
+                    - **Body**
+                        - anniversaryIds : 삭제할 기념일 ID 목록 (필수, 예: [1, 2, 5])
 
-                    **동작 방식**
+                    ## 동작 방식
                     1. 요청한 ID 목록이 모두 존재하는지 확인하고, 하나라도 존재하지 않으면 404 예외를 반환합니다.
                     2. 요청한 ID가 모두 로그인한 회원 소유인지 확인하고, 하나라도 본인 소유가 아니면 403 예외를 반환합니다.
                     3. 검증을 통과하면 요청한 기념일을 모두 삭제합니다. (부분 삭제는 지원하지 않으며, 검증 실패 시 전체가 실패합니다.)

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -33,6 +33,38 @@ public interface AnniversaryControllerDocs {
                     3. 음력 기반 기본 기념일(추석, 설날 등)은 KASI(한국천문연구원) 표준 기반 음력-양력 변환 라이브러리로 실제 양력 날짜를 계산하여 D-day에 반영합니다.
                     4. 다가오는 기념일(upcomingAnniversaries), 내가 추가한 기념일(myAnniversaries), 기본 기념일(commonAnniversaries) 세 목록을 함께 반환합니다.
                     """)
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            )
+    })
     ApiResponse<AnniversaryResDTO.GetAnniversaries> getAnniversaries(
             @AuthenticationPrincipal Long memberId
     );
@@ -74,6 +106,21 @@ public interface AnniversaryControllerDocs {
                                       "result": {
                                         "anniversaryId": 5
                                       }
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
+                                      "result": null
                                     }
                                     """)
                     )
@@ -143,18 +190,49 @@ public interface AnniversaryControllerDocs {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "존재하지 않는 기념일",
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": false,
-                                      "code": "ANNIVERSARY404_1",
-                                      "message": "존재하지 않는 일정입니다.",
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
                                       "result": null
                                     }
                                     """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원 또는 기념일",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 회원",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "MEMBER404_1",
+                                                      "message": "존재하지 않는 회원입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 기념일",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "ANNIVERSARY404_1",
+                                                      "message": "존재하지 않는 일정입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -215,18 +293,49 @@ public interface AnniversaryControllerDocs {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "존재하지 않는 기념일 포함",
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
                     content = @Content(
                             mediaType = "application/json",
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": false,
-                                      "code": "ANNIVERSARY404_1",
-                                      "message": "존재하지 않는 일정입니다.",
+                                      "code": "AUTH401_1",
+                                      "message": "토큰이 만료되었습니다.",
                                       "result": null
                                     }
                                     """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원 또는 기념일 포함",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 회원",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "MEMBER404_1",
+                                                      "message": "존재하지 않는 회원입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 기념일 포함",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "ANNIVERSARY404_1",
+                                                      "message": "존재하지 않는 일정입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -17,12 +17,19 @@ public interface OnboardingControllerDocs {
             summary = "닉네임 중복 확인 API",
             description = """
                     # 닉네임 중복 확인
-                    
-                    ## 요청 형식
-                    - 헤더: Authorization: Bearer {JWT 토큰}
-                    - 쿼리 파라미터: nickname
-                    
+
                     닉네임은 2~10자, 특수문자를 사용할 수 없습니다.
+
+                    ## 요청 형식
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+                    - **Query Parameter**
+                        - nickname : 확인할 닉네임
+
+                    ## 동작 방식
+                    1. 닉네임 형식(2~10자, 한글/영문/숫자만 허용)을 검증합니다. 형식에 맞지 않으면 400(ONBOARDING400_1)을 반환합니다.
+                    2. 형식이 유효하면 이미 사용 중인 닉네임인지 확인합니다.
+                    3. 사용 가능 여부(isAvailable)를 반환합니다.
                     """
     )
     @ApiResponses(value = {
@@ -80,17 +87,26 @@ public interface OnboardingControllerDocs {
             summary = "온보딩 정보 저장 API",
             description = """
                     # 온보딩 정보 저장 (step 1~5 부분 저장)
-                    
+
                     ## 요청 형식
-                   - 헤더: Authorization: Bearer {JWT 토큰}
-                    - Body: step + 해당 단계 필드
-                    
-                    ## 단계별 필드
-                    - step 1: name
-                    - step 2: gender, birthDate
-                    - step 3: parentPersonalityTagIds (최대 3)
-                    - step 4: currentRelationStateTagId (1개)
-                    - step 5: goalRelationshipTagIds (최소 1, 최대 2) → 저장 시 온보딩 완료
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+                    - **Body**
+                        - step : 저장할 온보딩 단계 (1~5)
+                        - step 1 : name
+                        - step 2 : gender, birthDate
+                        - step 3 : parentPersonalityTagIds (최대 3)
+                        - step 4 : currentRelationStateTagId (1개)
+                        - step 5 : goalRelationshipTagIds (최소 1, 최대 2) → 저장 시 온보딩 완료
+
+                    ## 동작 방식
+                    1. 요청받은 step(1~5)에 따라 필요한 필드를 검증합니다. 필수값이 없으면 400(ONBOARDING400_3)을 반환합니다.
+                    2. step 1은 이름/닉네임 형식을, step 2는 성별과 생년월일(미래 날짜 불가)을 검증합니다.
+                    3. step 3(부모님 성향 태그, 최대 3개)/step 4(현재 관계 상태 태그, 1개)/step 5(목표 관계 태그, 1~2개)는 각각 해당 카테고리의 태그인지 확인하고, 존재하지 않는 태그면 404(ONBOARDING404_1)를 반환합니다.
+                    4. 태그가 포함된 step은 기존 태그를 삭제하고 새로 저장합니다.
+                    5. 회원의 온보딩 단계(onboardingStep)를 갱신합니다.
+                    6. step이 5(마지막 단계)이면 온보딩을 완료 처리합니다.
+                    7. 저장된 단계와 완료 여부를 반환합니다.
                     """
     )
     @ApiResponses(value = {
@@ -165,12 +181,19 @@ public interface OnboardingControllerDocs {
             summary = "온보딩 진행 상태 조회 API",
             description = """
                     # 온보딩 진행 상태 조회
-                    
-                    ## 요청 형식
-                  - 헤더: Authorization: Bearer {JWT 토큰}
-                    
+
                     완료 여부 + 이어할 단계(currentStep) + 지금까지 저장된 값(savedData)을 반환합니다.
                     시작 전이면 currentStep, savedData는 null 입니다.
+
+                    ## 요청 형식
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+
+                    ## 동작 방식
+                    1. 회원의 저장된 온보딩 단계(onboardingStep)를 조회합니다.
+                    2. 온보딩을 시작한 적이 없으면(onboardingStep이 null) currentStep과 savedData를 null로 반환합니다.
+                    3. 시작했다면 회원의 태그를 카테고리별로 조회하여 parentTagIds, currentRelationTagId, goalTagIds로 매핑합니다.
+                    4. 온보딩 완료 여부, 이어서 진행할 단계, 지금까지 저장된 값을 함께 반환합니다.
                     """
     )
     @ApiResponses(value = {

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -182,7 +182,7 @@ public interface OnboardingControllerDocs {
             description = """
                     # 온보딩 진행 상태 조회
 
-                    완료 여부 + 이어할 단계(currentStep) + 지금까지 저장된 값(savedData)을 반환합니다.
+                    완료 여부 + 저장된 단계(currentStep) + 지금까지 저장된 값(savedData)을 반환합니다.
                     시작 전이면 currentStep, savedData는 null 입니다.
 
                     ## 요청 형식
@@ -193,7 +193,7 @@ public interface OnboardingControllerDocs {
                     1. 회원의 저장된 온보딩 단계(onboardingStep)를 조회합니다.
                     2. 온보딩을 시작한 적이 없으면(onboardingStep이 null) currentStep과 savedData를 null로 반환합니다.
                     3. 시작했다면 회원의 태그를 카테고리별로 조회하여 parentTagIds, currentRelationTagId, goalTagIds로 매핑합니다.
-                    4. 온보딩 완료 여부, 이어서 진행할 단계, 지금까지 저장된 값을 함께 반환합니다.
+                    4. 온보딩 완료 여부, 현재까지 저장된 단계, 지금까지 저장된 값을 함께 반환합니다.
                     """
     )
     @ApiResponses(value = {

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -17,15 +17,29 @@ public interface RecordControllerDocs {
             summary = "장 기록 작성 API",
             description = """
                     # 장 기록 작성
-                    
+
                     ## 요청 형식
-                    - 헤더: Authorization: Bearer {JWT 토큰}
-                    - storybookChapterId: 기록할 스토리북-장 ID
-                    - emotion / coverType: status가 COMPLETED일 때만 필수
-                    - imageUrl / imageKey: coverType이 IMAGE일 때만 필수
-                    - sceneCardId: coverType이 SCENE_CARD일 때만 필수
-                    - answers: 질문별 답변 목록 (최대 3개, 단계별 저장 시 일부만 포함 가능. status가 COMPLETED일 때는 장의 모든 질문에 대한 답변 필요)
-                    - status: DRAFT(임시저장) 또는 COMPLETED(최종완료)
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+                    - **Body**
+                        - storybookChapterId : 기록할 스토리북-장 ID
+                        - emotion / coverType : status가 COMPLETED일 때만 필수
+                        - imageUrl / imageKey : coverType이 IMAGE일 때만 필수
+                        - sceneCardId : coverType이 SCENE_CARD일 때만 필수
+                        - answers : 질문별 답변 목록 (최대 3개, 단계별 저장 시 일부만 포함 가능. status가 COMPLETED일 때는 장의 모든 질문에 대한 답변 필요)
+                        - status : DRAFT(임시저장) 또는 COMPLETED(최종완료)
+
+                    ## 동작 방식
+                    1. storybookChapterId로 장을 조회합니다. 존재하지 않으면 404(CHAPTER404_1)를 반환합니다.
+                    2. 회원의 스토리북 진행 정보(MemberStorybook)를 조회합니다. 아직 시작하지 않은 스토리북이면 403(CHAPTER403_1)을 반환합니다.
+                    3. 오늘 이미 이 스토리북의 장을 완료했다면 409(CHAPTER409_1)를 반환합니다.
+                    4. 진행 중인 장 순서를 기준으로 요청한 장에 접근 가능한지 검증합니다. 이미 완료한 장이면 403(CHAPTER403_2)을 반환합니다.
+                    5. coverType과 imageUrl/imageKey/sceneCardId 조합이 일치하는지 검증합니다. (CHAPTER400_1)
+                    6. status가 COMPLETED이면 coverType, emotion이 모두 입력되었는지, 장의 모든 질문에 답변했는지 검증합니다. (CHAPTER400_4~6)
+                    7. sceneCardId가 있으면 해당 장의 장면 카드가 맞는지 확인합니다. (CHAPTER400_2)
+                    8. 장 기록(MemberChapter)을 생성하거나 갱신합니다. 동시 요청으로 중복 저장이 발생하면 409(CHAPTER409_2)를 반환합니다.
+                    9. 기존 답변을 삭제하고 요청받은 답변을 새로 저장합니다. 각 답변의 chapterQuestionId가 해당 장의 질문인지 검증합니다. (CHAPTER400_3)
+                    10. status가 COMPLETED면 스토리북 진행 상태를 갱신하고 AI 요약 생성 이벤트를 발행합니다. 마지막 장(10번째)이면 isStorybookCompleted를 true로 반환합니다. status가 DRAFT면 임시저장 상태로 진행 정보를 갱신합니다.
                     """,
             responses = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -370,10 +384,20 @@ public interface RecordControllerDocs {
             summary = "완료된 장 다시보기 API",
             description = """
                     # 완료된 장 다시보기
-                    
+
                     ## 요청 형식
-                    - 헤더: Authorization: Bearer {JWT 토큰}
-                    - memberChapterId: 사용자 장 ID (path variable)
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+                    - **Path Variable**
+                        - memberChapterId : 다시 볼 장 기록 ID
+
+                    ## 동작 방식
+                    1. memberChapterId로 장 기록을 조회합니다. 존재하지 않으면 404(CHAPTER404_4)를 반환합니다.
+                    2. 조회한 장 기록이 로그인한 회원 소유인지 확인합니다. 본인 소유가 아니면 존재하지 않는 것과 동일하게 404(CHAPTER404_4)를 반환합니다.
+                    3. 장 기록이 완료(COMPLETED) 상태인지 확인합니다. 아직 완료되지 않았다면 403(CHAPTER403_4)을 반환합니다.
+                    4. coverType이 IMAGE면 imageKey로 presigned imageUrl을 새로 발급합니다.
+                    5. 질문 순서대로 답변 목록을 조회합니다.
+                    6. 완료된 장의 상세 정보를 반환합니다.
 
                     ## 참고
                     - 응답의 imageUrl은 매 요청마다 새로 발급되는 presigned GET URL이며, 발급 후 1시간 동안만 유효합니다. 캐싱하지 말고 응답받은 URL을 바로 사용해주세요.
@@ -485,5 +509,3 @@ public interface RecordControllerDocs {
             @Parameter(description = "다시 볼 장 기록 ID", example = "10")
             @PathVariable Long memberChapterId);
 }
-
-

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -33,7 +33,7 @@ public interface RecordControllerDocs {
                     1. storybookChapterId로 장을 조회합니다. 존재하지 않으면 404(CHAPTER404_1)를 반환합니다.
                     2. 회원의 스토리북 진행 정보(MemberStorybook)를 조회합니다. 아직 시작하지 않은 스토리북이면 403(CHAPTER403_1)을 반환합니다.
                     3. 오늘 이미 이 스토리북의 장을 완료했다면 409(CHAPTER409_1)를 반환합니다.
-                    4. 진행 중인 장 순서를 기준으로 요청한 장에 접근 가능한지 검증합니다. 이미 완료한 장이면 403(CHAPTER403_2)을 반환합니다.
+                    4. 진행 중인 장 순서를 기준으로 요청한 장에 접근 가능한지 검증합니다. 아직 열리지 않은 장이면 403(CHAPTER403_1), 이미 완료한 장이면 403(CHAPTER403_2)을 반환합니다.
                     5. coverType과 imageUrl/imageKey/sceneCardId 조합이 일치하는지 검증합니다. (CHAPTER400_1)
                     6. status가 COMPLETED이면 coverType, emotion이 모두 입력되었는지, 장의 모든 질문에 답변했는지 검증합니다. (CHAPTER400_4~6)
                     7. sceneCardId가 있으면 해당 장의 장면 카드가 맞는지 확인합니다. (CHAPTER400_2)

--- a/src/main/java/com/umc/halo/domain/relationship/controller/docs/RelationshipControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/relationship/controller/docs/RelationshipControllerDocs.java
@@ -16,12 +16,20 @@ public interface RelationshipControllerDocs {
             summary = "관계 정보 조회 API",
             description = """
                     # 관계 정보 조회
-                    
-                    ## 요청 형식
-                    - 헤더: Authorization: Bearer {JWT 토큰}
-                    
+
                     마이페이지에서 온보딩 때 선택한 관계 태그를 조회합니다.
                     온보딩 전이면 빈 목록([])과 null을 반환합니다.
+
+                    ## 요청 형식
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+
+                    ## 동작 방식
+                    1. 인증된 회원을 조회합니다. 존재하지 않으면 404(MEMBER404_1)를 반환합니다.
+                    2. 회원이 온보딩에서 선택한 태그 목록을 조회합니다.
+                    3. 태그를 카테고리별로 분류합니다: 부모님 성향(parentPersonalityTags), 현재 관계 상태(currentRelationState), 목표 관계(goalRelationships).
+                    4. 온보딩 전이라 저장된 태그가 없으면 빈 목록([])과 null을 반환합니다.
+                    5. 분류된 관계 정보를 반환합니다.
                     """
     )
     @ApiResponses(value = {

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -22,12 +22,12 @@ public interface SettingControllerDocs {
             description = """
                     # 알림 설정 조회
                     현재 알림 설정을 조회합니다. (정기 알림/정기 알림 시간/전체 알림/오늘의 장 알림/리텐션 알림/기념일 알림)
-                    
+
                     ## 요청 형식
                     - **Header**
                         - Content-Type: application/json
                         - Authorization: Bearer {Access Token}
-                    
+
                     ## 동작 방식
                     1. Access Token으로 현재 회원을 인증합니다.
                     2. 회원의 알림 설정 정보를 조회합니다.
@@ -60,6 +60,22 @@ public interface SettingControllerDocs {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_1",
+                                        "message": "토큰이 만료되었습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
                     description = "memberSetting이 생성되지 않음",
                     content = @Content(
@@ -84,12 +100,12 @@ public interface SettingControllerDocs {
             description = """
                     # BGM 설정 조회
                     현재 BGM 설정을 조회합니다. (선택된 배경음악, 배경음악 ON, OFF 여부/배경음악 볼륨)
-                    
+
                     ## 요청 형식
                     - **Header**
                         - Content-Type: application/json
                         - Authorization: Bearer {Access Token}
-                    
+
                     ## 동작 방식
                     1. Access Token으로 현재 회원을 인증합니다.
                     2. 회원의 BGM 설정 정보를 조회합니다.
@@ -112,6 +128,22 @@ public interface SettingControllerDocs {
                                             "bgmEnabled": true,
                                             "bgmVolume": 70
                                         }
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_1",
+                                        "message": "토큰이 만료되었습니다.",
+                                        "result": null
                                     }
                                     """
                             )
@@ -142,12 +174,12 @@ public interface SettingControllerDocs {
             description = """
                     # BGM 목록 조회
                     내장으로 다운로드받은 BGM 목록을 조회합니다.
-                    
+
                     ## 요청 형식
                     - **Header**
                         - Content-Type: application/json
                         - Authorization: Bearer {Access Token}
-                    
+
                     ## 동작 방식
                     1. 서버에 등록된 BGM 메타데이터를 조회합니다.
                     2. 각 BGM의 제목, 파일명, 이미지 정보를 반환합니다.
@@ -184,10 +216,7 @@ public interface SettingControllerDocs {
                                              "title": "산들바람3",
                                              "fileName": "http://www.bgm-example3.com",
                                              "imageName": "http://www.img-example3.com"
-                                           },
-                                           .
-                                           .
-                                           .
+                                           }
                                          ]
                                        }
                                      }
@@ -220,7 +249,7 @@ public interface SettingControllerDocs {
             description = """
                     # 알림 설정 수정
                     알림 설정을 수정합니다. (정기 알림/정기 알림 시간/전체 알림/오늘의 장 알림/리텐션 알림/기념일 알림)
-                    
+
                     ## 요청 형식
                     - **Header**
                         - Content-Type: application/json
@@ -231,7 +260,7 @@ public interface SettingControllerDocs {
                         - todayChapterNotificationEnabled : 오늘의 장 알림 ON/OFF 여부
                         - retentionNotificationEnabled : 리텐션 알림 ON/OFF 여부
                         - anniversaryNotificationEnabled : 기념일 알림 ON/OFF 여부
-                    
+
                     ## 동작 방식
                     1. Access Token으로 현재 회원을 인증합니다.
                     2. 회원의 알림 설정 정보를 조회합니다.
@@ -265,6 +294,22 @@ public interface SettingControllerDocs {
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_1",
+                                        "message": "토큰이 만료되었습니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
                     description = "memberSetting이 생성되지 않음",
                     content = @Content(
@@ -289,7 +334,7 @@ public interface SettingControllerDocs {
             description = """
                     # BGM 설정 수정
                     BGM 설정을 수정합니다. (선택된 배경음악, 배경음악 ON, OFF 여부/배경음악 볼륨)
-                    
+
                     ## 요청 형식
                     - **Header**
                         - Content-Type: application/json
@@ -298,7 +343,7 @@ public interface SettingControllerDocs {
                         - bgmId : 선택한 BGM ID (선택하지 않은 경우 null)
                         - bgmEnabled : BGM ON/OFF 여부
                         - bgmVolume : BGM 볼륨 (0~100)
-                    
+
                     ## 동작 방식
                     1. Access Token으로 현재 회원을 인증합니다.
                     2. 회원의 BGM 설정 정보를 조회합니다.
@@ -353,7 +398,7 @@ public interface SettingControllerDocs {
                                     {
                                         "isSuccess": false,
                                         "code": "BGM400_2",
-                                        "message": “BGM 볼륨은 필수입니다.”,
+                                        "message": "BGM 볼륨은 필수입니다.",
                                         "result": null
                                     }
                                     """
@@ -369,7 +414,7 @@ public interface SettingControllerDocs {
                                     {
                                         "isSuccess": false,
                                         "code": "BGM400_3",
-                                        "message": “BGM 볼륨 값이 올바르지 않습니다.”,
+                                        "message": "BGM 볼륨 값이 올바르지 않습니다.",
                                         "result": null
                                     }
                                     """
@@ -385,7 +430,23 @@ public interface SettingControllerDocs {
                                     {
                                         "isSuccess": false,
                                         "code": "BGM400_4",
-                                        "message": “존재하지 않는 BGM입니다.”,
+                                        "message": "존재하지 않는 BGM입니다.",
+                                        "result": null
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "accessToken 만료·유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                        "isSuccess": false,
+                                        "code": "AUTH401_1",
+                                        "message": "토큰이 만료되었습니다.",
                                         "result": null
                                     }
                                     """
@@ -401,7 +462,7 @@ public interface SettingControllerDocs {
                                     {
                                         "isSuccess": false,
                                         "code": "SETTING404_1",
-                                        "message": “설정을 찾을 수 없습니다.”,
+                                        "message": "설정을 찾을 수 없습니다.",
                                         "result": null
                                     }
                                     """

--- a/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
@@ -21,12 +21,16 @@ public interface TermControllerDocs {
             summary = "약관 목록 조회 API",
             description = """
                     # 약관 목록 조회
-                    
-                    ## 요청 형식
-                    - 인증이 필요하지 않습니다. (Public)
-                    
+
                     약관 동의 화면에 노출할 약관 목록을 조회합니다.
                     isRequired가 true면 필수 약관, false면 선택 약관입니다.
+
+                    ## 요청 형식
+                    - 인증이 필요하지 않습니다. (Public)
+
+                    ## 동작 방식
+                    1. 등록된 전체 약관을 ID 순으로 조회합니다.
+                    2. 각 약관의 필수 여부(isRequired)와 함께 목록을 반환합니다.
                     """
     )
     @ApiResponses(value = {
@@ -57,14 +61,23 @@ public interface TermControllerDocs {
             summary = "약관 동의 처리 API",
             description = """
                     # 약관 동의 처리
-                    
-                    ## 요청 형식
-                    - 헤더: Authorization: Bearer {JWT 토큰}
-                    - Body: agreements (약관별 동의 내역)
-                    
+
                     필수 약관에 모두 동의해야 저장됩니다.
                     선택 약관은 동의하지 않아도 서비스 이용이 가능합니다.
                     이미 동의한 약관은 새로 저장하지 않고 동의 여부만 갱신합니다.
+
+                    ## 요청 형식
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+                    - **Body**
+                        - agreements : 약관별 동의 내역
+
+                    ## 동작 방식
+                    1. 인증된 회원을 조회합니다. 존재하지 않으면 404(MEMBER404_1)를 반환합니다.
+                    2. 요청받은 약관 ID들이 모두 존재하는지 확인합니다. 존재하지 않으면 404(TERMS404_1)를 반환합니다.
+                    3. 필수 약관(isRequired=true)이 모두 요청에 포함되어 동의(true) 처리되었는지 검증합니다. 하나라도 빠지거나 미동의면 400(TERMS400_1)을 반환합니다.
+                    4. 이미 동의 이력이 있는 약관은 동의 여부만 갱신하고, 없는 약관은 새로 저장합니다. (동시 요청으로 인한 저장 충돌 시 재조회 후 갱신 처리)
+                    5. 처리 결과를 반환합니다.
                     """
     )
     @ApiResponses(value = {
@@ -138,13 +151,20 @@ public interface TermControllerDocs {
             summary = "약관 동의 여부 조회 API",
             description = """
                     # 약관 동의 여부 조회
-                    
-                    ## 요청 형식
-                    - 헤더: Authorization: Bearer {JWT 토큰}
-                    
+
                     필수 약관 전체 동의 여부를 조회합니다.
                     앱 실행 시 약관 동의 화면 노출 여부 판단에 사용합니다.
                     필수 약관 중 하나라도 동의하지 않았으면 false를 반환합니다.
+
+                    ## 요청 형식
+                    - **Header**
+                        - Authorization: Bearer {JWT 토큰}
+
+                    ## 동작 방식
+                    1. 인증된 회원을 조회합니다. 존재하지 않으면 404(MEMBER404_1)를 반환합니다.
+                    2. 회원이 동의한 약관 목록을 조회합니다.
+                    3. 필수 약관(isRequired=true)이 모두 동의 목록에 포함되어 있는지 확인합니다.
+                    4. 필수 약관 중 하나라도 동의하지 않았으면 termsAgreed를 false로, 모두 동의했으면 true로 반환합니다.
                     """
     )
     @ApiResponses(value = {

--- a/src/test/java/com/umc/halo/TokenGenerator.java
+++ b/src/test/java/com/umc/halo/TokenGenerator.java
@@ -1,4 +1,0 @@
-package com.umc.halo;
-
-public class TokenGenerator {
-}


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- Swagger 문서(@Operation description) 양식을 전체 파일에 걸쳐 통일했습니다.
- 6개 파일에 없던 "동작 방식" 섹션을 추가하고, 3개 파일은 표기 방식을 기준 스타일에 맞게 통일했습니다.
- Storybook/Anniversary/Setting에 누락돼 있던 401/404 에러 응답도 함께 채웠습니다.

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 'CalendarControllerDocs', 'ChapterControllerDocs', 'OnboardingControllerDocs', 'RecordControllerDocs', 'RelationshipControllerDocs', 'TermControllerDocs': "동작 방식" 섹션 신규 추가
- 'StorybookControllerDocs', 'AnniversaryControllerDocs', 'SettingControllerDocs': 제목/섹션 표기 방식 통일 + 누락 에러 응답(401/404) 추가
- 'StorybookControllerDocs': 'startStorybook'에 누락됐던 404('STORYBOOK404_1'), 409('STORYBOOK409_2') 예시도 추가
- 코드 로직/기존 응답 예시는 변경 없음, description과 '@ApiResponses'만 수정

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #91
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서 개선**
  * Swagger API 문서의 요청 형식과 처리 절차를 단계별 설명으로 구체화했습니다.
  * 헤더, 쿼리 파라미터, 경로 변수, 본문 필드 안내를 일관된 형식으로 정리했습니다.
  * 인증 실패 및 리소스 미존재 등 오류 응답 예시를 보강했습니다.
  * BGM 응답 예시와 오류 메시지 표기를 명확하게 다듬었습니다.
* **정리**
  * 사용되지 않는 테스트용 토큰 생성기 클래스를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->