### PR TITLE
[feat] 정기 알림 시간/기념일 알림 설정 변경 시 기념일 알림에 적용

### DIFF
--- a/src/main/java/com/umc/halo/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/umc/halo/domain/notification/converter/NotificationConverter.java
@@ -13,7 +13,7 @@ public class NotificationConverter {
         throw new IllegalStateException("Utility class");
     }
 
-    public static Notification toAnniversaryNotification(Anniversary anniversary, NotificationType notificationType, String title, String message, LocalDateTime scheduledAt) {
+    public static Notification toAnniversaryNotification(Anniversary anniversary, NotificationType notificationType, String title, String message, LocalDateTime scheduledAt, Boolean settingEnabled, Boolean anniversaryEnabled) {
         return Notification.builder()
                 .member(anniversary.getMember())
                 .anniversary(anniversary)
@@ -22,6 +22,8 @@ public class NotificationConverter {
                 .message(message)
                 .scheduledAt(scheduledAt)
                 .status(NotificationStatus.SCHEDULED)
+                .settingEnabled(settingEnabled)
+                .anniversaryEnabled(anniversaryEnabled)
                 .build();
     }
 }

--- a/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
@@ -70,9 +70,15 @@ public class Notification extends BaseEntity {
         this.status = NotificationStatus.SCHEDULED;
     }
 
-    public void cancel() {
+    public void cancelBySetting() {
         if (this.status != NotificationStatus.SENT) {
-            this.status = NotificationStatus.CANCELED;
+            this.status = NotificationStatus.CANCELED_BY_SETTING;
+        }
+    }
+
+    public void cancelByAnniversary() {
+        if (this.status != NotificationStatus.SENT) {
+            this.status = NotificationStatus.CANCELED_BY_ANNIVERSARY;
         }
     }
 

--- a/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
@@ -11,7 +11,7 @@ import java.time.*;
 @Entity
 @Table(
         name = "notification",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"anniversary_id", "notification_type"})
+        uniqueConstraints = @UniqueConstraint(columnNames = {"anniversary_id", "notification_type", "scheduled_at"})
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
@@ -53,13 +53,15 @@ public class Notification extends BaseEntity {
     @Builder.Default
     private NotificationStatus status = NotificationStatus.SCHEDULED;
 
-    public void update(String title, String message, LocalDateTime scheduledAt) {
+    @Column(name = "setting_enabled", nullable = false)
+    private Boolean settingEnabled;
+
+    @Column(name = "anniversary_enabled", nullable = false)
+    private Boolean anniversaryEnabled;
+
+    public void updateContent(String title, String message) {
         this.title = title;
         this.message = message;
-        this.scheduledAt = scheduledAt;
-        if (this.status != NotificationStatus.SENT) {
-            this.status = NotificationStatus.SCHEDULED;
-        }
     }
 
     public void reserve(LocalDateTime scheduledAt) {
@@ -70,18 +72,6 @@ public class Notification extends BaseEntity {
         this.status = NotificationStatus.SCHEDULED;
     }
 
-    public void cancelBySetting() {
-        if (this.status != NotificationStatus.SENT) {
-            this.status = NotificationStatus.CANCELED_BY_SETTING;
-        }
-    }
-
-    public void cancelByAnniversary() {
-        if (this.status != NotificationStatus.SENT) {
-            this.status = NotificationStatus.CANCELED_BY_ANNIVERSARY;
-        }
-    }
-
     public void updateScheduledAt(LocalDateTime scheduledAt) {
         if (this.status == NotificationStatus.SENT) {
             return;
@@ -89,4 +79,17 @@ public class Notification extends BaseEntity {
         this.scheduledAt = scheduledAt;
     }
 
+    public void updateSettingEnabled(boolean enabled) {
+        this.settingEnabled = enabled;
+    }
+
+    public void updateAnniversaryEnabled(boolean enabled) {
+        this.anniversaryEnabled = enabled;
+    }
+
+    public void expire() {
+        if (this.status != NotificationStatus.SENT) {
+            this.status = NotificationStatus.EXPIRED;
+        }
+    }
 }

--- a/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
@@ -76,11 +76,8 @@ public class Notification extends BaseEntity {
         }
     }
 
-    public boolean isReserved() {
-        return status == NotificationStatus.SCHEDULED;
+    public void updateScheduledAt(LocalDateTime scheduledAt) {
+        this.scheduledAt = scheduledAt;
     }
 
-    public boolean isCanceled() {
-        return status == NotificationStatus.CANCELED;
-    }
 }

--- a/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Notification.java
@@ -77,6 +77,9 @@ public class Notification extends BaseEntity {
     }
 
     public void updateScheduledAt(LocalDateTime scheduledAt) {
+        if (this.status == NotificationStatus.SENT) {
+            return;
+        }
         this.scheduledAt = scheduledAt;
     }
 

--- a/src/main/java/com/umc/halo/domain/notification/enums/NotificationStatus.java
+++ b/src/main/java/com/umc/halo/domain/notification/enums/NotificationStatus.java
@@ -3,6 +3,5 @@ package com.umc.halo.domain.notification.enums;
 public enum NotificationStatus {
     SCHEDULED,
     SENT,
-    CANCELED_BY_SETTING,
-    CANCELED_BY_ANNIVERSARY
+    EXPIRED
 }

--- a/src/main/java/com/umc/halo/domain/notification/enums/NotificationStatus.java
+++ b/src/main/java/com/umc/halo/domain/notification/enums/NotificationStatus.java
@@ -3,5 +3,6 @@ package com.umc.halo.domain.notification.enums;
 public enum NotificationStatus {
     SCHEDULED,
     SENT,
-    CANCELED
+    CANCELED_BY_SETTING,
+    CANCELED_BY_ANNIVERSARY
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
@@ -18,7 +18,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("""
         select n
         from Notification n
-        left join fetch n.anniversary
+        join fetch n.anniversary
         where n.member.id = :memberId
         and n.notificationType in :notificationTypes
         and n.status in :statuses

--- a/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
@@ -4,6 +4,7 @@ import com.umc.halo.domain.notification.entity.*;
 import com.umc.halo.domain.notification.enums.NotificationStatus;
 import com.umc.halo.domain.notification.enums.NotificationType;
 import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.*;
 
 import java.util.List;
@@ -14,5 +15,13 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     void deleteByMemberId(Long memberId);
     Optional<Notification> findByAnniversaryIdAndNotificationTypeAndStatusIn(Long anniversaryId, NotificationType notificationType, List<NotificationStatus> statuses);
     void deleteAllByAnniversaryIdIn(List<Long> distinctIds);
-    List<Notification> findAllByMemberIdAndNotificationTypeInAndStatusIn(Long memberId, List<NotificationType> notificationTypes, List<NotificationStatus> statuses);
+    @Query("""
+        select n
+        from Notification n
+        left join fetch n.anniversary
+        where n.member.id = :memberId
+        and n.notificationType in :notificationTypes
+        and n.status in :statuses
+    """)
+    List<Notification> findAllWithAnniversary(@Param("memberId") Long memberId, @Param("notificationTypes") List<NotificationType> notificationTypes, @Param("statuses") List<NotificationStatus> statuses);
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
@@ -14,4 +14,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     void deleteByMemberId(Long memberId);
     Optional<Notification> findByAnniversaryIdAndNotificationTypeAndStatusIn(Long anniversaryId, NotificationType notificationType, List<NotificationStatus> statuses);
     void deleteAllByAnniversaryIdIn(List<Long> distinctIds);
+    List<Notification> findAllByMemberIdAndNotificationTypeInAndStatusIn(Long memberId, List<NotificationType> notificationTypes, List<NotificationStatus> statuses);
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
@@ -18,7 +18,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query("""
         select n
         from Notification n
-        join fetch n.anniversary
+        left join fetch n.anniversary
         where n.member.id = :memberId
         and n.notificationType in :notificationTypes
         and n.status in :statuses

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -47,7 +47,6 @@ public interface SettingControllerDocs {
                                         "code": "NOTIFICATION200_1",
                                         "message": "알림 설정을 성공적으로 조회했습니다.",
                                         "result": {
-                                            "regularNotificationEnabled": true,
                                             "regularNotificationTime": "10:00",
                                             "todayChapterNotificationEnabled": true,
                                             "retentionNotificationEnabled": false,
@@ -255,7 +254,6 @@ public interface SettingControllerDocs {
                         - Content-Type: application/json
                         - Authorization: Bearer {Access Token}
                     - **Body**
-                        - regularNotificationEnabled : 정기 알림 ON/OFF 여부
                         - regularNotificationTime : 정기 알림 시간
                         - todayChapterNotificationEnabled : 오늘의 장 알림 ON/OFF 여부
                         - retentionNotificationEnabled : 리텐션 알림 ON/OFF 여부
@@ -281,7 +279,6 @@ public interface SettingControllerDocs {
                                         "code": "NOTIFICATION200_2",
                                         "message": "알림 설정을 성공적으로 수정했습니다.",
                                         "result": {
-                                            "regularNotificationEnabled": true,
                                             "regularNotificationTime": "10:00",
                                             "todayChapterNotificationEnabled": true,
                                             "retentionNotificationEnabled": false,

--- a/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
+++ b/src/main/java/com/umc/halo/domain/setting/converter/SettingConverter.java
@@ -11,13 +11,11 @@ public class SettingConverter {
 
     public static SettingResDTO.NotificationSettings toNotificationSettings(MemberSetting memberSetting) {
         boolean isAllNotificationEnabled =
-                memberSetting.getRegularNotificationEnabled()
-                && memberSetting.getTodayChapterNotificationEnabled()
+                memberSetting.getTodayChapterNotificationEnabled()
                 && memberSetting.getRetentionNotificationEnabled()
                 && memberSetting.getAnniversaryNotificationEnabled();
 
         return SettingResDTO.NotificationSettings.builder()
-                .regularNotificationEnabled(memberSetting.getRegularNotificationEnabled())
                 .regularNotificationTime(memberSetting.getRegularNotificationTime())
                 .todayChapterNotificationEnabled(memberSetting.getTodayChapterNotificationEnabled())
                 .retentionNotificationEnabled(memberSetting.getRetentionNotificationEnabled())

--- a/src/main/java/com/umc/halo/domain/setting/dto/SettingReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/setting/dto/SettingReqDTO.java
@@ -12,9 +12,6 @@ public class SettingReqDTO {
     @Builder
     public record UpdateNotificationSettings(
             @NotNull
-            Boolean regularNotificationEnabled,
-
-            @NotNull
             LocalTime regularNotificationTime,
 
             @NotNull

--- a/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
+++ b/src/main/java/com/umc/halo/domain/setting/dto/SettingResDTO.java
@@ -9,7 +9,6 @@ public class SettingResDTO {
 
     @Builder
     public record NotificationSettings(
-            Boolean regularNotificationEnabled,
             LocalTime regularNotificationTime,
             Boolean todayChapterNotificationEnabled,
             Boolean retentionNotificationEnabled,

--- a/src/main/java/com/umc/halo/domain/setting/entity/MemberSetting.java
+++ b/src/main/java/com/umc/halo/domain/setting/entity/MemberSetting.java
@@ -35,10 +35,6 @@ public class MemberSetting extends BaseEntity {
     @Builder.Default
     private Integer bgmVolume = 100;
 
-    @Column(name = "regular_notification_enabled", nullable = false)
-    @Builder.Default
-    private Boolean regularNotificationEnabled = true;
-
     @Column(name = "regular_notification_time", nullable = false)
     @Builder.Default
     private LocalTime regularNotificationTime = LocalTime.of(9,0);
@@ -56,13 +52,11 @@ public class MemberSetting extends BaseEntity {
     private Boolean anniversaryNotificationEnabled = true;
 
     public void updateNotificationSettings(
-            Boolean regularNotificationEnabled,
             LocalTime regularNotificationTime,
             Boolean todayChapterNotificationEnabled,
             Boolean retentionNotificationEnabled,
             Boolean anniversaryNotificationEnabled
     ){
-        this.regularNotificationEnabled = regularNotificationEnabled;
         this.regularNotificationTime = regularNotificationTime;
         this.todayChapterNotificationEnabled = todayChapterNotificationEnabled;
         this.retentionNotificationEnabled = retentionNotificationEnabled;

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -64,7 +64,6 @@ public class SettingService {
         boolean previousAnniversaryEnabled = memberSetting.getAnniversaryNotificationEnabled();
 
         memberSetting.updateNotificationSettings(
-                dto.regularNotificationEnabled(),
                 dto.regularNotificationTime(),
                 dto.todayChapterNotificationEnabled(),
                 dto.retentionNotificationEnabled(),

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -111,17 +111,18 @@ public class SettingService {
 
     private void updateNotificationScheduledTime(Long memberId, LocalTime notifyTime) {
 
-        List<Notification> notifications = notificationRepository.findAllWithAnniversary(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_SETTING));
+        List<Notification> notifications = notificationRepository.findAllWithAnniversary(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED));
         LocalDate today = LocalDate.now();
         LocalDateTime now = LocalDateTime.now();
 
         for(Notification notification : notifications) {
 
-            if (notification.getAnniversary() == null) {
+            Anniversary anniversary = notification.getAnniversary();
+
+            if (anniversary == null) {
                 continue;
             }
 
-            Anniversary anniversary = notification.getAnniversary();
             LocalDate nextOccurrence = resolveNextOccurrence(anniversary, today);
 
             if(nextOccurrence == null) {
@@ -139,32 +140,37 @@ public class SettingService {
             }
 
             if (!scheduledAt.isAfter(now)) {
-                notification.cancelBySetting();
+                notification.expire();
                 continue;
             }
 
-            notification.updateScheduledAt(scheduledAt);
+            if (notification.getStatus() == NotificationStatus.EXPIRED) {
+                notification.reserve(scheduledAt);
+            } else {
+                notification.updateScheduledAt(scheduledAt);
+            }
         }
     }
 
     private void updateAnniversaryNotifications(Long memberId, boolean enabled, MemberSetting memberSetting) {
 
-        List<Notification> notifications = notificationRepository.findAllWithAnniversary(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_SETTING));
+        List<Notification> notifications = notificationRepository.findAllWithAnniversary(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED));
         LocalDate today = LocalDate.now();
         LocalDateTime now = LocalDateTime.now();
 
         for(Notification notification : notifications) {
 
             if(!enabled) {
-                notification.cancelBySetting();
-                continue;
-            }
-
-            if (notification.getAnniversary() == null) {
+                notification.updateSettingEnabled(false);
                 continue;
             }
 
             Anniversary anniversary = notification.getAnniversary();
+
+            if (anniversary == null) {
+                continue;
+            }
+
             LocalDate nextOccurrence = resolveNextOccurrence(anniversary, today);
 
             if(nextOccurrence == null) {
@@ -180,11 +186,17 @@ public class SettingService {
             }
 
             if (!scheduledAt.isAfter(now)) {
-                notification.cancelBySetting();
+                notification.expire();
                 continue;
             }
 
-            notification.reserve(scheduledAt);
+            notification.updateSettingEnabled(true);
+
+            if (notification.getStatus() == NotificationStatus.EXPIRED) {
+                notification.reserve(scheduledAt);
+            } else {
+                notification.updateScheduledAt(scheduledAt);
+            }
         }
     }
 

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -111,7 +111,9 @@ public class SettingService {
 
     private void updateNotificationScheduledTime(Long memberId, LocalTime notifyTime) {
 
-        List<Notification> notifications = notificationRepository.findAllByMemberIdAndNotificationTypeInAndStatusIn(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED));
+        List<Notification> notifications = notificationRepository.findAllWithAnniversary(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_SETTING));
+        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
 
         for(Notification notification : notifications) {
 
@@ -120,7 +122,7 @@ public class SettingService {
             }
 
             Anniversary anniversary = notification.getAnniversary();
-            LocalDate nextOccurrence = resolveNextOccurrence(anniversary, LocalDate.now());
+            LocalDate nextOccurrence = resolveNextOccurrence(anniversary, today);
 
             if(nextOccurrence == null) {
                 continue;
@@ -136,18 +138,25 @@ public class SettingService {
                 continue;
             }
 
+            if (!scheduledAt.isAfter(now)) {
+                notification.cancelBySetting();
+                continue;
+            }
+
             notification.updateScheduledAt(scheduledAt);
         }
     }
 
     private void updateAnniversaryNotifications(Long memberId, boolean enabled, MemberSetting memberSetting) {
 
-        List<Notification> notifications = notificationRepository.findAllByMemberIdAndNotificationTypeInAndStatusIn(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED));
+        List<Notification> notifications = notificationRepository.findAllWithAnniversary(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_SETTING));
+        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
 
         for(Notification notification : notifications) {
 
             if(!enabled) {
-                notification.cancel();
+                notification.cancelBySetting();
                 continue;
             }
 
@@ -156,7 +165,7 @@ public class SettingService {
             }
 
             Anniversary anniversary = notification.getAnniversary();
-            LocalDate nextOccurrence = resolveNextOccurrence(anniversary, LocalDate.now());
+            LocalDate nextOccurrence = resolveNextOccurrence(anniversary, today);
 
             if(nextOccurrence == null) {
                 continue;
@@ -168,6 +177,11 @@ public class SettingService {
                 scheduledAt = nextOccurrence.minusDays(7).atTime(memberSetting.getRegularNotificationTime());
             } else {
                 scheduledAt = nextOccurrence.atTime(memberSetting.getRegularNotificationTime());
+            }
+
+            if (!scheduledAt.isAfter(now)) {
+                notification.cancelBySetting();
+                continue;
             }
 
             notification.reserve(scheduledAt);

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -1,5 +1,10 @@
 package com.umc.halo.domain.setting.service;
 
+import com.umc.halo.domain.notification.entity.Anniversary;
+import com.umc.halo.domain.notification.entity.Notification;
+import com.umc.halo.domain.notification.enums.NotificationStatus;
+import com.umc.halo.domain.notification.enums.NotificationType;
+import com.umc.halo.domain.notification.repository.NotificationRepository;
 import com.umc.halo.domain.setting.converter.SettingConverter;
 import com.umc.halo.domain.setting.dto.SettingReqDTO;
 import com.umc.halo.domain.setting.dto.SettingResDTO;
@@ -14,7 +19,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +31,7 @@ public class SettingService {
 
     private final MemberSettingRepository memberSettingRepository;
     private final BgmRepository bgmRepository;
+    private final NotificationRepository notificationRepository;
 
     @Transactional(readOnly = true)
     public SettingResDTO.NotificationSettings getNotificationSettings(Long memberId) {
@@ -50,6 +60,9 @@ public class SettingService {
         MemberSetting memberSetting = memberSettingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
 
+        LocalTime previousNotificationTime = memberSetting.getRegularNotificationTime();
+        boolean previousAnniversaryEnabled = memberSetting.getAnniversaryNotificationEnabled();
+
         memberSetting.updateNotificationSettings(
                 dto.regularNotificationEnabled(),
                 dto.regularNotificationTime(),
@@ -57,6 +70,14 @@ public class SettingService {
                 dto.retentionNotificationEnabled(),
                 dto.anniversaryNotificationEnabled()
         );
+
+        if (!Objects.equals(previousNotificationTime, dto.regularNotificationTime())) {
+            updateNotificationScheduledTime(memberId, dto.regularNotificationTime());
+        }
+
+        if (previousAnniversaryEnabled != dto.anniversaryNotificationEnabled()) {
+            updateAnniversaryNotifications(memberId, dto.anniversaryNotificationEnabled(), memberSetting);
+        }
 
         return SettingConverter.toNotificationSettings(memberSetting);
     }
@@ -88,5 +109,88 @@ public class SettingService {
         memberSetting.updateBgmSettings(bgm, dto.bgmEnabled(), dto.bgmVolume());
 
         return SettingConverter.toBgmSettings(memberSetting);
+    }
+
+    private void updateNotificationScheduledTime(Long memberId, LocalTime notifyTime) {
+
+        List<Notification> notifications = notificationRepository.findAllByMemberIdAndNotificationTypeInAndStatusIn(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED));
+
+        for(Notification notification : notifications) {
+
+            if (notification.getAnniversary() == null) {
+                continue;
+            }
+
+            Anniversary anniversary = notification.getAnniversary();
+            LocalDate nextOccurrence = resolveNextOccurrence(anniversary, LocalDate.now());
+
+            if(nextOccurrence == null) {
+                continue;
+            }
+
+            LocalDateTime scheduledAt;
+
+            if(notification.getNotificationType() == NotificationType.ANNIVERSARY_D7) {
+                scheduledAt = nextOccurrence.minusDays(7).atTime(notifyTime);
+            } else if(notification.getNotificationType() == NotificationType.ANNIVERSARY_DDAY) {
+                scheduledAt = nextOccurrence.atTime(notifyTime);
+            } else {
+                continue;
+            }
+
+            notification.updateScheduledAt(scheduledAt);
+        }
+    }
+
+    private void updateAnniversaryNotifications(Long memberId, boolean enabled, MemberSetting memberSetting) {
+
+        List<Notification> notifications = notificationRepository.findAllByMemberIdAndNotificationTypeInAndStatusIn(memberId, List.of(NotificationType.ANNIVERSARY_D7, NotificationType.ANNIVERSARY_DDAY), List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED));
+
+        for(Notification notification : notifications) {
+
+            if(!enabled) {
+                notification.cancel();
+                continue;
+            }
+
+            if (notification.getAnniversary() == null) {
+                continue;
+            }
+
+            Anniversary anniversary = notification.getAnniversary();
+            LocalDate nextOccurrence = resolveNextOccurrence(anniversary, LocalDate.now());
+
+            if(nextOccurrence == null) {
+                continue;
+            }
+
+            LocalDateTime scheduledAt;
+
+            if(notification.getNotificationType() == NotificationType.ANNIVERSARY_D7) {
+                scheduledAt = nextOccurrence.minusDays(7).atTime(memberSetting.getRegularNotificationTime());
+            } else {
+                scheduledAt = nextOccurrence.atTime(memberSetting.getRegularNotificationTime());
+            }
+
+            notification.reserve(scheduledAt);
+        }
+    }
+
+    private LocalDate resolveNextOccurrence(Anniversary anniversary, LocalDate today) {
+
+        LocalDate anniversaryDate = anniversary.getAnniversaryDate();
+
+        if (!Boolean.TRUE.equals(anniversary.getIsRepeated())) {
+            return anniversaryDate.isBefore(today) ? null : anniversaryDate;
+        }
+
+        LocalDate thisYear;
+
+        try {
+            thisYear = anniversaryDate.withYear(today.getYear());
+        } catch (Exception e) {
+            thisYear = LocalDate.of(today.getYear(), 2, 28);
+        }
+        return thisYear.isBefore(today) ? anniversary.getAnniversaryDate().withYear(today.getYear() + 1) : thisYear;
     }
 }

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -185,12 +185,12 @@ public class SettingService {
                 scheduledAt = nextOccurrence.atTime(memberSetting.getRegularNotificationTime());
             }
 
+            notification.updateSettingEnabled(true);
+
             if (!scheduledAt.isAfter(now)) {
                 notification.expire();
                 continue;
             }
-
-            notification.updateSettingEnabled(true);
 
             if (notification.getStatus() == NotificationStatus.EXPIRED) {
                 notification.reserve(scheduledAt);

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -14,7 +14,6 @@ import com.umc.halo.domain.setting.exception.SettingException;
 import com.umc.halo.domain.setting.exception.code.SettingErrorCode;
 import com.umc.halo.domain.setting.repository.BgmRepository;
 import com.umc.halo.domain.setting.repository.MemberSettingRepository;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -190,6 +189,6 @@ public class SettingService {
         } catch (Exception e) {
             thisYear = LocalDate.of(today.getYear(), 2, 28);
         }
-        return thisYear.isBefore(today) ? anniversary.getAnniversaryDate().withYear(today.getYear() + 1) : thisYear;
+        return thisYear.isBefore(today) ? anniversaryDate.withYear(today.getYear() + 1) : thisYear;
     }
 }

--- a/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
+++ b/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
@@ -68,11 +68,11 @@ public class AnniversaryNotificationListener {
 
 
         if (anniversary.getSevenDaysAlarmEnabled() && d7.isAfter(now)) {
-            saveOrUpdateNotification(anniversary, NotificationType.ANNIVERSARY_D7, d7Title, d7Message, d7);
+            saveOrUpdateNotification(anniversary, memberSetting, NotificationType.ANNIVERSARY_D7, d7Title, d7Message, d7);
         }
 
         if (anniversary.getDayAlarmEnabled() && dday.isAfter(now)) {
-            saveOrUpdateNotification(anniversary, NotificationType.ANNIVERSARY_DDAY, ddayTitle, ddayMessage, dday);
+            saveOrUpdateNotification(anniversary, memberSetting, NotificationType.ANNIVERSARY_DDAY, ddayTitle, ddayMessage, dday);
         }
 
     }
@@ -109,8 +109,8 @@ public class AnniversaryNotificationListener {
             ddayMessage = createNotificationMessage(anniversary, NotificationType.ANNIVERSARY_DDAY);
         }
 
-        updateOrCancel(anniversary, NotificationType.ANNIVERSARY_D7, d7Title, d7Message, d7, now, anniversary.getSevenDaysAlarmEnabled());;
-        updateOrCancel(anniversary, NotificationType.ANNIVERSARY_DDAY, ddayTitle, ddayMessage, dday, now, anniversary.getDayAlarmEnabled());
+        updateOrCancelNotification(anniversary, memberSetting, NotificationType.ANNIVERSARY_D7, d7Title, d7Message, d7, now, anniversary.getSevenDaysAlarmEnabled());
+        updateOrCancelNotification(anniversary, memberSetting, NotificationType.ANNIVERSARY_DDAY, ddayTitle, ddayMessage, dday, now, anniversary.getDayAlarmEnabled());
 
     }
 
@@ -148,44 +148,56 @@ public class AnniversaryNotificationListener {
 
 
 
-    private void saveOrUpdateNotification(Anniversary anniversary, NotificationType notificationType, String title, String message, LocalDateTime scheduledAt) {
+    private void saveOrUpdateNotification(Anniversary anniversary, MemberSetting memberSetting, NotificationType notificationType, String title, String message, LocalDateTime scheduledAt) {
 
-        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), notificationType, List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_ANNIVERSARY)).orElse(null);
+        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), notificationType, List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED)).orElse(null);
+
+        boolean anniversaryEnabled = notificationType == NotificationType.ANNIVERSARY_D7 ? anniversary.getSevenDaysAlarmEnabled() : anniversary.getDayAlarmEnabled();
 
         if(notification == null) {
-            notificationRepository.save(NotificationConverter.toAnniversaryNotification(anniversary, notificationType, title, message, scheduledAt));
-        } else {
-            notification.update(title, message, scheduledAt);
+            notificationRepository.save(NotificationConverter.toAnniversaryNotification(anniversary, notificationType, title, message, scheduledAt, memberSetting.getAnniversaryNotificationEnabled(), anniversaryEnabled));
+            return;
         }
+
+        notification.updateSettingEnabled(memberSetting.getAnniversaryNotificationEnabled());
+        notification.updateAnniversaryEnabled(anniversaryEnabled);
+        notification.updateContent(title, message);
+        notification.reserve(scheduledAt);
     }
 
-    private void updateOrCancel(Anniversary anniversary, NotificationType type, String title, String message, LocalDateTime scheduledAt, LocalDateTime now, boolean enabled) {
+    private void updateOrCancelNotification(Anniversary anniversary, MemberSetting memberSetting, NotificationType notificationType, String title, String message, LocalDateTime scheduledAt, LocalDateTime now, boolean enabled) {
 
-        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), type, List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_ANNIVERSARY)).orElse(null);
+        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), notificationType, List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED)).orElse(null);
 
-        if(enabled && scheduledAt.isAfter(now)) {
-            if(notification == null) {
-                notificationRepository.save(NotificationConverter.toAnniversaryNotification(anniversary, type, title, message != null ? message : createDefaultNotificationMessage(type), scheduledAt));
-            } else {
-                if(message != null) {
-                    notification.update(title, message, scheduledAt);
-                } else {
-                    notification.reserve(scheduledAt);
-                }
+        if (notification == null) {
+            if (!enabled || !scheduledAt.isAfter(now)) {
+                return;
             }
-        } else {
-            if(notification != null) {
-                notification.cancelByAnniversary();
-            }
+            notificationRepository.save(NotificationConverter.toAnniversaryNotification(anniversary, notificationType, title, message != null ? message : createDefaultNotificationMessage(notificationType), scheduledAt, memberSetting.getAnniversaryNotificationEnabled(), enabled));
+            return;
         }
+
+        notification.updateSettingEnabled(memberSetting.getAnniversaryNotificationEnabled());
+        notification.updateAnniversaryEnabled(enabled);
+
+        if (!scheduledAt.isAfter(now)) {
+            notification.expire();
+            return;
+        }
+
+        if (message != null) {
+            notification.updateContent(title, message);
+        }
+
+        notification.reserve(scheduledAt);
     }
 
-    private void cancelNotification(Anniversary anniversary, NotificationType type) {
+    private void cancelNotification(Anniversary anniversary, NotificationType notificationType) {
 
-        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), type, List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_ANNIVERSARY)).orElse(null);
+        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), notificationType, List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED)).orElse(null);
 
         if(notification != null) {
-            notification.cancelByAnniversary();
+            notification.updateAnniversaryEnabled(false);
         }
     }
 

--- a/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
+++ b/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
@@ -150,7 +150,7 @@ public class AnniversaryNotificationListener {
 
     private void saveOrUpdateNotification(Anniversary anniversary, NotificationType notificationType, String title, String message, LocalDateTime scheduledAt) {
 
-        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), notificationType, List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED)).orElse(null);
+        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), notificationType, List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_ANNIVERSARY)).orElse(null);
 
         if(notification == null) {
             notificationRepository.save(NotificationConverter.toAnniversaryNotification(anniversary, notificationType, title, message, scheduledAt));
@@ -161,7 +161,7 @@ public class AnniversaryNotificationListener {
 
     private void updateOrCancel(Anniversary anniversary, NotificationType type, String title, String message, LocalDateTime scheduledAt, LocalDateTime now, boolean enabled) {
 
-        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), type, List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED)).orElse(null);
+        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), type, List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_ANNIVERSARY)).orElse(null);
 
         if(enabled && scheduledAt.isAfter(now)) {
             if(notification == null) {
@@ -175,17 +175,17 @@ public class AnniversaryNotificationListener {
             }
         } else {
             if(notification != null) {
-                notification.cancel();
+                notification.cancelByAnniversary();
             }
         }
     }
 
     private void cancelNotification(Anniversary anniversary, NotificationType type) {
 
-        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), type, List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED)).orElse(null);
+        Notification notification = notificationRepository.findByAnniversaryIdAndNotificationTypeAndStatusIn(anniversary.getId(), type, List.of(NotificationStatus.SCHEDULED, NotificationStatus.CANCELED_BY_ANNIVERSARY)).orElse(null);
 
         if(notification != null) {
-            notification.cancel();
+            notification.cancelByAnniversary();
         }
     }
 

