### PR TITLE
[refactor] 캐릭터/캐릭터 변형 테이블 분리+Variant 확장

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
@@ -17,23 +17,23 @@ public interface ChapterControllerDocs {
             summary = "오늘의 장 조회 API",
             description = """
                     # 오늘의 장 조회
-
+                    
                     ## 요청 형식
                     - **Header**
                         - Authorization: Bearer {JWT 토큰}
                     - **Path Variable**
                         - storybookId : 조회할 스토리북 ID
                         - chapterOrder : 조회할 장 순서 (1~10)
-
+                    
                     ## 동작 방식
                     1. storybookId와 chapterOrder로 장을 조회합니다. 존재하지 않으면 404(CHAPTER404_1)를 반환합니다.
                     2. 회원의 스토리북 진행 정보(MemberStorybook)를 조회합니다.
                     3. 오늘 이미 이 스토리북의 장을 완료했다면 403(CHAPTER403_3)을 반환합니다.
                     4. 진행 중인 장 순서를 기준으로 요청한 장에 접근 가능한지 검증합니다. 아직 열리지 않은 장이면 403(CHAPTER403_1), 이미 완료한 장이면 403(CHAPTER403_2)을 반환합니다.
-                    5. 스토리북의 캐릭터(ORIGINAL/IMAGE_CHOICE), 질문 목록, 장면 카드를 함께 조회합니다.
+                    5. 스토리북의 캐릭터(WRITING/SCENE_CARD), 질문 목록, 장면 카드를 함께 조회합니다.
                     6. 임시저장(draft) 답변이 있으면 함께 조회하고, imageKey가 있으면 presigned imageUrl을 새로 발급합니다.
                     7. 오늘의 장 정보를 반환합니다.
-
+                    
                     ## 참고
                     - 응답의 imageUrl은 매 요청마다 새로 발급되는 presigned GET URL이며, 발급 후 1시간 동안만 유효합니다. 캐싱하지 말고 응답받은 URL을 바로 사용해주세요.
                     """,
@@ -57,8 +57,8 @@ public interface ChapterControllerDocs {
                                                                 "storybookTitle": "오래 전 당신",
                                                                 "guide": "부모님이 지금 내 나이였을 땐 어떤 하루를 보냈을까요? 사진 한 장을 보며 가볍게 물어봐요.",
                                                                 "character": {
-                                                                  "originalUrl": "https://example.com/character-original.png",
-                                                                  "imageChoiceUrl": "https://example.com/character-image-choice.png"
+                                                                  "writingCharacterImageUrl": "https://example.com/character-writing.png",
+                                                                  "sceneCardCharacterImageUrl": "https://example.com/character-scene-card.png"
                                                                 },
                                                                 "questions": [
                                                                   { "chapterQuestionId": 1, "questionOrder": 1, "question": "나와 같은 나이였던 시절에 대한 질문1" },
@@ -99,8 +99,8 @@ public interface ChapterControllerDocs {
                                                                 "storybookTitle": "오래 전 당신",
                                                                 "guide": "부모님이 지금 내 나이였을 땐 어떤 하루를 보냈을까요? 사진 한 장을 보며 가볍게 물어봐요.",
                                                                 "character": {
-                                                                  "originalUrl": "https://example.com/character-original.png",
-                                                                  "imageChoiceUrl": "https://example.com/character-image-choice.png"
+                                                                  "writingCharacterImageUrl": "https://example.com/character-writing.png",
+                                                                  "sceneCardCharacterImageUrl": "https://example.com/character-scene-card.png"
                                                                 },
                                                                 "questions": [
                                                                   { "chapterQuestionId": 1, "questionOrder": 1, "question": "나와 같은 나이였던 시절에 대한 질문1" },
@@ -254,7 +254,7 @@ public interface ChapterControllerDocs {
                                                             """
                                             ),
                                             @ExampleObject(
-                                                    name = "스토리북에 ORIGINAL/IMAGE_CHOICE 캐릭터가 등록되지 않음",
+                                                    name = "스토리북에 WRITING/SCENE_CARD 캐릭터가 등록되지 않음",
                                                     value = """
                                                             {
                                                                 "isSuccess": false,

--- a/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
@@ -11,8 +11,8 @@ public class ChapterConverter {
 
     public static ChapterResDTO.TodayChapter toTodayChapter(
             Chapter chapter,
-            StorybookCharacter originalCharacter,
-            StorybookCharacter imageChoiceCharacter,
+            StorybookCharacter writingCharacter,
+            StorybookCharacter sceneCardCharacter,
             List<ChapterQuestion> questions,
             List<SceneCard> sceneCards,
             MemberChapter memberChapter,
@@ -26,8 +26,8 @@ public class ChapterConverter {
 
                 .character(
                         ChapterResDTO.TodayChapter.Character.builder()
-                                .originalUrl(originalCharacter.getImageUrl())
-                                .imageChoiceUrl(imageChoiceCharacter.getImageUrl())
+                                .writingCharacterImageUrl(writingCharacter.getImageUrl())
+                                .sceneCardCharacterImageUrl(sceneCardCharacter.getImageUrl())
                                 .build()
                 )
 

--- a/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
@@ -11,8 +11,8 @@ public class ChapterConverter {
 
     public static ChapterResDTO.TodayChapter toTodayChapter(
             Chapter chapter,
-            StorybookCharacter writingCharacter,
-            StorybookCharacter sceneCardCharacter,
+            StorybookCharacterVariant writingCharacterVariant,
+            StorybookCharacterVariant sceneCardCharacterVariant,
             List<ChapterQuestion> questions,
             List<SceneCard> sceneCards,
             MemberChapter memberChapter,
@@ -26,8 +26,8 @@ public class ChapterConverter {
 
                 .character(
                         ChapterResDTO.TodayChapter.Character.builder()
-                                .writingCharacterImageUrl(writingCharacter.getImageUrl())
-                                .sceneCardCharacterImageUrl(sceneCardCharacter.getImageUrl())
+                                .writingCharacterImageUrl(writingCharacterVariant.getImageUrl())
+                                .sceneCardCharacterImageUrl(sceneCardCharacterVariant.getImageUrl())
                                 .build()
                 )
 

--- a/src/main/java/com/umc/halo/domain/content/chapter/dto/ChapterResDTO.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/dto/ChapterResDTO.java
@@ -22,8 +22,8 @@ public class ChapterResDTO {
     ) {
         @Builder
         public record Character(
-                String originalUrl,
-                String imageChoiceUrl
+                String writingCharacterImageUrl,
+                String sceneCardCharacterImageUrl
         ) {
         }
 

--- a/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
@@ -76,9 +76,9 @@ public class ChapterService {
         validateChapterStatus(member, storybook, chapterOrder, memberChapter, memberStorybookOpt.orElse(null));
 
         // character 조회
-        StorybookCharacter originalCharacter = storybookCharacterRepository.findByStorybookAndVariant(storybook, Variant.ORIGINAL)
+        StorybookCharacter writingCharacter = storybookCharacterRepository.findByStorybookAndVariant(storybook, Variant.WRITING)
                 .orElseThrow(() -> new StorybookException(StorybookErrorCode.NOT_FOUND_CHARACTER));
-        StorybookCharacter imageChoiceCharacter = storybookCharacterRepository.findByStorybookAndVariant(storybook, Variant.IMAGE_CHOICE)
+        StorybookCharacter sceneCardCharacter = storybookCharacterRepository.findByStorybookAndVariant(storybook, Variant.SCENE_CARD)
                 .orElseThrow(() -> new StorybookException(StorybookErrorCode.NOT_FOUND_CHARACTER));
 
         // question 조회
@@ -97,8 +97,8 @@ public class ChapterService {
 
         return ChapterConverter.toTodayChapter(
                 chapter,
-                originalCharacter,
-                imageChoiceCharacter,
+                writingCharacter,
+                sceneCardCharacter,
                 questions,
                 sceneCards,
                 memberChapter,

--- a/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/service/ChapterService.java
@@ -35,7 +35,7 @@ public class ChapterService {
     private final MemberRepository memberRepository;
     private final MemberStorybookRepository memberStorybookRepository;
     private final MemberChapterAnswerRepository memberChapterAnswerRepository;
-    private final StorybookCharacterRepository storybookCharacterRepository;
+    private final StorybookCharacterVariantRepository storybookCharacterVariantRepository;
     private final ChapterQuestionRepository chapterQuestionRepository;
     private final SceneCardRepository sceneCardRepository;
     private final ImageService imageService;
@@ -76,9 +76,9 @@ public class ChapterService {
         validateChapterStatus(member, storybook, chapterOrder, memberChapter, memberStorybookOpt.orElse(null));
 
         // character 조회
-        StorybookCharacter writingCharacter = storybookCharacterRepository.findByStorybookAndVariant(storybook, Variant.WRITING)
+        StorybookCharacterVariant writingCharacterVariant = storybookCharacterVariantRepository.findByStorybookCharacter_StorybookAndVariant(storybook, Variant.WRITING)
                 .orElseThrow(() -> new StorybookException(StorybookErrorCode.NOT_FOUND_CHARACTER));
-        StorybookCharacter sceneCardCharacter = storybookCharacterRepository.findByStorybookAndVariant(storybook, Variant.SCENE_CARD)
+        StorybookCharacterVariant sceneCardCharacterVariant = storybookCharacterVariantRepository.findByStorybookCharacter_StorybookAndVariant(storybook, Variant.SCENE_CARD)
                 .orElseThrow(() -> new StorybookException(StorybookErrorCode.NOT_FOUND_CHARACTER));
 
         // question 조회
@@ -97,8 +97,8 @@ public class ChapterService {
 
         return ChapterConverter.toTodayChapter(
                 chapter,
-                writingCharacter,
-                sceneCardCharacter,
+                writingCharacterVariant,
+                sceneCardCharacterVariant,
                 questions,
                 sceneCards,
                 memberChapter,

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
@@ -19,7 +19,7 @@ public class StorybookCharacter extends BaseEntity {
     @Column(name = "storybook_character_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "storybook_id", nullable = false)
     private Storybook storybook;
 

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
@@ -19,7 +19,7 @@ public class StorybookCharacter extends BaseEntity {
     @Column(name = "storybook_character_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "storybook_id", nullable = false)
     private Storybook storybook;
 

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
@@ -6,7 +6,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "storybook_character")
+@Table(name = "storybook_character",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"storybook_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacter.java
@@ -25,12 +25,5 @@ public class StorybookCharacter extends BaseEntity {
     @Column(length = 10, nullable = false)
     private String name;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private Variant variant;
-
-    @Column(name = "image_url", nullable = false)
-    private String imageUrl;
-
 
 }

--- a/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacterVariant.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/entity/StorybookCharacterVariant.java
@@ -1,0 +1,49 @@
+package com.umc.halo.domain.content.storybook.entity;
+
+import com.umc.halo.domain.content.storybook.enums.Variant;
+import com.umc.halo.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Table(name = "storybook_character_variant",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"storybook_character_id", "variant"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StorybookCharacterVariant extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "storybook_character_variant_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "storybook_character_id", nullable = false)
+    private StorybookCharacter storybookCharacter;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Variant variant;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+}

--- a/src/main/java/com/umc/halo/domain/content/storybook/enums/Variant.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/enums/Variant.java
@@ -1,6 +1,8 @@
 package com.umc.halo.domain.content.storybook.enums;
 
 public enum Variant {
-    ORIGINAL,
-    IMAGE_CHOICE
+    WRITING,
+    SCENE_CARD,
+    EXHIBITION,
+    PROFILE
 }

--- a/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookCharacterRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookCharacterRepository.java
@@ -10,7 +10,4 @@ import java.util.*;
 @Repository
 public interface StorybookCharacterRepository extends JpaRepository<StorybookCharacter, Long> {
 
-    Optional<StorybookCharacter> findByStorybookAndVariant(Storybook storybook, Variant variant);
-
-    List<StorybookCharacter> findByStorybookInAndVariant(List<Storybook> storybooks, Variant variant);
 }

--- a/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookCharacterVariantRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookCharacterVariantRepository.java
@@ -19,6 +19,7 @@ public interface StorybookCharacterVariantRepository extends JpaRepository<Story
     @Query("""
                     SELECT sv FROM StorybookCharacterVariant sv
                     JOIN FETCH sv.storybookCharacter sc
+                    JOIN FETCH sc.storybook s
                     WHERE sc.storybook IN :storybooks AND sv.variant=:variant
             """)
     List<StorybookCharacterVariant> findAllByStorybookCharacter_StorybookInAndVariant(

--- a/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookCharacterVariantRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/repository/StorybookCharacterVariantRepository.java
@@ -1,0 +1,27 @@
+package com.umc.halo.domain.content.storybook.repository;
+
+import com.umc.halo.domain.content.storybook.entity.Storybook;
+import com.umc.halo.domain.content.storybook.entity.StorybookCharacterVariant;
+import com.umc.halo.domain.content.storybook.enums.Variant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface StorybookCharacterVariantRepository extends JpaRepository<StorybookCharacterVariant, Long> {
+
+    Optional<StorybookCharacterVariant> findByStorybookCharacter_StorybookAndVariant(Storybook storybook, Variant variant);
+
+    @Query("""
+                    SELECT sv FROM StorybookCharacterVariant sv
+                    JOIN FETCH sv.storybookCharacter sc
+                    WHERE sc.storybook IN :storybooks AND sv.variant=:variant
+            """)
+    List<StorybookCharacterVariant> findAllByStorybookCharacter_StorybookInAndVariant(
+            @Param("storybooks") List<Storybook> storybooks,
+            @Param("variant") Variant variant);
+}

--- a/src/main/java/com/umc/halo/domain/exhibition/converter/ExhibitionConverter.java
+++ b/src/main/java/com/umc/halo/domain/exhibition/converter/ExhibitionConverter.java
@@ -4,6 +4,7 @@ import com.umc.halo.domain.content.chapter.entity.Chapter;
 import com.umc.halo.domain.content.storybook.dto.StorybookResDTO;
 import com.umc.halo.domain.content.storybook.entity.Storybook;
 import com.umc.halo.domain.content.storybook.entity.StorybookCharacter;
+import com.umc.halo.domain.content.storybook.entity.StorybookCharacterVariant;
 import com.umc.halo.domain.exhibition.dto.ExhibitionChapterResDTO;
 import com.umc.halo.domain.exhibition.dto.ExhibitionResDTO;
 import com.umc.halo.domain.record.entity.MemberChapter;
@@ -32,8 +33,10 @@ public class ExhibitionConverter {
     }
 
     public static ExhibitionResDTO.CompletedStorybook toCompletedStorybook(
-            MemberStorybook ms, StorybookCharacter character) {
+            MemberStorybook ms,
+            StorybookCharacterVariant characterVariant) {
         Storybook sb = ms.getStorybook();
+        StorybookCharacter character = characterVariant.getStorybookCharacter();
         return new ExhibitionResDTO.CompletedStorybook(
                 sb.getId(),
                 sb.getThemeOrder(),
@@ -42,7 +45,7 @@ public class ExhibitionConverter {
                 ms.getLastCompletedDate(),
                 character.getId(),
                 character.getName(),
-                character.getImageUrl()
+                characterVariant.getImageUrl()
         );
     }
 

--- a/src/main/java/com/umc/halo/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/umc/halo/domain/exhibition/service/ExhibitionService.java
@@ -107,7 +107,7 @@ public class ExhibitionService {
                     .map(MemberStorybook::getStorybook)
                     .toList();
             Map<Long, StorybookCharacter> characterMap = storybookCharacterRepository
-                    .findByStorybookInAndVariant(completedStorybooks, Variant.ORIGINAL).stream()
+                    .findByStorybookInAndVariant(completedStorybooks, Variant.EXHIBITION).stream()
                     .collect(Collectors.toMap(c -> c.getStorybook().getId(), Function.identity()));
 
             for (MemberStorybook ms : completed) {

--- a/src/main/java/com/umc/halo/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/umc/halo/domain/exhibition/service/ExhibitionService.java
@@ -4,11 +4,11 @@ import com.umc.halo.domain.content.chapter.entity.Chapter;
 import com.umc.halo.domain.content.chapter.entity.SceneCard;
 import com.umc.halo.domain.content.chapter.repository.ChapterRepository;
 import com.umc.halo.domain.content.storybook.entity.Storybook;
-import com.umc.halo.domain.content.storybook.entity.StorybookCharacter;
+import com.umc.halo.domain.content.storybook.entity.StorybookCharacterVariant;
 import com.umc.halo.domain.content.storybook.enums.Variant;
 import com.umc.halo.domain.content.storybook.exception.StorybookException;
 import com.umc.halo.domain.content.storybook.exception.code.StorybookErrorCode;
-import com.umc.halo.domain.content.storybook.repository.StorybookCharacterRepository;
+import com.umc.halo.domain.content.storybook.repository.StorybookCharacterVariantRepository;
 import com.umc.halo.domain.content.storybook.service.StorybookService;
 import com.umc.halo.domain.exhibition.converter.ExhibitionConverter;
 import com.umc.halo.domain.exhibition.dto.ExhibitionChapterResDTO;
@@ -47,7 +47,7 @@ public class ExhibitionService {
     private final MemberStorybookRepository memberStorybookRepository;
     private final MemberChapterRepository memberChapterRepository;
     private final ChapterRepository chapterRepository;
-    private final StorybookCharacterRepository storybookCharacterRepository;
+    private final StorybookCharacterVariantRepository storybookCharacterVariantRepository;
     private final StorybookService storybookService;
 
     public ExhibitionResDTO.MainInfo getExhibition(Long memberId) {
@@ -106,16 +106,16 @@ public class ExhibitionService {
             List<Storybook> completedStorybooks = completed.stream()
                     .map(MemberStorybook::getStorybook)
                     .toList();
-            Map<Long, StorybookCharacter> characterMap = storybookCharacterRepository
-                    .findByStorybookInAndVariant(completedStorybooks, Variant.EXHIBITION).stream()
-                    .collect(Collectors.toMap(c -> c.getStorybook().getId(), Function.identity()));
+            Map<Long, StorybookCharacterVariant> characterVariantMap = storybookCharacterVariantRepository
+                    .findAllByStorybookCharacter_StorybookInAndVariant(completedStorybooks, Variant.EXHIBITION).stream()
+                    .collect(Collectors.toMap(c -> c.getStorybookCharacter().getStorybook().getId(), Function.identity()));
 
             for (MemberStorybook ms : completed) {
-                StorybookCharacter character = characterMap.get(ms.getStorybook().getId());
-                if (character == null) {
+                StorybookCharacterVariant characterVariant = characterVariantMap.get(ms.getStorybook().getId());
+                if (characterVariant == null) {
                     throw new StorybookException(StorybookErrorCode.NOT_FOUND_CHARACTER);
                 }
-                completedDtos.add(ExhibitionConverter.toCompletedStorybook(ms, character));
+                completedDtos.add(ExhibitionConverter.toCompletedStorybook(ms, characterVariant));
             }
         } else if (!inProgress.isEmpty()) {
             for (MemberStorybook ms : inProgress) {

--- a/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
@@ -16,6 +16,7 @@ import java.util.*;
 public class StorybookSeeder {
     private final StorybookRepository storybookRepository;
     private final StorybookCharacterRepository storybookCharacterRepository;
+    private final StorybookCharacterVariantRepository storybookCharacterVariantRepository;
     private final ChapterSeeder chapterSeeder;
 
     @Transactional
@@ -86,46 +87,41 @@ public class StorybookSeeder {
     private static final List<String> CHARACTER_NAMES = List.of("하로", "온이", "다솜", "결", "다온", "가온");
 
     @Transactional
-    public List<StorybookCharacter> seedStorybookCharacter(Storybook storybook, String characterName) {
-        List<StorybookCharacter> storybookCharacters = new ArrayList<>();
-
-        storybookCharacters.add(
+    public StorybookCharacter seedStorybookCharacter(Storybook storybook, String characterName) {
+        StorybookCharacter storybookCharacter = storybookCharacterRepository.save(
                 StorybookCharacter.builder()
                         .storybook(storybook)
                         .name(characterName)
+                        .build()
+        );
+
+        List<StorybookCharacterVariant> variants = List.of(
+                StorybookCharacterVariant.builder()
+                        .storybookCharacter(storybookCharacter)
                         .variant(Variant.WRITING)
                         .imageUrl("https://example.com/character-writing.png")
-                        .build()
-        );
-        storybookCharacters.add(
-                StorybookCharacter.builder()
-                        .storybook(storybook)
-                        .name(characterName)
+                        .build(),
+                StorybookCharacterVariant.builder()
+                        .storybookCharacter(storybookCharacter)
                         .variant(Variant.SCENE_CARD)
                         .imageUrl("https://example.com/character-scene-card.png")
-                        .build()
-        );
-        storybookCharacters.add(
-                StorybookCharacter.builder()
-                        .storybook(storybook)
-                        .name(characterName)
+                        .build(),
+                StorybookCharacterVariant.builder()
+                        .storybookCharacter(storybookCharacter)
                         .variant(Variant.EXHIBITION)
                         .imageUrl("https://example.com/character-exhibition.png")
-                        .build()
-        );
-        storybookCharacters.add(
-                StorybookCharacter.builder()
-                        .storybook(storybook)
-                        .name(characterName)
+                        .build(),
+                StorybookCharacterVariant.builder()
+                        .storybookCharacter(storybookCharacter)
                         .variant(Variant.PROFILE)
                         .imageUrl("https://example.com/character-profile.png")
                         .build()
         );
 
-        List<StorybookCharacter> savedStorybookCharacters = storybookCharacterRepository.saveAll(storybookCharacters);
-        log.info("StorybookCharacters {}건 시딩 완료", savedStorybookCharacters.size());
+        storybookCharacterVariantRepository.saveAll(variants);
+        log.info("StorybookCharacter/Variant 시딩 완료 (character: {}, variant {}건)", characterName, variants.size());
 
-        return savedStorybookCharacters;
+        return storybookCharacter;
     }
 
     @Transactional

--- a/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/StorybookSeeder.java
@@ -93,16 +93,32 @@ public class StorybookSeeder {
                 StorybookCharacter.builder()
                         .storybook(storybook)
                         .name(characterName)
-                        .variant(Variant.ORIGINAL)
-                        .imageUrl("https://example.com/character-original.png")
+                        .variant(Variant.WRITING)
+                        .imageUrl("https://example.com/character-writing.png")
                         .build()
         );
         storybookCharacters.add(
                 StorybookCharacter.builder()
                         .storybook(storybook)
                         .name(characterName)
-                        .variant(Variant.IMAGE_CHOICE)
-                        .imageUrl("https://example.com/character-image-choice.png")
+                        .variant(Variant.SCENE_CARD)
+                        .imageUrl("https://example.com/character-scene-card.png")
+                        .build()
+        );
+        storybookCharacters.add(
+                StorybookCharacter.builder()
+                        .storybook(storybook)
+                        .name(characterName)
+                        .variant(Variant.EXHIBITION)
+                        .imageUrl("https://example.com/character-exhibition.png")
+                        .build()
+        );
+        storybookCharacters.add(
+                StorybookCharacter.builder()
+                        .storybook(storybook)
+                        .name(characterName)
+                        .variant(Variant.PROFILE)
+                        .imageUrl("https://example.com/character-profile.png")
                         .build()
         );
 

--- a/src/main/resources/db/migration/V10__drop_storybook_character_column.sql
+++ b/src/main/resources/db/migration/V10__drop_storybook_character_column.sql
@@ -1,0 +1,16 @@
+-- 대표 행 선정(삭제 위함)
+CREATE TEMPORARY TABLE tmp_character AS
+SELECT storybook_id, MIN(storybook_character_id) AS keep_id
+FROM storybook_character
+GROUP BY storybook_id;
+
+DELETE sc
+FROM storybook_character sc
+    JOIN tmp_character t ON t.storybook_id=sc.storybook_id
+WHERE sc.storybook_character_id<>t.keep_id;
+
+DROP TEMPORARY TABLE tmp_character;
+
+ALTER TABLE storybook_character
+    DROP COLUMN variant,
+    DROP COLUMN image_url;

--- a/src/main/resources/db/migration/V11__add_storybook_character_storybook_unique_constraint.sql
+++ b/src/main/resources/db/migration/V11__add_storybook_character_storybook_unique_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE storybook_character
+    ADD UNIQUE INDEX uk_storybook_character_storybook (storybook_id);

--- a/src/main/resources/db/migration/V8__migrate_storybook_character_data.sql
+++ b/src/main/resources/db/migration/V8__migrate_storybook_character_data.sql
@@ -31,3 +31,14 @@ FROM storybook_character sc
          JOIN tmp_character t ON t.storybook_id = sc.storybook_id;
 
 DROP TEMPORARY TABLE tmp_character;
+
+-- 실제 URL로 UPDATE 필요
+INSERT INTO storybook_character_variant (created_at, updated_at, storybook_character_id, variant, image_url)
+SELECT w.created_at, w.updated_at, w.storybook_character_id, 'EXHIBITION', w.image_url
+FROM storybook_character_variant w
+WHERE w.variant = 'WRITING';
+
+INSERT INTO storybook_character_variant (created_at, updated_at, storybook_character_id, variant, image_url)
+SELECT w.created_at, w.updated_at, w.storybook_character_id, 'PROFILE', w.image_url
+FROM storybook_character_variant w
+WHERE w.variant = 'WRITING';

--- a/src/main/resources/db/migration/V8__migrate_storybook_character_data.sql
+++ b/src/main/resources/db/migration/V8__migrate_storybook_character_data.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS storybook_character_variant
+(
+    storybook_character_variant_id BIGINT AUTO_INCREMENT NOT NULL,
+    created_at                     datetime              NOT NULL,
+    updated_at                     datetime              NOT NULL,
+    storybook_character_id         BIGINT                NOT NULL,
+    variant                        VARCHAR(255)          NOT NULL,
+    image_url                      VARCHAR(255)          NOT NULL,
+    CONSTRAINT pk_storybook_character_variant PRIMARY KEY (storybook_character_variant_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+-- 대표 행 선정
+CREATE TEMPORARY TABLE tmp_character AS
+SELECT storybook_id, MIN(storybook_character_id) AS keep_id
+FROM storybook_character
+GROUP BY storybook_id;
+
+INSERT INTO storybook_character_variant (created_at, updated_at, storybook_character_id, variant, image_url)
+SELECT sc.created_at,
+       sc.updated_at,
+       t.keep_id,
+       CASE sc.variant
+           WHEN 'ORIGINAL' THEN 'WRITING'
+           WHEN 'IMAGE_CHOICE' THEN 'SCENE_CARD'
+           ELSE sc.variant
+           END,
+       sc.image_url
+FROM storybook_character sc
+         JOIN tmp_character t ON t.storybook_id = sc.storybook_id;
+
+DROP TEMPORARY TABLE tmp_character;

--- a/src/main/resources/db/migration/V9__add_storybook_character_variant_constraints.sql
+++ b/src/main/resources/db/migration/V9__add_storybook_character_variant_constraints.sql
@@ -1,0 +1,6 @@
+ALTER TABLE storybook_character_variant
+    ADD CONSTRAINT FK_STORYBOOK_CHARACTER_VARIANT_ON_STORYBOOK_CHARACTER
+    FOREIGN KEY (storybook_character_id) REFERENCES storybook_character (storybook_character_id);
+
+ALTER TABLE storybook_character_variant
+    ADD UNIQUE INDEX uk_storybook_character_variant_character_variant (storybook_character_id, variant);


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 캐릭터/캐릭터 변형 테이블 분리+Variant 확장
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `Variant` enum: `ORIGINAL`→`WRITING`, `IMAGE_CHOICE`→`SCENE_CARD` 변경, `EXHIBITION`/`PROFILE` 추가
- `StorybookCharacter`/`StorybookCharacterVariant` 엔티티 정규화 고려하여 분리
- `StorybookCharacterRepository`/`StorybookCharacterVariantRepository` 분리, 목록 조회는 N+1 방지를 위해 @Query + JOIN FETCH 적용
- `ChapterService`/`ChapterConverter`, `ExhibitionService`/`ExhibitionConverter`가 `StorybookCharacterVariant` 기준으로 캐릭터 이미지를 조회하도록 수정
- `StorybookSeeder`: 캐릭터 1건당 variant 4종(`WRITING`/`SCENE_CARD`/`EXHIBITION`/`PROFILE`) 시딩하도록 수정
- DB 마이그레이션 V8~V10 추가
  - V8: 기존 `storybook_character`(캐릭터당 2행, `variant`/`image_url` 보유) 데이터를 `storybook_character_variant`로 이관
  - V9: FK, (`storybook_character_id`, `variant`) UNIQUE 제약 추가
  - V10: 중복 캐릭터 행 정리 + `storybook_character`의 `variant`/`image_url` 컬럼 삭제
  - 실패 시 복구 범위를 좁히기 위해 이관/제약/삭제를 버전별로 분리
- `ChapterControllerDocs` Swagger 문서에 새 variant 명칭 반영
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 로컬 DB 초기화 후 서버 기동 확인 (Flyway V8~V10 정상 적용) 
- 오늘의 장 조회
<img width="1037" height="1282" alt="image" src="https://github.com/user-attachments/assets/8b79136e-2226-4737-9a09-21f99f2cb235" />

- 테마함 조회
<img width="1049" height="1403" alt="image" src="https://github.com/user-attachments/assets/27da2043-925d-4ffb-afc7-8bf5829a386c" />

---

## ✅ 확인 사항

- [X] 서버 정상 기동 확인
- [X] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [X] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #123
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 시더 변경으로 로컬 데이터베이스 삭제 후 새로 생성 권장(미수행시 테마함 조회에서 오류 발생)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경 사항**
  * 캐릭터 유형이 `WRITING`, `SCENE_CARD`, `EXHIBITION`, `PROFILE`로 개편되었습니다.
  * 장 조회 응답에서 유형별 캐릭터 이미지 URL이 제공됩니다.
  * 완료된 스토리북 전시에 전용 `EXHIBITION` 캐릭터 이미지가 사용됩니다.
  * 기존 캐릭터 데이터가 새로운 유형 체계로 이전됩니다.
  * 장 조회 API 문서와 오류·응답 예시가 새 유형 및 이미지 필드에 맞게 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->