### PR TITLE
[refactor] 약관 동의 여부 판단 로직 단일 쿼리로 통일

### DIFF
--- a/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
@@ -162,9 +162,8 @@ public interface TermControllerDocs {
 
                     ## 동작 방식
                     1. 인증된 회원을 조회합니다. 존재하지 않으면 404(MEMBER404_1)를 반환합니다.
-                    2. 회원이 동의한 약관 목록을 조회합니다.
-                    3. 필수 약관(isRequired=true)이 모두 동의 목록에 포함되어 있는지 확인합니다.
-                    4. 필수 약관 중 하나라도 동의하지 않았으면 termsAgreed를 false로, 모두 동의했으면 true로 반환합니다.
+                    2. 필수 약관 전체 개수와 회원이 동의한 필수 약관 개수를 비교합니다.
+                    3. 두 개수가 같으면 termsAgreed를 true로, 다르면 false로 반환합니다.
                     """
     )
     @ApiResponses(value = {

--- a/src/main/java/com/umc/halo/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/umc/halo/domain/term/repository/TermRepository.java
@@ -10,6 +10,4 @@ import java.util.List;
 public interface TermRepository extends JpaRepository<Term, Long> {
 
     List<Term> findAllByOrderByIdAsc();
-
-    List<Term> findAllByIsRequiredTrue();
 }

--- a/src/main/java/com/umc/halo/domain/term/service/TermService.java
+++ b/src/main/java/com/umc/halo/domain/term/service/TermService.java
@@ -112,16 +112,11 @@ public class TermService {
     @Transactional(readOnly = true)
     public TermResDTO.AgreementStatus getAgreementStatus(Long memberId) {
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+        if (!memberRepository.existsById(memberId)) {
+            throw new MemberException(MemberErrorCode.NOT_FOUND);
+        }
 
-        Set<Long> agreedTermIds = memberTermRepository.findAllByMember(member).stream()
-                .filter(memberTerm -> Boolean.TRUE.equals(memberTerm.getIsAgreed()))
-                .map(memberTerm -> memberTerm.getTerm().getId())
-                .collect(Collectors.toSet());
-
-        boolean termsAgreed = termRepository.findAllByIsRequiredTrue().stream()
-                .allMatch(term -> agreedTermIds.contains(term.getId()));
+        boolean termsAgreed = memberTermRepository.areAllRequiredTermsAgreed(memberId);
 
         return TermConverter.toAgreementStatus(termsAgreed);
     }


### PR DESCRIPTION
## 📝 작업 내용

- 약관 동의 여부 조회 API의 필수 약관 전체 동의 판단을 단일 쿼리로 통일
- 기존에는 TermService에서 자바 스트림으로, #117에서 추가된 MemberTermRepository에서는 JPQL로
  같은 판단을 하고 있어 약관 정책 변경 시 API별로 termsAgreed 값이 달라질 수 있었습니다.
- 
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
- TermService (getAgreementStatus 계산 로직을 areAllRequiredTermsAgreed 호출로 교체, 404 판정을 existsById로 변경)
- TermRepository (미사용 메서드가 된 findAllByIsRequiredTrue 삭제)
- TermControllerDocs (약관 동의 여부 조회 동작 방식 설명 수정)
- 
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- GET /api/v1/terms/agreements 정상 동작 확인 (변경 전과 동일한 응답)
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #126 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 응답 스펙 변경 없음 → Notion 명세서 수정 없습니다.
- 쿼리 3회 → 2회로 감소했습니다.
- 필수 약관이 0건인 경우도 기존과 동일하게 true를 반환합니다.
- #117 에서 추가된 areAllRequiredTermsAgreed 메서드를 재사용했습니다.

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 약관 동의 여부 조회 기준을 개선했습니다.
  * 회원이 모든 필수 약관에 동의한 경우에만 동의 완료로 정확히 표시됩니다.
  * 존재하지 않는 회원 조회 시 기존과 동일하게 오류가 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->