### PR TITLE
[feat] 약관 목록 조회에 전문·수정일 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
@@ -45,10 +45,10 @@ public interface TermControllerDocs {
                                       "code": "TERMS200_1",
                                       "message": "약관 목록 조회 성공",
                                       "result": [
-                                        { "termId": 1, "title": "서비스 이용약관", "shortDescription": "HALO 서비스 이용 기준", "isRequired": true },
-                                        { "termId": 2, "title": "개인정보 처리방침", "shortDescription": "수집 항목 보관 기간 안내", "isRequired": true },
-                                        { "termId": 3, "title": "콘텐츠 보관 및 활용 안내", "shortDescription": "사진·기록 저장 기준", "isRequired": true },
-                                        { "termId": 4, "title": "마케팅 정보 수신 동의", "shortDescription": "이벤트·업데이트 안내", "isRequired": false }
+                                        { "termId": 1, "title": "서비스 이용약관", "shortDescription": "HALO 서비스 이용 기준", "description": "제1조(목적) 이 약관은 HALO 서비스의 이용 조건을 규정합니다. ...", "isRequired": true, "updatedAt": "2026-07-30T21:51:59" },
+                                        { "termId": 2, "title": "개인정보 처리방침", "shortDescription": "수집 항목 보관 기간 안내", "description": "회사는 이름, 생년월일 등을 수집합니다. ...", "isRequired": true, "updatedAt": "2026-07-30T21:51:59" },
+                                        { "termId": 3, "title": "콘텐츠 보관 및 활용 안내", "shortDescription": "사진·기록 저장 기준", "description": "회원이 작성한 기록·사진 콘텐츠는 안전하게 저장됩니다. ...", "isRequired": true, "updatedAt": "2026-07-30T21:51:59" },
+                                        { "termId": 4, "title": "마케팅 정보 수신 동의", "shortDescription": "이벤트·업데이트 안내", "isRequired": false, "description": "이벤트·프로모션 정보를 이메일 또는 푸시로 받습니다. ...", "updatedAt": "2026-07-30T21:51:59" }
                                       ]
                                     }
                                     """)

--- a/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
@@ -12,7 +12,10 @@ public class TermConverter {
                 .termId(term.getId())
                 .title(term.getTitle())
                 .shortDescription(term.getShortDescription())
+                .description(term.getDescription())
                 .isRequired(term.getIsRequired())
+                .isRequired(term.getIsRequired())
+                .updatedAt(term.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
@@ -14,7 +14,6 @@ public class TermConverter {
                 .shortDescription(term.getShortDescription())
                 .description(term.getDescription())
                 .isRequired(term.getIsRequired())
-                .isRequired(term.getIsRequired())
                 .updatedAt(term.getUpdatedAt())
                 .build();
     }

--- a/src/main/java/com/umc/halo/domain/term/dto/TermResDTO.java
+++ b/src/main/java/com/umc/halo/domain/term/dto/TermResDTO.java
@@ -1,6 +1,7 @@
 package com.umc.halo.domain.term.dto;
 
 import lombok.Builder;
+import java.time.LocalDateTime;
 
 public class TermResDTO {
 
@@ -8,8 +9,10 @@ public class TermResDTO {
     public record Info(
             Long termId,
             String title,
+            String description,
             String shortDescription,
-            Boolean isRequired
+            Boolean isRequired,
+            LocalDateTime updatedAt
     ) {}
 
     @Builder

--- a/src/main/java/com/umc/halo/domain/term/dto/TermResDTO.java
+++ b/src/main/java/com/umc/halo/domain/term/dto/TermResDTO.java
@@ -9,8 +9,8 @@ public class TermResDTO {
     public record Info(
             Long termId,
             String title,
-            String description,
             String shortDescription,
+            String description,
             Boolean isRequired,
             LocalDateTime updatedAt
     ) {}


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 약관 목록 조회(GET /api/v1/terms) 응답에 약관 전문(description)과 최종 수정일(updatedAt) 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `TermResDTO.Info`에 description, updatedAt 필드 추가
- `TermConverter.toInfo`에서 두 필드 매핑
- `TermControllerDocs` 목록 조회 Swagger Example 갱신
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="1051" height="492" alt="스크린샷 2026-08-02 오후 12 36 06" src="https://github.com/user-attachments/assets/522956ca-d990-44f5-a67f-8498e47a73da" />


---

## ✅ 확인 사항
- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #131 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 약관 목록 조회 API에서 약관의 상세 설명과 최종 수정일을 함께 제공합니다.
  * 약관 정보 응답에 `description` 및 `updatedAt` 필드가 추가되었습니다.

* **문서**
  * Swagger 성공 응답 예시에 약관 상세 설명과 최종 수정일이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->