### PR TITLE
[fix] 장 기록 작성 요청 및 presigned URL 발급 응답의 불필요한 imageUrl 필드 제거

### DIFF
--- a/src/main/java/com/umc/halo/domain/image/controller/docs/ImageControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/image/controller/docs/ImageControllerDocs.java
@@ -48,7 +48,6 @@ public interface ImageControllerDocs {
                                         "message": "presigned URL을 성공적으로 발급했습니다.",
                                         "result": {
                                             "presignedUrl": "https://halo-bucket.s3.ap-northeast-2.amazonaws.com/images/1/9f1c2e3a-....png?X-Amz-Algorithm=...",
-                                            "imageUrl": "https://halo-bucket.s3.ap-northeast-2.amazonaws.com/images/1/9f1c2e3a-....png",
                                             "imageKey": "images/1/9f1c2e3a-....png",
                                             "expires": 300
                                         }

--- a/src/main/java/com/umc/halo/domain/image/converter/ImageConverter.java
+++ b/src/main/java/com/umc/halo/domain/image/converter/ImageConverter.java
@@ -26,11 +26,10 @@ public class ImageConverter {
     }
 
     public static ImageResDTO.CreatePresignedUrl toCreatePresignedUrl(
-            PresignedPutObjectRequest presignedPutObjectRequest, String imageKey, String imageUrl, Duration expiration) {
+            PresignedPutObjectRequest presignedPutObjectRequest, String imageKey, Duration expiration) {
         return ImageResDTO.CreatePresignedUrl.builder()
                 .presignedUrl(presignedPutObjectRequest.url().toString())
                 .imageKey(imageKey)
-                .imageUrl(imageUrl)
                 .expires((int) expiration.toSeconds())
                 .build();
     }

--- a/src/main/java/com/umc/halo/domain/image/dto/ImageResDTO.java
+++ b/src/main/java/com/umc/halo/domain/image/dto/ImageResDTO.java
@@ -7,7 +7,6 @@ public class ImageResDTO {
     @Builder
     public record CreatePresignedUrl(
             String presignedUrl,
-            String imageUrl,
             String imageKey,
             Integer expires
     ) {

--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -44,13 +44,12 @@ public class ImageService {
 
         ImageContentType contentType = ImageContentType.from(dto.contentType());
         String imageKey = generateImageKey(memberId, contentType);
-        String imageUrl = buildImageUrl(imageKey);
 
         PutObjectRequest putObjectRequest = ImageConverter.toPutObjectRequest(bucket, imageKey, contentType, dto.fileSize());
         PutObjectPresignRequest putPresignRequest = ImageConverter.toPutObjectPresignRequest(EXPIRATION, putObjectRequest);
         PresignedPutObjectRequest presignedPutObjectRequest = s3Presigner.presignPutObject(putPresignRequest);
 
-        return ImageConverter.toCreatePresignedUrl(presignedPutObjectRequest, imageKey, imageUrl, EXPIRATION);
+        return ImageConverter.toCreatePresignedUrl(presignedPutObjectRequest, imageKey, EXPIRATION);
     }
 
     // imageKey 발급 (presigned URL 발급시, pending/images/)

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -24,7 +24,7 @@ public interface RecordControllerDocs {
                     - **Body**
                         - chapterId : 기록할 장 ID
                         - emotion / coverType : status가 COMPLETED일 때만 필수
-                        - imageUrl / imageKey : coverType이 IMAGE일 때만 필수
+                        - imageKey : coverType이 IMAGE일 때만 필수
                         - sceneCardId : coverType이 SCENE_CARD일 때만 필수
                         - answers : 질문별 답변 목록 (최대 3개, 단계별 저장 시 일부만 포함 가능. status가 COMPLETED일 때는 장의 모든 질문에 대한 답변 필요)
                         - status : DRAFT(임시저장) 또는 COMPLETED(최종완료)
@@ -34,7 +34,7 @@ public interface RecordControllerDocs {
                     2. 회원의 스토리북 진행 정보(MemberStorybook)를 조회합니다. 아직 시작하지 않은 스토리북이면 403(CHAPTER403_1)을 반환합니다.
                     3. 오늘 이미 이 스토리북의 장을 완료했다면 409(CHAPTER409_1)를 반환합니다.
                     4. 진행 중인 장 순서를 기준으로 요청한 장에 접근 가능한지 검증합니다. 아직 열리지 않은 장이면 403(CHAPTER403_1), 이미 완료한 장이면 403(CHAPTER403_2)을 반환합니다.
-                    5. coverType과 imageUrl/imageKey/sceneCardId 조합이 일치하는지 검증합니다. (CHAPTER400_1)
+                    5. coverType과 imageKey/sceneCardId 조합이 일치하는지 검증합니다. (CHAPTER400_1)
                     6. status가 COMPLETED이면 coverType, emotion이 모두 입력되었는지, 장의 모든 질문에 답변했는지 검증합니다. (CHAPTER400_4~6)
                     7. sceneCardId가 있으면 해당 장의 장면 카드가 맞는지 확인합니다. (CHAPTER400_2)
                     8. 장 기록(MemberChapter)을 생성하거나 갱신합니다. 동시 요청으로 중복 저장이 발생하면 409(CHAPTER409_2)를 반환합니다.

--- a/src/main/java/com/umc/halo/domain/record/dto/RecordReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/record/dto/RecordReqDTO.java
@@ -15,7 +15,6 @@ public class RecordReqDTO {
             Long chapterId,
             Emotion emotion,
             CoverType coverType,
-            String imageUrl,
             String imageKey,
             Long sceneCardId,
             @Valid

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -80,7 +80,7 @@ public class RecordService {
                 if (recordReqDTO.sceneCardId() != null) {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
                 }
-                if ((recordReqDTO.imageUrl() == null) || (recordReqDTO.imageKey() == null)) {
+                if (recordReqDTO.imageKey() == null) {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
                 }
                 // 기존 기록의 imageKey와 동일하면 그대로 사용
@@ -90,7 +90,7 @@ public class RecordService {
                     imageKey = imageService.finalizeImage(memberId, recordReqDTO.imageKey()).finalKey();
                 }
             } else {
-                if ((recordReqDTO.imageKey() != null) || (recordReqDTO.imageUrl() != null)) {
+                if (recordReqDTO.imageKey() != null) {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
                 }
                 if (recordReqDTO.sceneCardId() == null) {
@@ -98,7 +98,7 @@ public class RecordService {
                 }
             }
         } else {
-            if ((recordReqDTO.sceneCardId() != null) || (recordReqDTO.imageKey() != null) || (recordReqDTO.imageUrl() != null)) {
+            if ((recordReqDTO.sceneCardId() != null) || (recordReqDTO.imageKey() != null)) {
                 throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
             }
         }

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -80,7 +80,7 @@ public class RecordService {
                 if (recordReqDTO.sceneCardId() != null) {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
                 }
-                if (recordReqDTO.imageKey() == null) {
+                if (recordReqDTO.imageKey() == null || recordReqDTO.imageKey().isBlank()) {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
                 }
                 // 기존 기록의 imageKey와 동일하면 그대로 사용


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 장 기록 작성 API(`POST /api/v1/member-chapters`) 요청에서 명세와 어긋나게 남아있던 `imageUrl` 필드 제거 (imageKey만 사용)
- presigned URL 발급 API(`POST /api/v1/images/presigned-url`) 응답에서 실제로 쓰이지 않던 `imageUrl` 필드 제거
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `RecordReqDTO.WriteChapterRecord`: `imageUrl` 필드 삭제
- `RecordControllerDocs`: 요청 Swagger 예시에서 `imageUrl` 제거
- `RecordService`: 관련 참조 정리
- `ImageResDTO.CreatePresignedUrl`: `imageUrl` 필드 삭제 (`presignedUrl`, `imageKey`, `expires`만 유지)
- `ImageConverter.toCreatePresignedUrl`, `ImageService.createPresignedUrl`: `imageUrl` 생성/전달 로직 제거
- `ImageControllerDocs`: 응답 Swagger 예시에서 `imageUrl` 제거
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 장 기록 작성
<img width="1024" height="1304" alt="image" src="https://github.com/user-attachments/assets/d0fcdde9-0101-40eb-a5c9-7a5cc2d7e297" />
- presigned url 발급
<img width="1017" height="1595" alt="image" src="https://github.com/user-attachments/assets/d59ce673-11c4-4e4f-b5f4-8c7ed2f4b8a7" />
<img width="1024" height="330" alt="image" src="https://github.com/user-attachments/assets/6d79bf83-16fc-4d6f-a12b-564c29e8ea77" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #151
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 이미지 업로드 응답에서 `imageUrl` 항목이 제거되었습니다.
  * 이미지 업로드 결과는 presigned URL, 이미지 키, 만료 시간으로 제공됩니다.
  * 기록 작성 시 이미지 커버는 `imageKey`만 사용하도록 변경되었습니다.
  * 장면 카드 커버의 입력 검증이 새로운 이미지 정보 형식에 맞게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->