### PR TITLE
[fix] 토큰 유효성 검증 시 refresh token이 아닌지도 확인하도록 수정

### DIFF
--- a/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String token = header.substring(7); // "Bearer " 제거
 
         // 유효한 토큰이면 인증 객체를 만들어 SecurityContext에 저장
-        if (jwtUtil.isValid(token)) {
+        if (jwtUtil.isValid(token) && !jwtUtil.isRefreshToken(token)) {
             Long memberId = jwtUtil.getMemberId(token);
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
@@ -41,7 +41,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             Long memberId = jwtUtil.getMemberId(token);
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(
-                            memberId,               // principal = memberId (현재는 memberId만 사용 (MemberRepository 생기면 회원 조회로 수정 예정)
+                            memberId,
                             null,
                             Collections.emptyList() // 권한 목록 (role 구분 없어 현재 비움)
                     );


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 토큰 유효성 검증 시 refresh token이 아닌지도 확인하도록 수정
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `JwtAuthFilter`: `doFilterInternal`에서 토큰 유효성 검증 시 refresh token이 아닌지도 확인
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- refresh token 사용
<img width="1039" height="1206" alt="image" src="https://github.com/user-attachments/assets/902cecce-04e1-40e5-aa03-0a7f27105f15" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #162
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* JWT 토큰 인증 처리 개선 - Refresh 토큰은 더 이상 인증 객체를 생성하지 않으며, Access 토큰만 인증으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->