### PR TITLE
[refactor] Anniversary 예외 클래스 exception/code 패키지로 이동

### DIFF
--- a/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
@@ -3,7 +3,7 @@ package com.umc.halo.domain.notification.controller;
 import com.umc.halo.domain.notification.controller.docs.AnniversaryControllerDocs;
 import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
 import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
-import com.umc.halo.domain.notification.exception.AnniversarySuccessCode;
+import com.umc.halo.domain.notification.exception.code.AnniversarySuccessCode;
 import com.umc.halo.domain.notification.service.AnniversaryService;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;

--- a/src/main/java/com/umc/halo/domain/notification/exception/AnniversaryException.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/AnniversaryException.java
@@ -1,5 +1,6 @@
 package com.umc.halo.domain.notification.exception;
 
+import com.umc.halo.domain.notification.exception.code.AnniversaryErrorCode;
 import com.umc.halo.global.apiPayload.exception.ProjectException;
 
 public class AnniversaryException extends ProjectException {

--- a/src/main/java/com/umc/halo/domain/notification/exception/code/AnniversaryErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/code/AnniversaryErrorCode.java
@@ -1,4 +1,4 @@
-package com.umc.halo.domain.notification.exception;
+package com.umc.halo.domain.notification.exception.code;
 
 import com.umc.halo.global.apiPayload.code.BaseErrorCode;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/umc/halo/domain/notification/exception/code/AnniversarySuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/code/AnniversarySuccessCode.java
@@ -1,4 +1,4 @@
-package com.umc.halo.domain.notification.exception;
+package com.umc.halo.domain.notification.exception.code;
 
 import com.umc.halo.global.apiPayload.code.BaseSuccessCode;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -10,7 +10,7 @@ import com.umc.halo.domain.notification.dto.AnniversaryReqDTO;
 import com.umc.halo.domain.notification.dto.AnniversaryResDTO;
 import com.umc.halo.domain.notification.entity.Anniversary;
 import com.umc.halo.domain.notification.entity.CommonAnniversary;
-import com.umc.halo.domain.notification.exception.AnniversaryErrorCode;
+import com.umc.halo.domain.notification.exception.code.AnniversaryErrorCode;
 import com.umc.halo.domain.notification.exception.AnniversaryException;
 import com.umc.halo.domain.notification.repository.AnniversaryRepository;
 import com.umc.halo.domain.notification.repository.CommonAnniversaryRepository;


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- Anniversary 도메인의 예외 클래스(AnniversaryErrorCode, AnniversarySuccessCode)를 컨벤션 문서 구조에 맞게 exception/code/ 패키지로 이동

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- AnniversaryErrorCode.java, AnniversarySuccessCode.java를 notification/exception/ → notification/exception/code/로 이동
- AnniversaryException.java, AnniversaryController.java, AnniversaryService.java import 경로 수정
- 기능 변화 없는 순수 구조 리팩터링

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #101
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 기념일 알림 기능의 성공·오류 코드 위치를 일관된 구조로 정리했습니다.
  * 관련 기능의 동작과 예외 처리 흐름은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->