### PR TITLE
[FEAT] 테마함 감상 장 목록 응답에 스토리북 제목 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/exhibition/converter/ExhibitionConverter.java
+++ b/src/main/java/com/umc/halo/domain/exhibition/converter/ExhibitionConverter.java
@@ -71,8 +71,8 @@ public class ExhibitionConverter {
 
 
     public static ExhibitionChapterResDTO.ChaptersInfo toChaptersInfo(
-            Long storybookId, List<ExhibitionChapterResDTO.ChapterInfo> chapters) {
-        return new ExhibitionChapterResDTO.ChaptersInfo(storybookId, chapters);
+            Long storybookId, String title, List<ExhibitionChapterResDTO.ChapterInfo> chapters) {
+        return new ExhibitionChapterResDTO.ChaptersInfo(storybookId, title, chapters);
     }
 
     public static ExhibitionChapterResDTO.ChapterInfo toChapterInfo(

--- a/src/main/java/com/umc/halo/domain/exhibition/dto/ExhibitionChapterResDTO.java
+++ b/src/main/java/com/umc/halo/domain/exhibition/dto/ExhibitionChapterResDTO.java
@@ -9,6 +9,7 @@ public class ExhibitionChapterResDTO {
 
     public record ChaptersInfo(
             Long storybookId,
+            String title,
             List<ChapterInfo> chapters
     ) {}
 

--- a/src/main/java/com/umc/halo/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/umc/halo/domain/exhibition/service/ExhibitionService.java
@@ -141,10 +141,11 @@ public class ExhibitionService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
-        memberStorybookRepository.findAllByMemberWithStorybook(member).stream()
+        MemberStorybook memberStorybook = memberStorybookRepository.findAllByMemberWithStorybook(member).stream()
                 .filter(ms -> ms.getStorybook().getId().equals(storybookId))
                 .findFirst()
                 .orElseThrow(() -> new ExhibitionException(ExhibitionErrorCode.NOT_FOUND));
+        String title = memberStorybook.getStorybook().getTitle();
 
 
         List<Chapter> chapters = chapterRepository
@@ -171,7 +172,7 @@ public class ExhibitionService {
                 })
                 .toList();
 
-        return ExhibitionConverter.toChaptersInfo(storybookId, chapterInfos);
+        return ExhibitionConverter.toChaptersInfo(storybookId, title, chapterInfos);
     }
 
     private String resolveChapterImageUrl(MemberChapter mc) {


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 감상 모드 화면 상단에 표시할 스토리북(테마) 제목을 응답에 추가했습니다.
- 감상 장 목록 조회(`GET /api/v1/exhibitions/{storybookId}/chapters`) 응답의 `result` 최상위에 `title` 필드 추가.
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `ExhibitionChapterResDTO.ChaptersInfo` — `title` 필드 추가
- `ExhibitionConverter.toChaptersInfo` — 파라미터에 `title` 추가
- `ExhibitionService.getChapters` — 접근 권한 검증 시 이미 조회하는 `memberStorybook`에서 제목을 꺼내 전달
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="1298" height="451" alt="스크린샷 2026-08-05 오전 10 06 00" src="https://github.com/user-attachments/assets/ae991322-7b3f-4cb9-9592-6a4ae209da1b" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #170 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
- 응답 예시:
```json
  "result": {
    "storybookId": 101,
    "title": "오래 전 당신",
    "chapters": [ ... ]
  }
```
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 전시 장 목록 조회 응답에 스토리북 제목이 함께 표시됩니다.
  * 장 목록과 해당 스토리북 정보를 더욱 쉽게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->