### PR TITLE
[feat] 공용기념일(CommonAnniversary) 알림 기본값 조정 및 기본 메모 문구 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -30,7 +30,7 @@ public interface AnniversaryControllerDocs {
                     ## 동작 방식
                     1. 로그인한 회원이 등록한 기념일 목록을 조회합니다.
                     2. 반복 여부(isRepeated)를 기준으로 다가오는 기념일의 D-day를 계산합니다.
-                    3. 음력 기반 기념일(개인 기념일 및 추석, 설날 등 기본 기념일)은 KASI(한국천문연구원) 표준 기반 음력-양력 변환 라이브러리로 실제 양력 날짜를 계산하여 D-day에 반영합니다.
+                    3. 음력 기반 기념일(사용자가 음력으로 등록한 개인 기념일)은 KASI(한국천문연구원) 표준 기반 음력-양력 변환 라이브러리로 실제 양력 날짜를 계산하여 D-day에 반영합니다.
                     4. 다가오는 기념일(upcomingAnniversaries), 내가 추가한 기념일(myAnniversaries), 기본 기념일(commonAnniversaries) 세 목록을 함께 반환합니다.
                     """)
     @ApiResponses(value = {

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -35,6 +35,33 @@ public interface AnniversaryControllerDocs {
                     """)
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "기념일 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples = @ExampleObject(value = """
+                        {
+                          "isSuccess": true,
+                          "code": "ANNIVERSARY200_1",
+                          "message": "기념일 목록 조회에 성공했습니다.",
+                          "result": {
+                            "upcomingAnniversaries": [
+                              { "anniversaryId": 1, "title": "아버지 생신", "anniversaryDate": "2026-09-12", "dDay": 38 },
+                              { "anniversaryId": null, "title": "어버이날", "anniversaryDate": "2027-05-08", "dDay": 276 }
+                            ],
+                            "myAnniversaries": [
+                              { "anniversaryId": 1, "title": "아버지 생신", "anniversaryDate": "2026-09-12", "isLunar": false, "isRepeated": true, "sevenDaysAlarmEnabled": true, "dayAlarmEnabled": true, "memo": "아버지 생신! 열심히 준비해야겠다!" }
+                            ],
+                            "commonAnniversaries": [
+                              { "commonAnniversaryId": 1, "title": "어버이날", "month": 5, "day": 8, "isLunar": false, "sevenDaysAlarmEnabled": false, "dayAlarmEnabled": true, "memo": "늘 곁을 지켜준 부모님께 감사한 마음을 전해보세요." }
+                            ]
+                          }
+                        }
+                        """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "401",
                     description = "accessToken 만료·유효하지 않음",
                     content = @Content(

--- a/src/main/java/com/umc/halo/domain/notification/converter/AnniversaryConverter.java
+++ b/src/main/java/com/umc/halo/domain/notification/converter/AnniversaryConverter.java
@@ -68,6 +68,7 @@ public class AnniversaryConverter {
                 .isLunar(commonAnniversary.getIsLunar())
                 .sevenDaysAlarmEnabled(commonAnniversary.getSevenDaysAlarmEnabled())
                 .dayAlarmEnabled(commonAnniversary.getDayAlarmEnabled())
+                .memo(commonAnniversary.getMemo())
                 .build();
     }
 

--- a/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryResDTO.java
+++ b/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryResDTO.java
@@ -46,7 +46,8 @@ public class AnniversaryResDTO {
             Integer day,
             Boolean isLunar,
             Boolean sevenDaysAlarmEnabled,
-            Boolean dayAlarmEnabled
+            Boolean dayAlarmEnabled,
+            String memo
     ) {}
 
     @Builder

--- a/src/main/java/com/umc/halo/domain/notification/entity/CommonAnniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/CommonAnniversary.java
@@ -32,9 +32,12 @@ public class CommonAnniversary extends BaseEntity {
 
     @Column(name = "seven_days_alarm_enabled", nullable = false)
     @Builder.Default
-    private Boolean sevenDaysAlarmEnabled = true;
+    private Boolean sevenDaysAlarmEnabled = false;
 
     @Column(name = "day_alarm_enabled", nullable = false)
     @Builder.Default
     private Boolean dayAlarmEnabled = true;
+
+    @Column(length = 255)
+    private String memo;
 }

--- a/src/main/java/com/umc/halo/global/seed/NotificationSeeder.java
+++ b/src/main/java/com/umc/halo/global/seed/NotificationSeeder.java
@@ -27,22 +27,46 @@ public class NotificationSeeder {
     public List<CommonAnniversary> seedCommonAnniversary() {
         List<CommonAnniversary> commonAnniversaries = List.of(
                 CommonAnniversary.builder()
+                        .title("아버지의 날")
+                        .month(3)
+                        .day(19)
+                        .isLunar(false)
+                        .memo("오늘은 아버지께 평소 전하지 못했던 마음을 건네보세요.")
+                        .build(),
+                CommonAnniversary.builder()
                         .title("어버이날")
                         .month(5)
                         .day(8)
                         .isLunar(false)
+                        .memo("늘 곁을 지켜준 부모님께 감사한 마음을 전해보세요.")
                         .build(),
                 CommonAnniversary.builder()
-                        .title("추석")
-                        .month(8)
-                        .day(15)
-                        .isLunar(true)
-                        .build(),
-                CommonAnniversary.builder()
-                        .title("설날")
-                        .month(1)
+                        .title("세계 부모의 날")
+                        .month(6)
                         .day(1)
-                        .isLunar(true)
+                        .isLunar(false)
+                        .memo("부모님의 사랑과 헌신을 다시 한번 떠올려보는 날이에요.")
+                        .build(),
+                CommonAnniversary.builder()
+                        .title("세계 사진의 날")
+                        .month(8)
+                        .day(19)
+                        .isLunar(false)
+                        .memo("부모님과 함께한 소중한 순간을 오늘 한 장 남겨보세요.")
+                        .build(),
+                CommonAnniversary.builder()
+                        .title("세계 돌봄과 지원의 날")
+                        .month(10)
+                        .day(29)
+                        .isLunar(false)
+                        .memo("서로를 아끼고 돌봐온 마음을 따뜻하게 나눠보세요.")
+                        .build(),
+                CommonAnniversary.builder()
+                        .title("어머니의 날")
+                        .month(12)
+                        .day(22)
+                        .isLunar(false)
+                        .memo("오늘은 어머니께 따뜻한 마음 한마디를 전해보세요.")
                         .build()
         );
 

--- a/src/main/resources/db/migration/V28__add_memo_to_common_anniversary.sql
+++ b/src/main/resources/db/migration/V28__add_memo_to_common_anniversary.sql
@@ -1,0 +1,5 @@
+ALTER TABLE common_anniversary
+    ADD COLUMN memo VARCHAR(255) NULL;
+
+UPDATE common_anniversary
+SET seven_days_alarm_enabled = false;


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 공용기념일(CommonAnniversary)의 알림 기본값을 조정하고, 기본 메모 문구를 넣을 수 있도록 memo 컬럼을 추가했습니다.

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `CommonAnniversary.java`: `memo` 컬럼 추가, `sevenDaysAlarmEnabled` 기본값 true → false 변경 (dayAlarmEnabled는 true 유지)
- `V28__add_memo_to_common_anniversary.sql`: memo 컬럼 추가 마이그레이션 + 기존 데이터 seven_days_alarm_enabled 백필
- `AnniversaryResDTO.CommonAnniversaryInfo`: `memo` 필드 추가
- `AnniversaryConverter.toCommonAnniversaryInfo()`: `memo` 매핑 추가
- `NotificationSeeder.seedCommonAnniversary()`: 신규 공용기념일 6종(추석/설날 제외)으로 시드 데이터 교체, 문구 반영
- `AnniversaryControllerDocs.java`: 기념일 목록 조회 200 성공 예시 추가

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- `/api/v1/anniversary` 응답에서 commonAnniversaries 6종 모두 memo 정상 반환, sevenDaysAlarmEnabled=false / dayAlarmEnabled=true 확인 완료
<img width="868" height="1061" alt="스크린샷 2026-08-05 오후 9 24 31" src="https://github.com/user-attachments/assets/dcb89c6d-ba55-4017-bb7d-cc44936f5d0f" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [x] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #174
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 신규 공용기념일 6종 데이터는 로컬 시더에만 반영했고, dev/prod DB 실 데이터 반영은 별도로 진행 예정입니다.
- ERD도 memo 컬럼 및 seven_days_alarm_enabled 기본값 반영해서 수정 완료했습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 공통 기념일에 메모를 등록하고 조회할 수 있습니다.
  * 기념일 목록에서 메모와 상세 정보를 함께 확인할 수 있습니다.
  * 아버지의 날, 세계 부모의 날 등 새로운 공통 기념일이 추가되었습니다.

* **변경 사항**
  * 공통 기념일의 7일 전 알림 기본 설정이 꺼짐으로 변경되었습니다.
  * 기존 기념일의 설명과 제공 목록이 최신 기준으로 업데이트되었습니다.

* **문서**
  * 기념일 목록 조회 API의 성공 응답 예시가 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->