### PR TITLE
[fix] dev 배포 시 CD 파이프라인 실패 3건 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,14 +76,16 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       # 배포 시작 시에만 이번 러너 IP를 22번 포트에 임시로 열고 끝나면 반드시 제거
+      # CIDR이 아니라 authorize가 만든 규칙의 rule ID로 추적
       - name: 러너 IP를 보안그룹에 임시 허용 (SSH 22번 포트)
         id: allow-runner-ip
         run: |
           RUNNER_IP="$(curl -sf https://checkip.amazonaws.com)/32"
-          echo "ip=$RUNNER_IP" >> "$GITHUB_OUTPUT"
-          aws ec2 authorize-security-group-ingress \
+          RULE_ID=$(aws ec2 authorize-security-group-ingress \
             --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
-            --protocol tcp --port 22 --cidr "$RUNNER_IP"
+            --protocol tcp --port 22 --cidr "$RUNNER_IP" \
+            --output json | jq -r '.SecurityGroupRules[0].SecurityGroupRuleId')
+          echo "rule-id=$RULE_ID" >> "$GITHUB_OUTPUT"
 
       - name: dev Basic Auth 자격증명 준비
         id: htpasswd
@@ -323,13 +325,23 @@ jobs:
             exit 1
           EOF
 
+      # rule-id가 없으면 revoke할 대상이 없으므로 건너뜀
+      # CIDR이 아닌 rule ID를 지정해 이 job이 만든 규칙만 정확히 제거
       - name: 보안그룹에서 러너 IP 제거
-        if: always()
-        continue-on-error: true
+        if: always() && steps.allow-runner-ip.outputs.rule-id != ''
         run: |
-          aws ec2 revoke-security-group-ingress \
-            --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
-            --protocol tcp --port 22 --cidr "${{ steps.allow-runner-ip.outputs.ip }}"
+          RULE_ID="${{ steps.allow-runner-ip.outputs.rule-id }}"
+          for i in 1 2 3; do
+            if aws ec2 revoke-security-group-ingress \
+              --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
+              --security-group-rule-ids "$RULE_ID"; then
+              exit 0
+            fi
+            echo "보안그룹 규칙 제거 실패, 재시도 ($i/3)" >&2
+            sleep 5
+          done
+          echo "보안그룹 규칙(rule-id: $RULE_ID) 제거 최종 실패 - SSH 인그레스가 열린 채로 남아있을 수 있음, 수동 확인 필요" >&2
+          exit 1
 
   deploy-dev:
     if: github.ref == 'refs/heads/develop'
@@ -353,14 +365,16 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
 
       # 배포 시작 시에만 이번 러너 IP를 22번 포트에 임시로 열고 끝나면 반드시 제거
+      # CIDR이 아니라 authorize가 만든 규칙의 rule ID로 추적
       - name: 러너 IP를 보안그룹에 임시 허용 (SSH 22번 포트)
         id: allow-runner-ip
         run: |
           RUNNER_IP="$(curl -sf https://checkip.amazonaws.com)/32"
-          echo "ip=$RUNNER_IP" >> "$GITHUB_OUTPUT"
-          aws ec2 authorize-security-group-ingress \
+          RULE_ID=$(aws ec2 authorize-security-group-ingress \
             --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
-            --protocol tcp --port 22 --cidr "$RUNNER_IP"
+            --protocol tcp --port 22 --cidr "$RUNNER_IP" \
+            --output json | jq -r '.SecurityGroupRules[0].SecurityGroupRuleId')
+          echo "rule-id=$RULE_ID" >> "$GITHUB_OUTPUT"
 
       - name: dev Basic Auth 자격증명 준비
         id: htpasswd
@@ -548,10 +562,20 @@ jobs:
             exit 1
           EOF
 
+      # rule-id가 없으면 revoke할 대상이 없으므로 건너뜀
+      # CIDR이 아닌 rule ID를 지정해 이 job이 만든 규칙만 정확히 제거
       - name: 보안그룹에서 러너 IP 제거
-        if: always()
-        continue-on-error: true
+        if: always() && steps.allow-runner-ip.outputs.rule-id != ''
         run: |
