### PR TITLE
[fix] 닉네임 중복 확인 시 본인 닉네임 제외

### DIFF
--- a/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
@@ -25,10 +25,11 @@ public class OnboardingController implements OnboardingControllerDocs {
     // 닉네임 중복 확인
     @GetMapping("/nickname/check")
     public ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
+            @AuthenticationPrincipal Long memberId,
             @RequestParam String nickname
     ) {
         BaseSuccessCode code = OnboardingSuccessCode.NICKNAME_AVAILABLE;
-        return ApiResponse.onSuccess(code, onboardingService.checkNickname(nickname));
+        return ApiResponse.onSuccess(code, onboardingService.checkNickname(memberId, nickname));
     }
 
     // 온보딩 정보 저장

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -80,6 +80,7 @@ public interface OnboardingControllerDocs {
             )
     })
     ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
+            Long memberId,
             @Parameter(description = "확인할 닉네임", example = "정민") String nickname
     );
 

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -80,7 +80,7 @@ public interface OnboardingControllerDocs {
             )
     })
     ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
-            Long memberId,
+            @Parameter(hidden = true) Long memberId,
             @Parameter(description = "확인할 닉네임", example = "정민") String nickname
     );
 

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -43,9 +43,15 @@ public class OnboardingService {
 
     // 닉네임 중복 확인
     @Transactional(readOnly = true)
-    public OnboardingResDTO.NicknameCheck checkNickname(String nickname) {
+    public OnboardingResDTO.NicknameCheck checkNickname(Long memberId, String nickname) {
 
         validateNicknameFormat(nickname);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD));
+
+        if (nickname.equals(member.getName())) {
+            return OnboardingConverter.toNicknameCheck(true);
+        }
         // 중복 조회
         boolean available = !memberRepository.existsByName(nickname);
         return OnboardingConverter.toNicknameCheck(available);


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 닉네임 중복 확인 API에서 로그인한 회원 본인의 닉네임을 중복으로 판단하던 문제 수정
- 온보딩 step1 저장 후 뒤로가기로 이름 화면에 돌아와 같은 이름으로 다음을 누르면 본인 닉네임인데도 isAvailable=false가 반환되어 진행이 막히는 상황
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.

- OnboardingService.checkNickname: memberId를 받아 본인이 이미 사용 중인 닉네임이면 사용 가능으로 처리
- OnboardingController: @AuthenticationPrincipal memberId 추가
- OnboardingControllerDocs: 메서드 시그니처 동기화
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="1413" height="698" alt="스크린샷 2026-08-05 오후 9 27 01" src="https://github.com/user-attachments/assets/4fc87746-fbaf-4c87-b0aa-13869d9bc143" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #175 
 
---

## 📌 참고 사항


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 닉네임 중복 확인 시 현재 로그인한 회원 정보를 반영하도록 개선했습니다.
  * 기존 닉네임과 동일한 경우 사용 가능한 닉네임으로 처리됩니다.
  * 존재하지 않는 회원의 닉네임 확인 요청은 예외 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->