### PR TITLE
[FEAT] 캘린더 메인 조회 응답 구조 수정

### DIFF
--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -41,11 +41,15 @@ public interface CalendarControllerDocs {
                               "message": "캘린더 메인 조회를 성공했습니다.",
                               "result": {
                                 "stats": { "completedPageCount": 30, "completedStorybookCount": 3, "inProgressStorybookCount": 2 },
-                                "recordedDays": [9, 10, 11, 19],
+                                "recordedDays": [
+                                  { "day": 9, "hasCompletedStorybook": false },
+                                  { "day": 19, "hasCompletedStorybook": true }
+                                ],
                                 "completedStorybooks": [
-                                  { "storybookId": 1, "spineColor": "#F0997B" },
-                                  { "storybookId": 2, "spineColor": "#FAC775" },
-                                  { "storybookId": 3, "spineColor": "#D3C7A9" }
+                                  { "storybookId": 1 },
+                                  { "storybookId": 2 },
+                                  { "storybookId": 3 }
+                                ]
                                 ]
                               }
                             }

--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -50,7 +50,7 @@ public interface CalendarControllerDocs {
                                   { "storybookId": 2 },
                                   { "storybookId": 3 }
                                 ]
-                                ]
+                               
                               }
                             }
                             """))

--- a/src/main/java/com/umc/halo/domain/calendar/converter/CalendarConverter.java
+++ b/src/main/java/com/umc/halo/domain/calendar/converter/CalendarConverter.java
@@ -17,17 +17,22 @@ public class CalendarConverter {
                 .inProgressStorybookCount(inProgressStorybookCount)
                 .build();
     }
+    public static CalendarMonthlyResDTO.RecordedDay toRecordedDay(int day, boolean hasCompletedStorybook) {
+        return CalendarMonthlyResDTO.RecordedDay.builder()
+                .day(day)
+                .hasCompletedStorybook(hasCompletedStorybook)
+                .build();
+    }
 
     public static CalendarMonthlyResDTO.CompletedStorybook toCompletedStorybook(Storybook storybook) {
         return CalendarMonthlyResDTO.CompletedStorybook.builder()
                 .storybookId(storybook.getId())
-                .spineColor(storybook.getSpineColor())
                 .build();
     }
 
     public static CalendarMonthlyResDTO.MonthlyInfo toMonthlyInfo(
             CalendarMonthlyResDTO.Stats stats,
-            List<Integer> recordedDays,
+            List<CalendarMonthlyResDTO.RecordedDay> recordedDays,
             List<CalendarMonthlyResDTO.CompletedStorybook> completedStorybooks) {
         return CalendarMonthlyResDTO.MonthlyInfo.builder()
                 .stats(stats)

--- a/src/main/java/com/umc/halo/domain/calendar/dto/CalendarMonthlyResDTO.java
+++ b/src/main/java/com/umc/halo/domain/calendar/dto/CalendarMonthlyResDTO.java
@@ -8,7 +8,7 @@ public class CalendarMonthlyResDTO {
     @Builder
     public record MonthlyInfo(
             Stats stats,
-            List<Integer> recordedDays,
+            List<RecordedDay> recordedDays,
             List<CompletedStorybook> completedStorybooks
     ) {}
 
@@ -21,7 +21,11 @@ public class CalendarMonthlyResDTO {
 
     @Builder
     public record CompletedStorybook(
-            Long storybookId,
-            String spineColor
+            Long storybookId
+    ) {}
+    @Builder
+    public record RecordedDay(
+            Integer day,
+            Boolean hasCompletedStorybook
     ) {}
 }

--- a/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
@@ -16,7 +16,7 @@ import com.umc.halo.domain.record.repository.MemberStorybookRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import java.util.Set;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -50,20 +50,17 @@ public class CalendarService {
 
         int completedPageCount = completedChapters.size();
 
-        List<Integer> recordedDays = completedChapters.stream()
-                .map(mc -> mc.getCompletedDate().getDayOfMonth())
-                .distinct()
-                .sorted()
-                .toList();
 
         List<MemberStorybook> memberStorybooks = memberStorybookRepository
                 .findAllByMemberWithStorybook(member);
 
-        List<CalendarMonthlyResDTO.CompletedStorybook> completedStorybooks = memberStorybooks.stream()
+        List<MemberStorybook> completedThisMonth = memberStorybooks.stream()
                 .filter(ms -> ms.getLastChapterOrder() == TOTAL_CHAPTER_COUNT)
                 .filter(ms -> ms.getLastCompletedDate() != null
                         && !ms.getLastCompletedDate().isBefore(startDate)
                         && !ms.getLastCompletedDate().isAfter(endDate))
+                .toList();
+        List<CalendarMonthlyResDTO.CompletedStorybook> completedStorybooks = completedThisMonth.stream()
                 .map(ms -> CalendarConverter.toCompletedStorybook(ms.getStorybook()))
                 .toList();
 
@@ -75,6 +72,18 @@ public class CalendarService {
                         && !ms.getLastCompletedDate().isBefore(startDate)
                         && !ms.getLastCompletedDate().isAfter(endDate))
                 .count();
+
+
+        Set<Integer> completedStorybookDays = completedThisMonth.stream()
+                .map(ms -> ms.getLastCompletedDate().getDayOfMonth())
+                .collect(Collectors.toSet());
+
+        List<CalendarMonthlyResDTO.RecordedDay> recordedDays = completedChapters.stream()
+                .map(mc -> mc.getCompletedDate().getDayOfMonth())
+                .distinct()
+                .sorted()
+                .map(day -> CalendarConverter.toRecordedDay(day, completedStorybookDays.contains(day)))
+                .toList();
 
         CalendarMonthlyResDTO.Stats stats = CalendarConverter.toStats(
                 completedPageCount, completedStorybookCount, inProgressStorybookCount);


### PR DESCRIPTION
## 📝 작업 내용
 
- 캘린더 메인 조회 응답 구조 수정 (달력 마크 연한/진한 구분, 책장 spineColor 제거)

---

## 🔧 변경 사항

- recordedDays: 숫자 배열 → 객체 배열(day + hasCompletedStorybook)로 변경
  - hasCompletedStorybook: 그날 스토리북 완성 여부 (true=진한 마크, false=연한 마크)
- completedStorybooks: spineColor 제거, storybookId만 반환 (색상은 안드에서 처리)
- CalendarService 월간 집계 로직 수정 (완성일 기준 마크 여부 계산)
- Swagger 문서 수정
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="1324" height="410" alt="image" src="https://github.com/user-attachments/assets/75b8ab74-a6e4-40bd-b28b-3397a5174d6a" />

---

## ✅ 확인 사항

- [X] 서버 정상 기동 확인
- [X] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [X] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #97 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- API 명세서: 캘린더 메인 조회 (수정 반영 완료)


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 캘린더 월간 조회에서 기록된 날짜별로 스토리북 완료 여부를 확인할 수 있습니다.
  * 월간 조회 응답의 기록 날짜 정보가 날짜와 완료 여부를 함께 제공합니다.
  * 완료된 스토리북 정보에는 스토리북 ID만 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->