-          aws ec2 revoke-security-group-ingress \
-            --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
-            --protocol tcp --port 22 --cidr "${{ steps.allow-runner-ip.outputs.ip }}"
+          RULE_ID="${{ steps.allow-runner-ip.outputs.rule-id }}"
+          for i in 1 2 3; do
+            if aws ec2 revoke-security-group-ingress \
+              --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
+              --security-group-rule-ids "$RULE_ID"; then
+              exit 0
+            fi
+            echo "보안그룹 규칙 제거 실패, 재시도 ($i/3)" >&2
+            sleep 5
+          done
+          echo "보안그룹 규칙(rule-id: $RULE_ID) 제거 최종 실패 - SSH 인그레스가 열린 채로 남아있을 수 있음, 수동 확인 필요" >&2
+          exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,12 +59,31 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
 
     steps:
       - name: 소스 체크아웃
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+
+      # OIDC로 단기 자격증명 발급 -> 이후 스텝들의 job 환경에 자동으로 노출되므로
+      # 아래 "러너 IP 허용"과 job 끝의 "러너 IP 제거" 둘 다 별도 자격증명 설정 없이 aws 호출 가능
+      - name: AWS 자격증명 설정 (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # 배포 시작 시에만 이번 러너 IP를 22번 포트에 임시로 열고 끝나면 반드시 제거
+      - name: 러너 IP를 보안그룹에 임시 허용 (SSH 22번 포트)
+        id: allow-runner-ip
+        run: |
+          RUNNER_IP="$(curl -sf https://checkip.amazonaws.com)/32"
+          echo "ip=$RUNNER_IP" >> "$GITHUB_OUTPUT"
+          aws ec2 authorize-security-group-ingress \
+            --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
+            --protocol tcp --port 22 --cidr "$RUNNER_IP"
 
       - name: dev Basic Auth 자격증명 준비
         id: htpasswd
@@ -304,6 +323,14 @@ jobs:
             exit 1
           EOF
 
+      - name: 보안그룹에서 러너 IP 제거
+        if: always()
+        continue-on-error: true
+        run: |
+          aws ec2 revoke-security-group-ingress \
+            --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
+            --protocol tcp --port 22 --cidr "${{ steps.allow-runner-ip.outputs.ip }}"
+
   deploy-dev:
     if: github.ref == 'refs/heads/develop'
     needs: build-and-push
@@ -311,12 +338,29 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write
 
     steps:
       - name: 소스 체크아웃
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+
+      - name: AWS 자격증명 설정 (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # 배포 시작 시에만 이번 러너 IP를 22번 포트에 임시로 열고 끝나면 반드시 제거
+      - name: 러너 IP를 보안그룹에 임시 허용 (SSH 22번 포트)
+        id: allow-runner-ip
+        run: |
+          RUNNER_IP="$(curl -sf https://checkip.amazonaws.com)/32"
+          echo "ip=$RUNNER_IP" >> "$GITHUB_OUTPUT"
+          aws ec2 authorize-security-group-ingress \
+            --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
+            --protocol tcp --port 22 --cidr "$RUNNER_IP"
 
       - name: dev Basic Auth 자격증명 준비
         id: htpasswd
@@ -503,3 +547,11 @@ jobs:
 
             exit 1
           EOF
+
+      - name: 보안그룹에서 러너 IP 제거
+        if: always()
+        continue-on-error: true
+        run: |
+          aws ec2 revoke-security-group-ingress \
+            --group-id "${{ secrets.EC2_SECURITY_GROUP_ID }}" \
+            --protocol tcp --port 22 --cidr "${{ steps.allow-runner-ip.outputs.ip }}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
 
     steps:
       - name: 소스 체크아웃
@@ -165,7 +166,9 @@ jobs:
               echo ".htpasswd 갱신 건너뜀 (DEV_BASIC_AUTH 시크릿 미설정, 기존 파일 유지)"
             fi
 
-            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+            # 같은 워크플로우 실행 안에서 build-and-push가 이미 이 패키지에 push
+            # 성공했으므로, 별도 PAT 없이 GITHUB_TOKEN으로도 pull 권한이 충분함
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
             # 롤백 대비, 직전에 성공적으로 배포된 이미지의 SHA 태그 기록 (최초 배포면 빈 값)
             PREV_SHA=$(cat .deployed_sha 2>/dev/null || true)
@@ -307,6 +310,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
 
     steps:
       - name: 소스 체크아웃
@@ -425,7 +429,7 @@ jobs:
           S3_BUCKET_SECRET_KEY=${{ secrets.DEV_S3_BUCKET_SECRET_KEY }}
           ENVEOF
 
-            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
             export DEV_IMAGE_TAG="${{ github.sha }}"
             # dev-app이 profiles: [dev]라 COMPOSE_PROFILES 없이는 config 검증에서 빠짐 ->

--- a/nginx/reload.sh
+++ b/nginx/reload.sh
@@ -13,6 +13,14 @@ if [ -f "$CONF_OUT" ]; then
 fi
 
 if try_full || try_partial; then
+  # 컨테이너가 방금 재생성된 직후라면 watch-and-reload.sh가 아직 최초 기동
+  # 대기 루프(최대 60초) 중이라 nginx 마스터가 안 떠 있을 수 있음
+  # pid 파일이 생길 때까지 잠깐 기다렸다 reload
+  i=0
+  while [ ! -f /var/run/nginx.pid ] && [ "$i" -lt 30 ]; do
+    sleep 2
+    i=$((i + 1))
+  done
   nginx -s reload
   echo "[reload] 설정 재로드 완료"
   exit 0


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
develop 배포가 순차적으로 세 군데서 실패하던 걸 각각 원인 파악 후 수정함.

- EC2 보안그룹 22번 포트가 특정 IP로만 열려 있어 GitHub Actions 러너의 랜덤 IP로는 SSH 접속이 타임아웃되던 문제
- EC2에서 GHCR 이미지 pull이 denied로 거부되던 문제
- nginx 컨테이너 재생성 직후 reload.sh가 nginx 마스터 기동 전에 reload를 시도해 실패하던 레이스 컨디션
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- .github/workflows/cd.yml
   - deploy-prod/deploy-dev에 OIDC(aws-actions/configure-aws-credentials) 기반 AWS 자격증명 스텝 추가                                                                                                                             
   - 배포 시작 시 GitHub Actions 러너의 공인 IP를 보안그룹 22번 포트에 임시 허용하고, 배포 종료 시(if: always()) 제거                                                                                                             
      - CIDR이 아니라 authorize-security-group-ingress가 생성한 규칙의 rule ID로 추적 — 우연히 같은 IP로 이미 있던 다른 규칙을 revoke 단계에서 잘못 건드리는 것 방지                                                               
      - revoke 실패 시 continue-on-error로 조용히 넘기지 않고 3회 재시도 후에도 실패하면 배포 자체를 실패 처리 — SSH 인그레스가 열린 채로 남을 경우 반드시 알아채도록 함         
- nginx/reload.sh
  - reload 전에 nginx 마스터 프로세스(pid 파일)가 뜰 때까지 짧게 대기하는 재시도 로직 추가 — 컨테이너 재생성 직후 곧바로 reload가 호출되는 케이스에서 불필요한 배포 실패/롤백 방지
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- sh -n / YAML 파서로 문법 검증 완료
- 실제 배포 동작은 develop 재배포 후 확인 필요
---

## ✅ 확인 사항

- [ ] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [ ] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #107
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- AWS_ROLE_ARN이 assume하는 IAM Role은 OIDC(token.actions.githubusercontent.com) 기반이며, 해당 보안그룹에 대한 ec2:AuthorizeSecurityGroupIngress/RevokeSecurityGroupIngress 권한만 최소 부여됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 배포 과정에서 인증 및 서버 접근 절차가 강화되어 배포 보안성이 향상되었습니다.
  * 배포 중 필요한 서버 접근 권한이 일시적으로만 허용되고, 완료 후 자동으로 정리됩니다.
  * 컨테이너 재생성 직후에도 Nginx가 준비될 때까지 기다린 후 설정을 다시 불러오도록 개선되어 배포 안정성이 높아졌습니다.
  * 컨테이너 이미지 인증 방식이 간소화되어 배포 환경의 관리 효율성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->