### PR TITLE
[feat] 관계 정보 조회 응답에 태그 description 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/relationship/controller/docs/RelationshipControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/relationship/controller/docs/RelationshipControllerDocs.java
@@ -45,13 +45,13 @@ public interface RelationshipControllerDocs {
                                       "message": "관계 정보 조회 성공",
                                       "result": {
                                         "parentPersonalityTags": [
-                                          { "tagId": 12, "title": "다정하게 표현하는 편" },
-                                          { "tagId": 15, "title": "걱정이 많은 편" }
+                                          { "tagId": 12, "title": "다정하게 표현하는 편", "description": null },
+                                          { "tagId": 15, "title": "걱정이 많은 편", "description": null }
                                         ],
-                                        "currentRelationState": { "tagId": 23, "title": "안부는 하지만 조금 어색한 편" },
+                                        "currentRelationState": { "tagId": 23, "title": "안부는 하지만 조금 어색한 편", "description": "일상적인 안부를 나누며 서로를 존중해요" },
                                         "goalRelationships": [
-                                          { "tagId": 31, "title": "어색하지 않게 이야기하고 싶어요" },
-                                          { "tagId": 33, "title": "부모님을 더 알고 싶어요" }
+                                          { "tagId": 31, "title": "어색하지 않게 이야기하고 싶어요", "description": null },
+                                          { "tagId": 33, "title": "부모님을 더 알고 싶어요", "description": null }
                                         ]
                                       }
                                     }

--- a/src/main/java/com/umc/halo/domain/relationship/converter/RelationshipConverter.java
+++ b/src/main/java/com/umc/halo/domain/relationship/converter/RelationshipConverter.java
@@ -10,6 +10,7 @@ public class RelationshipConverter {
         return RelationshipResDTO.TagInfo.builder()
                 .tagId(tag.getId())
                 .title(tag.getTitle())
+                .description(tag.getDescription())
                 .build();
     }
     public static RelationshipResDTO.Info toInfo(

--- a/src/main/java/com/umc/halo/domain/relationship/dto/RelationshipResDTO.java
+++ b/src/main/java/com/umc/halo/domain/relationship/dto/RelationshipResDTO.java
@@ -15,6 +15,7 @@ public class RelationshipResDTO {
     @Builder
     public record TagInfo(
             Long tagId,
-            String title
+            String title,
+            String description
     ) {}
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 마이페이지 관계 정보 화면에서 현재 관계 카드에 태그 설명을 표시하기 위해, 관계 정보 조회 응답 태그 객체에 description 필드 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `RelationshipResDTO.TagInfo`에 description 필드 추가
- `RelationshipConverter.toTagInfo`에서 tag.getDescription() 매핑
- Swagger 200 예시 갱신
- 세 필드(parentPersonalityTags[] / currentRelationState / goalRelationships[]) 모두 { tagId, title, description }로 통일
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="1222" height="463" alt="스크린샷 2026-08-06 오전 9 21 42" src="https://github.com/user-attachments/assets/62454763-7af7-465e-b774-a6b3651467ff" />
<img width="1232" height="468" alt="스크린샷 2026-08-06 오전 9 21 51" src="https://github.com/user-attachments/assets/b89bb053-c65d-479b-9ae7-7df763c6ebeb" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #182
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- description은 CURRENT_RELATIONSHIP 태그에만 존재, 나머지 카테고리는 null


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 관계 정보 조회 API 응답에 각 관계 태그의 설명이 포함됩니다.
  * 부모 성향 및 목표 관계 태그는 설명이 없을 경우 `null`로 제공됩니다.
  * 현재 관계 상태 태그에는 상세 설명이 표시됩니다.
  * API 문서의 성공 응답 예시가 실제 응답 형식에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->