### PR TITLE
[feat] 오늘의 장 조회 API 응답에 장 제목, 장 순서, 장 소개글 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
@@ -55,7 +55,10 @@ public interface ChapterControllerDocs {
                                                               "result": {
                                                                 "chapterId": 1,
                                                                 "storybookTitle": "오래 전 당신",
+                                                                "chapterTitle": "나와 같은 나이였던 시절",
+                                                                "chapterOrder": 1,
                                                                 "longImageUrl": "https://example.com/long-image.png",
+                                                                "description": "부모님을 한 사람으로 바라보는 첫 장입니다. 지금의 내 나이였을 때 부모님은 어떤 하루를 살고 있었는지 돌아봅니다.",
                                                                 "guide": "부모님이 지금 내 나이였을 땐 어떤 하루를 보냈을까요? 사진 한 장을 보며 가볍게 물어봐요.",
                                                                 "character": {
                                                                   "writingCharacterImageUrl": "https://example.com/character-writing.png",
@@ -98,7 +101,10 @@ public interface ChapterControllerDocs {
                                                               "result": {
                                                                 "chapterId": 1,
                                                                 "storybookTitle": "오래 전 당신",
+                                                                "chapterTitle": "나와 같은 나이였던 시절",
+                                                                "chapterOrder": 1,
                                                                 "longImageUrl": "https://example.com/long-image.png",
+                                                                "description": "부모님을 한 사람으로 바라보는 첫 장입니다. 지금의 내 나이였을 때 부모님은 어떤 하루를 살고 있었는지 돌아봅니다.",
                                                                 "guide": "부모님이 지금 내 나이였을 땐 어떤 하루를 보냈을까요? 사진 한 장을 보며 가볍게 물어봐요.",
                                                                 "character": {
                                                                   "writingCharacterImageUrl": "https://example.com/character-writing.png",

--- a/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/controller/docs/ChapterControllerDocs.java
@@ -53,8 +53,8 @@ public interface ChapterControllerDocs {
                                                               "code": "CHAPTER200_1",
                                                               "message": "오늘의 장을 성공적으로 조회했습니다.",
                                                               "result": {
-                                                                "chapterId": 1,
                                                                 "storybookTitle": "오래 전 당신",
+                                                                "chapterId": 1,
                                                                 "chapterTitle": "나와 같은 나이였던 시절",
                                                                 "chapterOrder": 1,
                                                                 "longImageUrl": "https://example.com/long-image.png",
@@ -99,8 +99,8 @@ public interface ChapterControllerDocs {
                                                               "code": "CHAPTER200_1",
                                                               "message": "오늘의 장을 성공적으로 조회했습니다.",
                                                               "result": {
-                                                                "chapterId": 1,
                                                                 "storybookTitle": "오래 전 당신",
+                                                                "chapterId": 1,
                                                                 "chapterTitle": "나와 같은 나이였던 시절",
                                                                 "chapterOrder": 1,
                                                                 "longImageUrl": "https://example.com/long-image.png",

--- a/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/converter/ChapterConverter.java
@@ -20,9 +20,12 @@ public class ChapterConverter {
             String imageUrl) {
 
         return ChapterResDTO.TodayChapter.builder()
-                .chapterId(chapter.getId())
                 .storybookTitle(chapter.getStorybook().getTitle())
+                .chapterId(chapter.getId())
+                .chapterTitle(chapter.getTitle())
+                .chapterOrder(chapter.getChapterOrder())
                 .longImageUrl(chapter.getLongImageUrl())
+                .description(chapter.getDescription())
                 .guide(chapter.getGuide())
 
                 .character(

--- a/src/main/java/com/umc/halo/domain/content/chapter/dto/ChapterResDTO.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/dto/ChapterResDTO.java
@@ -11,9 +11,12 @@ public class ChapterResDTO {
     // 오늘의 장 조회
     @Builder
     public record TodayChapter(
-            Long chapterId,
             String storybookTitle,
+            Long chapterId,
+            String chapterTitle,
+            Integer chapterOrder,
             String longImageUrl,
+            String description,
             String guide,
             Character character,
             List<Question> questions,


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 오늘의 장 조회 API 응답에 장 제목, 장 순서, 장 소개글 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `ChapterResDTO.TodayChapter`: `chapterTitle`, `chapterOrder`, `description` 필드 추가

- `ChapterConverter.toTodayChapter()`: `chapter.getTitle()`, `chapter.getChapterOrder()`, `chapter.getDescription()` 매핑

- `ChapterControllerDocs`: 오늘의 장 조회 Swagger 예시 응답 업데이트
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 오늘의 장 조회
<img width="1079" height="1606" alt="image" src="https://github.com/user-attachments/assets/26f2c00c-d47d-4951-b5c6-54be913cd360" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #180
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 오늘의 장 조회 API 응답에 장 제목, 장 순서, 장 설명 정보가 추가되었습니다.
  - 응답 정보의 표시 순서가 정리되어 장과 스토리북 정보를 더욱 일관되게 확인할 수 있습니다.
  - 기존 응답 기능은 유지되며, 새로운 필드를 활용하는 클라이언트에서 상세한 장 정보를 표시할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->