### PR TITLE
[feat] 약관 동의 여부 조회에 약관별 동의 내역 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
@@ -152,9 +152,9 @@ public interface TermControllerDocs {
             description = """
                     # 약관 동의 여부 조회
 
-                    필수 약관 전체 동의 여부를 조회합니다.
-                    앱 실행 시 약관 동의 화면 노출 여부 판단에 사용합니다.
-                    필수 약관 중 하나라도 동의하지 않았으면 false를 반환합니다.
+                    필수 약관 전체 동의 여부(termsAgreed)와 약관별 동의 내역(agreements)을 조회합니다.
+                    앱 실행 시 약관 동의 화면 노출 여부 판단, 뒤로가기 시 선택 약관 체크 상태 복원에 사용합니다.
+                    필수 약관 중 하나라도 동의하지 않았으면 termsAgreed는 false를 반환합니다.
 
                     ## 요청 형식
                     - **Header**
@@ -164,6 +164,8 @@ public interface TermControllerDocs {
                     1. 인증된 회원을 조회합니다. 존재하지 않으면 404(MEMBER404_1)를 반환합니다.
                     2. 필수 약관 전체 개수와 회원이 동의한 필수 약관 개수를 비교합니다.
                     3. 두 개수가 같으면 termsAgreed를 true로, 다르면 false로 반환합니다.
+                    4. agreements는 현재 등록된 전체 약관을 약관 ID 오름차순으로 반환합니다.
+                    5. 동의 이력이 없는 약관은 isAgreed를 false로 반환합니다.                
                     """
     )
     @ApiResponses(value = {

--- a/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/term/controller/docs/TermControllerDocs.java
@@ -177,7 +177,15 @@ public interface TermControllerDocs {
                                       "isSuccess": true,
                                       "code": "TERMS200_3",
                                       "message": "약관 동의 여부 조회 성공",
-                                      "result": { "termsAgreed": true }
+                                      "result": {
+                                              "termsAgreed": true,
+                                              "agreements": [
+                                                { "termId": 1, "isAgreed": true },
+                                                { "termId": 2, "isAgreed": true },
+                                                { "termId": 3, "isAgreed": true },
+                                                { "termId": 4, "isAgreed": false }
+                                              ]
+                                      }
                                     }
                                     """)
                     )

--- a/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/umc/halo/domain/term/converter/TermConverter.java
@@ -5,6 +5,8 @@ import com.umc.halo.domain.term.entity.MemberTerm;
 import com.umc.halo.domain.term.entity.Term;
 import com.umc.halo.domain.member.entity.Member;
 
+import java.util.List;
+
 public class TermConverter {
 
     public static TermResDTO.Info toInfo(Term term) {
@@ -18,9 +20,10 @@ public class TermConverter {
                 .build();
     }
 
-    public static TermResDTO.AgreementStatus toAgreementStatus(boolean termsAgreed) {
+    public static TermResDTO.AgreementStatus toAgreementStatus(boolean termsAgreed, List<TermResDTO.AgreementInfo> agreements) {
         return TermResDTO.AgreementStatus.builder()
                 .termsAgreed(termsAgreed)
+                .agreements(agreements)
                 .build();
     }
 

--- a/src/main/java/com/umc/halo/domain/term/dto/TermResDTO.java
+++ b/src/main/java/com/umc/halo/domain/term/dto/TermResDTO.java
@@ -2,6 +2,7 @@ package com.umc.halo.domain.term.dto;
 
 import lombok.Builder;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class TermResDTO {
 
@@ -17,6 +18,13 @@ public class TermResDTO {
 
     @Builder
     public record AgreementStatus(
-            Boolean termsAgreed
+            Boolean termsAgreed,
+            List<AgreementInfo> agreements
+    ) {}
+
+    @Builder
+    public record AgreementInfo(
+            Long termId,
+            Boolean isAgreed
     ) {}
 }

--- a/src/main/java/com/umc/halo/domain/term/service/TermService.java
+++ b/src/main/java/com/umc/halo/domain/term/service/TermService.java
@@ -108,16 +108,26 @@ public class TermService {
             }
         }
     }
-
+    
     @Transactional(readOnly = true)
     public TermResDTO.AgreementStatus getAgreementStatus(Long memberId) {
-
-        if (!memberRepository.existsById(memberId)) {
-            throw new MemberException(MemberErrorCode.NOT_FOUND);
-        }
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
         boolean termsAgreed = memberTermRepository.areAllRequiredTermsAgreed(memberId);
 
-        return TermConverter.toAgreementStatus(termsAgreed);
+        Set<Long> agreedTermIds = memberTermRepository.findAllByMember(member).stream()
+                .filter(mt -> Boolean.TRUE.equals(mt.getIsAgreed()))
+                .map(mt -> mt.getTerm().getId())
+                .collect(Collectors.toSet());
+
+        List<TermResDTO.AgreementInfo> agreements = termRepository.findAllByOrderByIdAsc().stream()
+                .map(term -> TermResDTO.AgreementInfo.builder()
+                        .termId(term.getId())
+                        .isAgreed(agreedTermIds.contains(term.getId()))
+                        .build())
+                .toList();
+
+        return TermConverter.toAgreementStatus(termsAgreed, agreements);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 약관 동의 여부 조회(GET /api/v1/terms/agreements) 응답에 약관별 동의 내역(agreements) 추가
- 온보딩에서 뒤로 돌아왔을 때 선택 약관(마케팅 등) 체크 상태를 복원하기 위함

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `TermResDTO.AgreementStatus`에 agreements 추가, `AgreementInfo` record 추가
- `TermConverter.toAgreementStatus`에 목록 파라미터 반영
- `TermService.getAgreementStatus`에서 약관별 동의 내역 조립
- `TermControllerDocs` 동의 여부 조회 Swagger Example 갱신
- termsAgreed(필수 전체 동의 여부)는 유지, agreements를 추가 (기존 화면 분기 로직 영향 없음)
- 전체 약관 기준으로 내려주며, 동의 이력 없는 약관은 isAgreed=false로 반환
- 기존 Repository 메서드(findAllByMember, findAllByOrderByIdAsc) 재사용 → 타 도메인·ERD 변경 없음
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="1289" height="490" alt="스크린샷 2026-08-05 오전 9 00 53" src="https://github.com/user-attachments/assets/15ec2c6a-d0de-4bf3-a878-f04b0f01602b" />
<img width="1285" height="484" alt="스크린샷 2026-08-05 오전 9 01 20" src="https://github.com/user-attachments/assets/e5b07b8e-8838-4954-a6de-2499ee4f0beb" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #164 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- API 명세서: 약관 동의 여부 조회


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 약관 동의 여부 조회 API가 전체 동의 여부뿐 아니라 약관별 동의 상태도 함께 제공합니다.
  * 각 약관의 ID와 동의 여부를 확인할 수 있도록 응답 정보가 확장되었습니다.
  * 존재하지 않는 회원 조회 시 기존 예외 처리는 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->