### PR TITLE
[refactor] lastChapterOrder+1 계산 로직을 MemberStorybook으로 공통화

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
@@ -279,7 +279,7 @@ public class StorybookService {
 
             for (Storybook sb : activeStorybooks) {
                 MemberStorybook memberStorybook = memberStorybookMap.get(sb.getId());
-                Integer chapterOrder = resolveDisplayChapterOrder(memberStorybook, memberChaptersMap.get(sb.getId()));
+                Integer chapterOrder = memberStorybook.resolveDisplayChapterOrder(memberChaptersMap.get(sb.getId()));
                 boolean todayAvailable = statusMap.get(sb) == StorybookStatus.IN_PROGRESS;
                 inProgressStorybooks.add(StorybookConverter.toInProgressStorybook(sb, chapterOrder, todayAvailable));
             }
@@ -321,7 +321,7 @@ public class StorybookService {
             status = StorybookStatus.IN_PROGRESS;
         }
 
-        Integer displayChapterOrder = resolveDisplayChapterOrder(memberStorybook, memberChapters);
+        Integer displayChapterOrder = memberStorybook.resolveDisplayChapterOrder(memberChapters);
         return StorybookConverter.toStorybookSummary(storybook, status, memberStorybook, displayChapterOrder);
     }
 
@@ -364,13 +364,5 @@ public class StorybookService {
                     return StorybookConverter.toSituationalRecommendation(tag.getTitle(), situationalStorybooks);
                 })
                 .toList();
-    }
-
-    private Integer resolveDisplayChapterOrder(MemberStorybook memberStorybook, List<MemberChapter> memberChapters) {
-        Integer lastChapterOrder = memberStorybook.getLastChapterOrder();
-        boolean lastCompleted = memberChapters.stream()
-                .anyMatch(mc -> lastChapterOrder.equals(mc.getChapter().getChapterOrder())
-                        && mc.getStatus() == Status.COMPLETED);
-        return (lastCompleted && lastChapterOrder < 10) ? lastChapterOrder + 1 : lastChapterOrder;
     }
 }

--- a/src/main/java/com/umc/halo/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/umc/halo/domain/exhibition/service/ExhibitionService.java
@@ -122,7 +122,7 @@ public class ExhibitionService {
                 List<MemberChapter> myChapters =
                         chaptersByStorybook.getOrDefault(ms.getStorybook().getId(), List.of());
                 inProgressDtos.add(ExhibitionConverter.toInProgressStorybook(
-                        ms, resolveNextChapterOrder(ms, myChapters)));
+                        ms, ms.resolveDisplayChapterOrder(myChapters)));
             }
         } else {
             recommendedDtos = storybookService.getRecommendedStorybooks(memberId).storybooks().stream()
@@ -181,15 +181,5 @@ public class ExhibitionService {
         }
         SceneCard sceneCard = mc.getSceneCard();
         return sceneCard == null ? null : sceneCard.getImageUrl();
-    }
-
-    private Integer resolveNextChapterOrder(MemberStorybook ms, List<MemberChapter> myChapters) {
-        Integer lastChapterOrder = ms.getLastChapterOrder();
-
-        boolean lastCompleted = myChapters.stream()
-                .anyMatch(mc -> lastChapterOrder.equals(mc.getChapter().getChapterOrder())
-                        && mc.getStatus() == Status.COMPLETED);
-
-        return lastCompleted ? lastChapterOrder + 1 : lastChapterOrder;
     }
 }

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
@@ -7,6 +7,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.*;
+import java.util.*;
+import com.umc.halo.domain.record.enums.*;
 
 @Entity
 @Table(
@@ -52,5 +54,12 @@ public class MemberStorybook extends BaseEntity {
 
     public boolean isCompletedToday() {
         return lastCompletedDate != null && lastCompletedDate.isEqual(LocalDate.now());
+    }
+
+    public Integer resolveDisplayChapterOrder(List<MemberChapter> memberChapters) {
+        boolean lastCompleted = memberChapters.stream()
+                .anyMatch(mc -> lastChapterOrder.equals(mc.getChapter().getChapterOrder())
+                        && mc.getStatus() == Status.COMPLETED);
+        return (lastCompleted && lastChapterOrder < 10) ? lastChapterOrder + 1 : lastChapterOrder;
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- ExhibitionService와 StorybookService에 중복 구현되어 있던 "다음 표시 장 순서(lastChapterOrder+1)" 계산 로직을 MemberStorybook 엔티티 메서드로 공통화했습니다.

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `MemberStorybook.java`: `resolveDisplayChapterOrder(List<MemberChapter>)` 메서드 추가
- `StorybookService.java`: 중복 private 메서드 `resolveDisplayChapterOrder` 제거, 호출부를 `memberStorybook.resolveDisplayChapterOrder(...)`로 교체
- `ExhibitionService.java`: 중복 private 메서드 `resolveNextChapterOrder` 제거, 호출부를 `ms.resolveDisplayChapterOrder(...)`로 교체

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 완료 임박(9/10장) 계정으로 홈 화면 조회, 스토리북 목록 조회, 테마함(전시) 조회 3개 API 모두 currentChapterOrder/lastChapterOrder/nextChapterOrder가 리팩토링 전과 동일하게 10으로 정상 계산됨을 확인
<img width="824" height="1017" alt="image" src="https://github.com/user-attachments/assets/45fe5a6f-1abc-45fc-9659-e57ab9ca92e8" />
<img width="868" height="1061" alt="image" src="https://github.com/user-attachments/assets/0a06ad3e-735f-4681-a891-b14c471882e5" />
<img width="868" height="1061" alt="image" src="https://github.com/user-attachments/assets/5baac4a4-ecbd-4a26-8c40-c7e29d481aaa" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #178
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 순수 리팩토링으로 API 응답 스펙 변경 없음
- 기존 ExhibitionService 쪽엔 lastChapterOrder < 10 상한 체크가 빠져있었는데, 공통화하면서 StorybookService 로직(상한 체크 포함)으로 통일되어 잠재 버그도 함께 수정됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 홈 화면, 스토리북 목록 요약, 전시 화면에서 다음에 표시되는 챕터 순서가 일관되게 계산됩니다.
  * 완료한 챕터와 진행 상황을 기준으로 적절한 표시 챕터가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->