--- a/src/main/resources/db/migration/V3__alter_member_setting_table.sql
+++ b/src/main/resources/db/migration/V3__alter_member_setting_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member_setting
+    DROP COLUMN regular_notification_enabled;

--- a/src/main/resources/db/migration/V4__alter_notification_table.sql
+++ b/src/main/resources/db/migration/V4__alter_notification_table.sql
@@ -1,15 +1,35 @@
 ALTER TABLE notification
-    ADD COLUMN setting_enabled BOOLEAN NOT NULL DEFAULT TRUE;
-
-ALTER TABLE notification
-    ADD COLUMN anniversary_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+    ADD COLUMN setting_enabled BOOLEAN NULL;
 
 UPDATE notification
-    SET status = 'EXPIRED'
-    WHERE status = 'CANCELED';
+SET setting_enabled = TRUE
+WHERE setting_enabled IS NULL;
+
+ALTER TABLE notification
+    MODIFY COLUMN setting_enabled BOOLEAN NOT NULL;
+
+ALTER TABLE notification
+    ADD COLUMN anniversary_enabled BOOLEAN NULL;
+
+UPDATE notification
+SET anniversary_enabled = TRUE
+WHERE anniversary_enabled IS NULL;
+
+ALTER TABLE notification
+    MODIFY COLUMN anniversary_enabled BOOLEAN NOT NULL;
+
+UPDATE notification
+SET status = 'EXPIRED'
+WHERE status = 'CANCELED';
+
+ALTER TABLE notification
+    DROP FOREIGN KEY FK_NOTIFICATION_ON_ANNIVERSARY;
 
 ALTER TABLE notification
     DROP INDEX uk_notification_anniversary_type;
 
 ALTER TABLE notification
     ADD CONSTRAINT uk_notification_anniversary_type_scheduled_at UNIQUE (anniversary_id, notification_type, scheduled_at);
