### PR TITLE
[fix] 메모 글자수 제한 50자로 변경

### DIFF
--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -20,13 +20,13 @@ public interface AnniversaryControllerDocs {
     @Operation(summary = "기념일 목록 조회 API",
             description = """
                     # 기념일 목록 조회
-
+                    
                     마이페이지 내 기념일 관리 화면에서 사용자의 기념일 정보를 조회합니다.
-
+                    
                     ## 요청 형식
                     - **Header**
                         - Authorization: Bearer {accessToken}
-
+                    
                     ## 동작 방식
                     1. 로그인한 회원이 등록한 기념일 목록을 조회합니다.
                     2. 반복 여부(isRepeated)를 기준으로 다가오는 기념일의 D-day를 계산합니다.
@@ -41,24 +41,24 @@ public interface AnniversaryControllerDocs {
                             mediaType = "application/json",
                             schema = @Schema(implementation = ApiResponse.class),
                             examples = @ExampleObject(value = """
-                        {
-                          "isSuccess": true,
-                          "code": "ANNIVERSARY200_1",
-                          "message": "기념일 목록 조회에 성공했습니다.",
-                          "result": {
-                            "upcomingAnniversaries": [
-                              { "anniversaryId": 1, "title": "아버지 생신", "anniversaryDate": "2026-09-12", "dDay": 38 },
-                              { "anniversaryId": null, "title": "어버이날", "anniversaryDate": "2027-05-08", "dDay": 276 }
-                            ],
-                            "myAnniversaries": [
-                              { "anniversaryId": 1, "title": "아버지 생신", "anniversaryDate": "2026-09-12", "isLunar": false, "isRepeated": true, "sevenDaysAlarmEnabled": true, "dayAlarmEnabled": true, "memo": "아버지 생신! 열심히 준비해야겠다!" }
-                            ],
-                            "commonAnniversaries": [
-                              { "commonAnniversaryId": 1, "title": "어버이날", "month": 5, "day": 8, "isLunar": false, "sevenDaysAlarmEnabled": false, "dayAlarmEnabled": true, "memo": "늘 곁을 지켜준 부모님께 감사한 마음을 전해보세요." }
-                            ]
-                          }
-                        }
-                        """)
+                                    {
+                                      "isSuccess": true,
+                                      "code": "ANNIVERSARY200_1",
+                                      "message": "기념일 목록 조회에 성공했습니다.",
+                                      "result": {
+                                        "upcomingAnniversaries": [
+                                          { "anniversaryId": 1, "title": "아버지 생신", "anniversaryDate": "2026-09-12", "dDay": 38 },
+                                          { "anniversaryId": null, "title": "어버이날", "anniversaryDate": "2027-05-08", "dDay": 276 }
+                                        ],
+                                        "myAnniversaries": [
+                                          { "anniversaryId": 1, "title": "아버지 생신", "anniversaryDate": "2026-09-12", "isLunar": false, "isRepeated": true, "sevenDaysAlarmEnabled": true, "dayAlarmEnabled": true, "memo": "아버지 생신! 열심히 준비해야겠다!" }
+                                        ],
+                                        "commonAnniversaries": [
+                                          { "commonAnniversaryId": 1, "title": "어버이날", "month": 5, "day": 8, "isLunar": false, "sevenDaysAlarmEnabled": false, "dayAlarmEnabled": true, "memo": "늘 곁을 지켜준 부모님께 감사한 마음을 전해보세요." }
+                                        ]
+                                      }
+                                    }
+                                    """)
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -99,9 +99,9 @@ public interface AnniversaryControllerDocs {
     @Operation(summary = "기념일 추가 API",
             description = """
                     # 기념일 추가
-
+                    
                     사용자가 새로운 기념일을 등록합니다.
-
+                    
                     ## 요청 형식
                     - **Header**
                         - Content-Type: application/json
@@ -113,11 +113,11 @@ public interface AnniversaryControllerDocs {
                         - isRepeated : 반복 여부 (필수)
                         - sevenDaysAlarmEnabled : D-7 알림 여부 (필수)
                         - dayAlarmEnabled : 당일 알림 여부 (필수)
-                        - memo : 메모 (선택, 255자 이하)
-
+                        - memo : 메모 (선택, 50자 이하)
+                    
                     ## 동작 방식
                     1. 기념일명, 날짜, 알림 설정을 필수로 입력받습니다.
-                    2. 메모는 선택 입력이며 255자 이하로 제한됩니다.
+                    2. 메모는 선택 입력이며 50자 이하로 제한됩니다.
                     3. 요청 값을 기반으로 기념일을 저장하고, 생성된 기념일의 ID를 반환합니다.
                     """)
     @ApiResponses(value = {
@@ -137,6 +137,54 @@ public interface AnniversaryControllerDocs {
                                       }
                                     }
                                     """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 값 누락 또는 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "기념일명 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "title": "기념일명은 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "기념일명 길이 초과",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "title": "기념일명은 20자 이하로 입력해주세요."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "메모 길이 초과",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "memo": "메모는 50자 이하로 입력해주세요."
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -178,9 +226,9 @@ public interface AnniversaryControllerDocs {
     @Operation(summary = "기념일 수정 API",
             description = """
                     # 기념일 수정
-
+                    
                     사용자가 등록한 기념일 정보를 수정합니다.
-
+                    
                     ## 요청 형식
                     - **Header**
                         - Content-Type: application/json
@@ -194,8 +242,8 @@ public interface AnniversaryControllerDocs {
                         - isRepeated : 반복 여부 (필수)
                         - sevenDaysAlarmEnabled : D-7 알림 여부 (필수)
                         - dayAlarmEnabled : 당일 알림 여부 (필수)
-                        - memo : 메모 (선택, 255자 이하)
-
+                        - memo : 메모 (선택, 50자 이하)
+                    
                     ## 동작 방식
                     1. 요청한 기념일이 존재하는지 확인하고, 존재하지 않으면 404 예외를 반환합니다.
                     2. 해당 기념일이 로그인한 회원 소유인지 확인하고, 본인 소유가 아니면 403 예외를 반환합니다.
@@ -218,6 +266,54 @@ public interface AnniversaryControllerDocs {
                                       }
                                     }
                                     """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 값 누락 또는 형식 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "기념일명 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "title": "기념일명은 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "기념일명 길이 초과",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "title": "기념일명은 20자 이하로 입력해주세요."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "메모 길이 초과",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "memo": "메모는 50자 이하로 입력해주세요."
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -291,16 +387,16 @@ public interface AnniversaryControllerDocs {
     @Operation(summary = "기념일 삭제 API",
             description = """
                     # 기념일 삭제
-
+                    
                     사용자가 등록한 기념일을 하나 이상 선택하여 한 번에 삭제합니다.
-
+                    
                     ## 요청 형식
                     - **Header**
                         - Content-Type: application/json
                         - Authorization: Bearer {accessToken}
                     - **Body**
                         - anniversaryIds : 삭제할 기념일 ID 목록 (필수, 예: [1, 2, 5])
-
+                    
                     ## 동작 방식
                     1. 요청한 ID 목록이 모두 존재하는지 확인하고, 하나라도 존재하지 않으면 404 예외를 반환합니다.
                     2. 요청한 ID가 모두 로그인한 회원 소유인지 확인하고, 하나라도 본인 소유가 아니면 403 예외를 반환합니다.
@@ -321,6 +417,26 @@ public interface AnniversaryControllerDocs {
                                       "result": null
                                     }
                                     """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "요청 값 누락",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "anniversaryIds 누락",
+                                    value = """
+                                            {
+                                              "isSuccess": false,
+                                              "code": "COMMON400_1",
+                                              "message": "잘못된 요청입니다.",
+                                              "result": {
+                                                "anniversaryIds": "삭제할 기념일 ID 목록은 필수입니다."
+                                              }
+                                            }
+                                            """
+                            )
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -183,6 +183,71 @@ public interface AnniversaryControllerDocs {
                                                       }
                                                     }
                                                     """
+                                    ),
+                                    @ExampleObject(
+                                            name = "날짜 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "anniversaryDate": "날짜는 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "음력 여부 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "isLunar": "음력 여부는 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "반복 여부 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "isRepeated": "반복 여부는 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "D-7 알림 여부 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "sevenDaysAlarmEnabled": "D-7 알림 여부는 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "당일 알림 여부 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "dayAlarmEnabled": "당일 알림 여부는 필수입니다."
+                                                      }
+                                                    }
+                                                    """
                                     )
                             }
                     )
@@ -309,6 +374,71 @@ public interface AnniversaryControllerDocs {
                                                       "message": "잘못된 요청입니다.",
                                                       "result": {
                                                         "memo": "메모는 50자 이하로 입력해주세요."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "날짜 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "anniversaryDate": "날짜는 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "음력 여부 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "isLunar": "음력 여부는 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "반복 여부 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "isRepeated": "반복 여부는 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "D-7 알림 여부 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "sevenDaysAlarmEnabled": "D-7 알림 여부는 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "당일 알림 여부 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "dayAlarmEnabled": "당일 알림 여부는 필수입니다."
                                                       }
                                                     }
                                                     """

--- a/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryReqDTO.java
@@ -30,9 +30,10 @@ public class AnniversaryReqDTO {
             @NotNull(message = "당일 알림 여부는 필수입니다.")
             Boolean dayAlarmEnabled,
 
-            @Size(max = 255, message = "메모는 255자 이하로 입력해주세요.")
+            @Size(max = 50, message = "메모는 50자 이하로 입력해주세요.")
             String memo
-    ) {}
+    ) {
+    }
 
     public record Update(
             @NotBlank(message = "기념일명은 필수입니다.")
@@ -54,12 +55,14 @@ public class AnniversaryReqDTO {
             @NotNull(message = "당일 알림 여부는 필수입니다.")
             Boolean dayAlarmEnabled,
 
-            @Size(max = 255, message = "메모는 255자 이하로 입력해주세요.")
+            @Size(max = 50, message = "메모는 50자 이하로 입력해주세요.")
             String memo
-    ) {}
+    ) {
+    }
 
     public record Delete(
             @NotEmpty(message = "삭제할 기념일 ID 목록은 필수입니다.")
             List<Long> anniversaryIds
-    ) {}
+    ) {
+    }
 }

