### PR TITLE
[fix] 챕터 완료 후 lastChapterOrder가 다음 장으로 갱신되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/storybook/converter/StorybookConverter.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/converter/StorybookConverter.java
@@ -55,14 +55,14 @@ public class StorybookConverter {
     }
 
     public static StorybookResDTO.StorybookSummary toStorybookSummary(
-            Storybook storybook, StorybookStatus status, MemberStorybook memberStorybook) {
+            Storybook storybook, StorybookStatus status, MemberStorybook memberStorybook, Integer displayChapterOrder) {
         return StorybookResDTO.StorybookSummary.builder()
                 .storybookId(storybook.getId())
                 .title(storybook.getTitle())
                 .shortDescription(storybook.getShortDescription())
                 .imageUrl(storybook.getImageUrl())
                 .status(status)
-                .lastChapterOrder(memberStorybook == null ? null : memberStorybook.getLastChapterOrder())
+                .lastChapterOrder(displayChapterOrder)
                 .lastCompletedDate(memberStorybook == null ? null : memberStorybook.getLastCompletedDate())
                 .build();
     }

--- a/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
@@ -225,6 +225,7 @@ public class StorybookService {
 
         // 스토리북마다 상태 계산 (목록 조회와 동일한 로직)
         Map<Storybook, StorybookStatus> statusMap = new LinkedHashMap<>();
+        Map<Long, List<MemberChapter>> memberChaptersMap = new LinkedHashMap<>();
         for (Storybook sb : storybooks) {
             MemberStorybook ms = memberStorybookMap.get(sb.getId());
             if (ms == null) {
@@ -234,6 +235,7 @@ public class StorybookService {
 
             List<MemberChapter> memberChapters =
                     memberChapterRepository.findByMemberAndChapter_Storybook_Id(member, sb.getId());
+            memberChaptersMap.put(sb.getId(), memberChapters);
 
             boolean completed = isCompleted(sb, memberChapters);
             boolean completedToday = ms.isCompletedToday();
@@ -268,7 +270,7 @@ public class StorybookService {
 
             for (Storybook sb : activeStorybooks) {
                 MemberStorybook memberStorybook = memberStorybookMap.get(sb.getId());
-                Integer chapterOrder = memberStorybook.getLastChapterOrder();
+                Integer chapterOrder = resolveDisplayChapterOrder(memberStorybook, memberChaptersMap.get(sb.getId()));
                 boolean todayAvailable = statusMap.get(sb) == StorybookStatus.IN_PROGRESS;
                 inProgressStorybooks.add(StorybookConverter.toInProgressStorybook(sb, chapterOrder, todayAvailable));
             }
@@ -291,7 +293,7 @@ public class StorybookService {
             Member member, Storybook storybook, MemberStorybook memberStorybook) {
 
         if (memberStorybook == null) {
-            return StorybookConverter.toStorybookSummary(storybook, StorybookStatus.NOT_STARTED, null);
+            return StorybookConverter.toStorybookSummary(storybook, StorybookStatus.NOT_STARTED, null, null);
         }
 
         List<MemberChapter> memberChapters =
@@ -310,7 +312,8 @@ public class StorybookService {
             status = StorybookStatus.IN_PROGRESS;
         }
 
-        return StorybookConverter.toStorybookSummary(storybook, status, memberStorybook);
+        Integer displayChapterOrder = resolveDisplayChapterOrder(memberStorybook, memberChapters);
+        return StorybookConverter.toStorybookSummary(storybook, status, memberStorybook, displayChapterOrder);
     }
 
     private boolean isStorybookCompleted(Member member, Storybook storybook) {
@@ -352,5 +355,13 @@ public class StorybookService {
                     return StorybookConverter.toSituationalRecommendation(tag.getTitle(), situationalStorybooks);
                 })
                 .toList();
+    }
+
+    private Integer resolveDisplayChapterOrder(MemberStorybook memberStorybook, List<MemberChapter> memberChapters) {
+        Integer lastChapterOrder = memberStorybook.getLastChapterOrder();
+        boolean lastCompleted = memberChapters.stream()
+                .anyMatch(mc -> lastChapterOrder.equals(mc.getChapter().getChapterOrder())
+                        && mc.getStatus() == Status.COMPLETED);
+        return (lastCompleted && lastChapterOrder < 10) ? lastChapterOrder + 1 : lastChapterOrder;
     }
 }

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
@@ -38,9 +38,8 @@ public class MemberStorybook extends BaseEntity {
     @Column(name = "last_completed_date")
     private LocalDate lastCompletedDate;
 
-
     public void updateCompleted(Integer chapterOrder) {
-        this.lastChapterOrder = chapterOrder;
+        this.lastChapterOrder = (chapterOrder < 10) ? chapterOrder + 1 : chapterOrder;
         this.lastCompletedDate = LocalDate.now();
     }
 

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
@@ -39,7 +39,7 @@ public class MemberStorybook extends BaseEntity {
     private LocalDate lastCompletedDate;
 
     public void updateCompleted(Integer chapterOrder) {
-        this.lastChapterOrder = (chapterOrder < 10) ? chapterOrder + 1 : chapterOrder;
+        this.lastChapterOrder = chapterOrder;
         this.lastCompletedDate = LocalDate.now();
     }
 


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 챕터 완료 시 lastChapterOrder가 다음 장으로 갱신되지 않아, 다음 장을 직접 열어보기 전까지 이미 완료한 장이 계속 "진행중"으로 표시되는 문제 수정

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- MemberStorybook.updateCompleted(): 원래대로 유지 (엔티티에는 마지막으로 완료한 장 번호를 그대로 저장 — 캘린더/전시 도메인이 이 값을 그대로 사용하고 있어서 값 자체는 바꾸지 않음)
- StorybookService: resolveDisplayChapterOrder() 신규 추가 — 마지막 완료 장이 완료 상태면 조회 시점에 +1 계산해서 응답에 반영 (10장이면 그대로 유지)
- StorybookConverter.toStorybookSummary(): displayChapterOrder 파라미터 추가
- getStorybookList()/getHome() 양쪽에 계산된 값 반영

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- storybookId=3(NOT_STARTED)을 시작 → 1장 완료 처리 → 2장을 전혀 열어보지 않은 상태에서 GET /api/v1/storybooks 호출 → status: "TODAY_DONE", lastChapterOrder: 2로 정상 반환 확인
<img width="868" height="1061" alt="스크린샷 2026-08-04 오후 4 00 23" src="https://github.com/user-attachments/assets/cf8fe8cb-7b3c-4bbf-a45b-bb3d1d4ff0f2" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #145
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.

- 처음엔 MemberStorybook 엔티티 값 자체를 +1로 저장하도록 고쳤으나, 캘린더(CalendarService)와 전시(ExhibitionService) 도메인이 lastChapterOrder를 "마지막으로 완료한 장 번호 그대로"라는 전제로 이미 쓰고 있어 충돌 발견 → 엔티티는 원복하고 StorybookService 조회 시점에서만 +1 계산하는 방식으로 변경
- ExhibitionService에 이미 동일한 패턴(resolveNextChapterOrder)이 있어 그 방식을 참고함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 버그 수정

* 홈 및 스토리북 목록에서 챕터 완료 상태에 따라 표시되는 챕터 순서가 올바르게 갱신됩니다.
* 10장 미만의 마지막 챕터를 완료하면 다음 챕터 순서가 표시됩니다.
* 마지막 챕터를 완료했거나 10장 이상인 경우 기존 순서가 유지됩니다.
* 챕터 완료 날짜 업데이트 동작은 기존과 동일하게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->