+
+ALTER TABLE notification
+    ADD CONSTRAINT FK_NOTIFICATION_ON_ANNIVERSARY FOREIGN KEY (anniversary_id) REFERENCES anniversary (anniversary_id);

--- a/src/main/resources/db/migration/V4__alter_notification_table.sql
+++ b/src/main/resources/db/migration/V4__alter_notification_table.sql
@@ -1,5 +1,15 @@
 ALTER TABLE notification
-    ADD COLUMN setting_enabled BOOLEAN NOT NULL;
+    ADD COLUMN setting_enabled BOOLEAN NOT NULL DEFAULT TRUE;
 
 ALTER TABLE notification
-    ADD COLUMN anniversary_enabled BOOLEAN NOT NULL;
+    ADD COLUMN anniversary_enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+UPDATE notification
+    SET status = 'EXPIRED'
+    WHERE status = 'CANCELED';
+
+ALTER TABLE notification
+    DROP INDEX uk_notification_anniversary_type;
+
+ALTER TABLE notification
+    ADD CONSTRAINT uk_notification_anniversary_type_scheduled_at UNIQUE (anniversary_id, notification_type, scheduled_at);

--- a/src/main/resources/db/migration/V4__alter_notification_table.sql
+++ b/src/main/resources/db/migration/V4__alter_notification_table.sql
@@ -1,0 +1,5 @@
+ALTER TABLE notification
+    ADD COLUMN setting_enabled BOOLEAN NOT NULL;
+
+ALTER TABLE notification
+    ADD COLUMN anniversary_enabled BOOLEAN NOT NULL;


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 정기 알림 시간 변경 -> 모든 알림의 scheduled_at 컬럼 수정
- 기념일 알림 설정 ON/OFF -> 기념일 알림 status 변경
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- MemberSetting 엔티티에서 regularNotificationEnabled 컬럼 삭제
- SettingService 파일 (정기 알림 시간 변경 -> 모든 알림 시간 변경)
- SettingService 파일 (기념일 ON/OFF 수정 -> 기념일 알림 status 변경)
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #104 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/hPCXfA4KaoptY5vMp


- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61?p=391ca1e217c080e6810ae2231055bb3d&pm=s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **알림 설정 변경**
  * 정기 알림의 ON/OFF 항목이 제거되고, 정기 알림 시간만 관리합니다.
  * 알림 설정 요청/응답 예시와 문서에서 정기 알림 enabled 정보가 제외됩니다.
* **기념일 알림 예약 동작**
  * 기념일 알림 설정 변경 시 D-7/D-DAY 예약 시간이 자동으로 갱신됩니다.
  * 비활성화하면 관련 알림은 해제(만료) 형태로 반영됩니다.
* **데이터 무결성 개선**
  * 기념일 알림 예약 시각까지 포함한 유니크 조건이 강화되어 중복 예약을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->