### PR TITLE
[FIX] 캘린더 일별 조회 completedChapterOrder 해당 날짜 기준으로 수정

### DIFF
--- a/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
@@ -104,9 +104,6 @@ public class CalendarService {
                 .sorted(Comparator.comparing(MemberChapter::getUpdatedAt).reversed())
                 .toList();
 
-        Map<Long, List<MemberChapter>> chaptersByStorybook = memberChapterRepository
-                .findAllByMemberWithChapter(member).stream()
-                .collect(Collectors.groupingBy(mc -> mc.getChapter().getStorybook().getId()));
         List<CalendarDailyResDTO.StorybookInfo> storybooks = new ArrayList<>();
         List<CalendarDailyResDTO.ChapterInfo> chapters = new ArrayList<>();
 
@@ -117,19 +114,11 @@ public class CalendarService {
             if (chapterOrderOfDay == TOTAL_CHAPTER_COUNT) {
                 storybooks.add(CalendarConverter.toStorybookInfo(storybook));
             } else {
-                List<MemberChapter> myChapters = chaptersByStorybook.getOrDefault(storybook.getId(), List.of());
-                Integer completedChapterOrder = resolveCompletedChapterOrder(myChapters);
-                chapters.add(CalendarConverter.toChapterInfo(storybook, completedChapterOrder));
+                chapters.add(CalendarConverter.toChapterInfo(storybook, chapterOrderOfDay));
             }
         }
 
         return CalendarConverter.toDailyInfo(date.toString(), storybooks, chapters);
-    }
-    private Integer resolveCompletedChapterOrder(List<MemberChapter> myChapters) {
-        return myChapters.stream()
-                .filter(mc -> mc.getStatus() == Status.COMPLETED)
-                .map(mc -> mc.getChapter().getChapterOrder())                .max(Integer::compareTo)
-                .orElse(0);
     }
 
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 캘린더 일별 조회에서 completedChapterOrder가 해당 날짜 기준으로 반환되도록 수정
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 기존: 회원 전체 기록 중 완료한 마지막 장을 반환 (날짜 무관) → 과거 날짜 조회 시 최신 장이 뜨는 버그
- 수정: 해당 날짜에 완료한 장(chapterOrderOfDay)을 그대로 반환
- 불필요해진 resolveCompletedChapterOrder랑 findAllByMemberWithChapter 전체 조회 제거했음

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
7/30 조회
<img width="1072" height="506" alt="스크린샷 2026-08-03 오전 12 26 59" src="https://github.com/user-attachments/assets/31a7668a-42db-45ba-9a13-a454151431be" />

7/31 조회
<img width="917" height="318" alt="스크린샷 2026-08-03 오전 12 30 58" src="https://github.com/user-attachments/assets/65ef15b0-e360-4eec-bf27-ec24508b0b00" />

---

## ✅ 확인 사항

- [X] 서버 정상 기동 확인
- [X] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [X] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #137
 
---

## 📌 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선**
  * 일별 캘린더에서 완료된 챕터가 실제 순서에 맞게 표시됩니다.
  * 마지막 챕터 완료 시 스토리북으로, 그 외에는 챕터 정보로 올바르게 분류됩니다.
  * 캘린더 조회 과정이 간소화되어 관련 정보가 더 정확하게 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->