--- a/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
@@ -46,7 +46,7 @@ public class Anniversary extends BaseEntity {
     @Builder.Default
     private Boolean dayAlarmEnabled = true;
 
-    @Column(length = 255)
+    @Column(length = 50)
     private String memo;
 
     public void update(String title, LocalDate anniversaryDate, Boolean isLunar, Boolean isRepeated,

--- a/src/main/java/com/umc/halo/domain/notification/entity/CommonAnniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/CommonAnniversary.java
@@ -38,6 +38,6 @@ public class CommonAnniversary extends BaseEntity {
     @Builder.Default
     private Boolean dayAlarmEnabled = true;
 
-    @Column(length = 255)
+    @Column(length = 50)
     private String memo;
 }

--- a/src/main/resources/db/migration/V31__alter_memo_size_constraint.sql
+++ b/src/main/resources/db/migration/V31__alter_memo_size_constraint.sql
@@ -1,0 +1,7 @@
+ALTER TABLE common_anniversary
+    MODIFY
+        COLUMN memo VARCHAR(50) NULL;
+
+ALTER TABLE anniversary
+    MODIFY
+        COLUMN memo VARCHAR(50) NULL;


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 메모 글자수 제한 50자로 변경
- Anniversary 스웨거 응답 예시에 400 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `AnniversaryReqDTO.java` : Create/Update의 `memo` 필드 `@Size(max = 50)`로 수정                                                                                                                         
- `Anniversary.java`, `CommonAnniversary.java` : `memo` 컬럼  `@Column(length = 50)`로 수정                                                                                                           
- `V31__alter_memo_size_constraint.sql` : `anniversary`, `common_anniversary` 테이블 `memo` 컬럼을 `VARCHAR(50)`으로 변경
- `AnniversaryControllerDocs.java` : `createAnniversary`, `updateAnniversary`, `deleteAnniversaries` 3개 API에 400(`COMMON400_1`) 응답 예시 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 기념일 추가 API
<img width="1067" height="1441" alt="image" src="https://github.com/user-attachments/assets/cda59943-77d9-4037-8a19-b60d5ab9c2e3" />
<img width="1079" height="1718" alt="image" src="https://github.com/user-attachments/assets/f1f4d3b1-25c5-4a5d-a9ab-a21202190c15" />
- 기념일 수정 API
<img width="1079" height="1678" alt="image" src="https://github.com/user-attachments/assets/5e9d1fef-9498-456e-b554-9e17fa00d100" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #186
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- IDE 자동 포맷팅으로 인한 변경(텍스트 블록 내 공백 트리밍)이 일부 섞여 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 기념일 추가·수정 시 메모 최대 길이가 50자로 제한됩니다.
  * 메모 길이 초과, 제목 누락·초과, 삭제 대상 누락에 대한 400 오류 안내가 보완되었습니다.
  * 기념일 메모 저장 규칙이 최대 50자에 맞게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->