### PR TITLE
[fix] 오늘의 장 조회 API에 longImageUrl 필드 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
@@ -55,6 +55,7 @@ public interface ChapterControllerDocs {
                                                               "result": {
                                                                 "chapterId": 1,
                                                                 "storybookTitle": "오래 전 당신",
+                                                                "longImageUrl": "https://example.com/long-image.png",
                                                                 "guide": "부모님이 지금 내 나이였을 땐 어떤 하루를 보냈을까요? 사진 한 장을 보며 가볍게 물어봐요.",
                                                                 "character": {
                                                                   "writingCharacterImageUrl": "https://example.com/character-writing.png",
@@ -97,6 +98,7 @@ public interface ChapterControllerDocs {
                                                               "result": {
                                                                 "chapterId": 1,
                                                                 "storybookTitle": "오래 전 당신",
+                                                                "longImageUrl": "https://example.com/long-image.png",
                                                                 "guide": "부모님이 지금 내 나이였을 땐 어떤 하루를 보냈을까요? 사진 한 장을 보며 가볍게 물어봐요.",
                                                                 "character": {
                                                                   "writingCharacterImageUrl": "https://example.com/character-writing.png",

--- a/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
@@ -22,6 +22,7 @@ public class ChapterConverter {
         return ChapterResDTO.TodayChapter.builder()
                 .chapterId(chapter.getId())
                 .storybookTitle(chapter.getStorybook().getTitle())
+                .longImageUrl(chapter.getLongImageUrl())
                 .guide(chapter.getGuide())
 
                 .character(

--- a/src/main/java/com/umc/halo/domain/content/chapter/dto/ChapterResDTO.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/dto/ChapterResDTO.java
@@ -11,9 +11,9 @@ public class ChapterResDTO {
     // 오늘의 장 조회
     @Builder
     public record TodayChapter(
-
             Long chapterId,
             String storybookTitle,
+            String longImageUrl,
             String guide,
             Character character,
             List<Question> questions,


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 오늘의 장 조회 API(GET /api/v1/storybooks/{storybookId}/chapters/{chapterOrder}) 응답에 longImageUrl 필드 추가

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- ChapterResDTO.TodayChapter: longImageUrl 필드 추가 (storybookTitle 다음, guide 앞)
- ChapterConverter.toTodayChapter(): .longImageUrl(chapter.getLongImageUrl()) 매핑 추가
- ChapterControllerDocs: 200 응답 예시 2개("임시저장(draft) 있음", "아직 시작하지 않은 장 (draft 없음)")에 longImageUrl 반영

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- storybookId=5, chapterOrder=1로 GET /api/v1/storybooks/5/chapters/1 호출
응답의 longImageUrl: "https://example.com/chapter1.png" 확인
DB(chapter 테이블, chapter_id=41)의 long_image_url 컬럼 값과 일치 확인
<img width="869" height="1061" alt="스크린샷 2026-08-04 오후 8 17 57" src="https://github.com/user-attachments/assets/b7513f0a-a648-4eab-825d-b9d1228bc324" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #155
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- longImageUrl은 Chapter 엔티티에 이미 존재하는 컬럼으로, ERD/마이그레이션 변경 없이 응답 DTO에만 노출 추가함
- #149/#150에서 상세조회 응답에서 제거된 것과 짝을 이루는 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * “오늘의 장 조회” API 응답에 스토리북의 긴 이미지 URL 정보가 추가되었습니다.
  * 드래프트 유무와 관계없이 성공 응답에서 해당 이미지 URL을 확인할 수 있습니다.

* **문서**
  * Swagger API 응답 예제에 긴 이미지 URL 필드가 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->