### PR TITLE
[FIX] 캘린더 이어하기 다음 장 계산 시 draft 상태 반영

### DIFF
--- a/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
@@ -107,6 +107,9 @@ public class CalendarService {
                 .findAllByMemberWithStorybook(member).stream()
                 .collect(Collectors.toMap(ms -> ms.getStorybook().getId(), Function.identity()));
 
+        Map<Long, List<MemberChapter>> chaptersByStorybook = memberChapterRepository
+                .findAllByMemberWithStorybookChapter(member).stream()
+                .collect(Collectors.groupingBy(mc -> mc.getStorybookChapter().getStorybook().getId()));
         List<CalendarDailyResDTO.StorybookInfo> storybooks = new ArrayList<>();
         List<CalendarDailyResDTO.ChapterInfo> chapters = new ArrayList<>();
 
@@ -118,12 +121,22 @@ public class CalendarService {
                 storybooks.add(CalendarConverter.toStorybookInfo(storybook));
             } else {
                 MemberStorybook ms = progressByStorybookId.get(storybook.getId());
-                int lastOrder = (ms != null) ? ms.getLastChapterOrder() : chapterOrderOfDay;
-                int nextChapterOrder = Math.min(lastOrder + 1, TOTAL_CHAPTER_COUNT);
+                List<MemberChapter> myChapters = chaptersByStorybook.getOrDefault(storybook.getId(), List.of());
+                Integer nextChapterOrder = resolveNextChapterOrder(ms, myChapters, chapterOrderOfDay);
                 chapters.add(CalendarConverter.toChapterInfo(storybook, nextChapterOrder));
             }
         }
 
         return CalendarConverter.toDailyInfo(date.toString(), storybooks, chapters);
+    }
+    private Integer resolveNextChapterOrder(MemberStorybook ms, List<MemberChapter> myChapters, int fallbackOrder) {
+        Integer lastChapterOrder = (ms != null) ? ms.getLastChapterOrder() : fallbackOrder;
+
+        boolean lastCompleted = myChapters.stream()
+                .anyMatch(mc -> lastChapterOrder.equals(mc.getStorybookChapter().getChapterOrder())
+                        && mc.getStatus() == Status.COMPLETED);
+
+        int next = lastCompleted ? lastChapterOrder + 1 : lastChapterOrder;
+        return Math.min(next, TOTAL_CHAPTER_COUNT);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 캘린더 일별 조회의 이어하기(nextChapterOrder)가 draft 상태를 반영하도록 수정
---

## 🔧 변경 사항

- CalendarService.getDaily: nextChapterOrder 계산 시 마지막 장 상태 확인
  - 마지막 장 COMPLETED → lastChapterOrder + 1
  - 마지막 장 DRAFT → lastChapterOrder (그 장부터)
- 테마함 ExhibitionService.resolveNextChapterOrder와 동일 로직 적용
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [X] 서버 정상 기동 확인
- [X] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [X] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #99 
 
---

## 📌 참고 사항

- 기존 lastChapterOrder + 1만 사용해 draft 중인 장을 건너뛰던 버그 수정

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 일일 캘린더에서 스토리북별 진행 상황을 정확히 반영하도록 다음 챕터 계산 로직을 개선했습니다.
  * 완료한 챕터가 있는 경우 해당 스토리북의 다음 챕터가 표시됩니다.
  * 챕터 진행이 전체 범위를 초과하지 않도록 처리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->