### PR TITLE
[refactor] 권한 없음(403) 예외 404로 통일

### DIFF
--- a/src/main/java/com/umc/halo/domain/image/exception/code/ImageErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/image/exception/code/ImageErrorCode.java
@@ -10,7 +10,6 @@ public enum ImageErrorCode implements BaseErrorCode {
 
     INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "IMAGE400_1", "지원하지 않는 파일 형식입니다."),
     FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "IMAGE400_2", "이미지 용량이 제한을 초과했습니다.(최대 10MB)"),
-    FORBIDDEN_IMAGE_KEY(HttpStatus.FORBIDDEN, "IMAGE403_1", "본인이 업로드한 이미지가 아닙니다."),
     NOT_FOUND_IN_S3(HttpStatus.NOT_FOUND, "IMAGE404_1", "S3에 해당 이미지가 존재하지 않습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -72,7 +72,7 @@ public class ImageService {
         // 이미 finalize된 imageKey인 경우 소유권 및 실재 여부 확인
         if (!imageKey.startsWith(PENDING_PREFIX)) {
             if (!imageKey.startsWith("images/" + memberId + "/")) {
-                throw new ImageException(ImageErrorCode.FORBIDDEN_IMAGE_KEY);
+                throw new ImageException(ImageErrorCode.NOT_FOUND_IN_S3);
             }
             try {
                 s3Client.headObject(ImageConverter.toHeadObjectRequest(bucket, imageKey));
@@ -84,7 +84,7 @@ public class ImageService {
 
         // 자신의 imageKey가 아닐 경우
         if (!imageKey.startsWith(PENDING_PREFIX + "images/" + memberId + "/")) {
-            throw new ImageException(ImageErrorCode.FORBIDDEN_IMAGE_KEY);
+            throw new ImageException(ImageErrorCode.NOT_FOUND_IN_S3);
         }
 
         // 실제로 업로드된 파일인지 확인

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -197,9 +197,8 @@ public interface AnniversaryControllerDocs {
                         - memo : 메모 (선택, 255자 이하)
 
                     ## 동작 방식
-                    1. 요청한 기념일이 존재하는지 확인하고, 존재하지 않으면 404 예외를 반환합니다.
-                    2. 해당 기념일이 로그인한 회원 소유인지 확인하고, 본인 소유가 아니면 403 예외를 반환합니다.
-                    3. 검증을 통과하면 요청 값으로 기념일 정보를 갱신합니다.
+                    1. 요청한 기념일이 존재하는지 확인하고, 존재하지 않거나 본인 소유가 아니면 404 예외를 반환합니다.
+                    2. 검증을 통과하면 요청 값으로 기념일 정보를 갱신합니다.
                     """)
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -265,21 +264,6 @@ public interface AnniversaryControllerDocs {
                                     )
                             }
                     )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403",
-                    description = "본인 소유가 아닌 기념일",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "code": "ANNIVERSARY403_1",
-                                      "message": "해당 기념일에 대한 권한이 없습니다.",
-                                      "result": null
-                                    }
-                                    """)
-                    )
             )
     })
     ApiResponse<AnniversaryResDTO.UpdateAnniversary> updateAnniversary(
@@ -303,7 +287,7 @@ public interface AnniversaryControllerDocs {
 
                     ## 동작 방식
                     1. 요청한 ID 목록이 모두 존재하는지 확인하고, 하나라도 존재하지 않으면 404 예외를 반환합니다.
-                    2. 요청한 ID가 모두 로그인한 회원 소유인지 확인하고, 하나라도 본인 소유가 아니면 403 예외를 반환합니다.
+                    2. 요청한 ID가 모두 로그인한 회원 소유인지 확인하고, 하나라도 본인 소유가 아니면 404 예외를 반환합니다.
                     3. 검증을 통과하면 요청한 기념일을 모두 삭제합니다. (부분 삭제는 지원하지 않으며, 검증 실패 시 전체가 실패합니다.)
                     """)
     @ApiResponses(value = {
@@ -367,21 +351,6 @@ public interface AnniversaryControllerDocs {
                                                     """
                                     )
                             }
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403",
-                    description = "본인 소유가 아닌 기념일 포함",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "code": "ANNIVERSARY403_1",
-                                      "message": "해당 기념일에 대한 권한이 없습니다.",
-                                      "result": null
-                                    }
-                                    """)
                     )
             )
     })

--- a/src/main/java/com/umc/halo/domain/notification/exception/code/AnniversaryErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/code/AnniversaryErrorCode.java
@@ -9,8 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AnniversaryErrorCode implements BaseErrorCode {
 
-    ANNIVERSARY_NOT_FOUND(HttpStatus.NOT_FOUND, "ANNIVERSARY404_1", "존재하지 않는 기념일입니다."),
-    ANNIVERSARY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ANNIVERSARY403_1", "해당 기념일에 대한 권한이 없습니다.");
+    ANNIVERSARY_NOT_FOUND(HttpStatus.NOT_FOUND, "ANNIVERSARY404_1", "존재하지 않는 기념일입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -204,7 +204,7 @@ public class AnniversaryService {
         boolean hasUnauthorized = anniversaries.stream()
                 .anyMatch(anniversary -> !anniversary.getMember().getId().equals(memberId));
         if (hasUnauthorized) {
-            throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_ACCESS_DENIED);
+            throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_NOT_FOUND);
         }
 
         notificationRepository.deleteAllByAnniversaryIdIn(distinctIds);
@@ -239,7 +239,7 @@ public class AnniversaryService {
         Anniversary anniversary = anniversaryRepository.findById(anniversaryId)
                 .orElseThrow(() -> new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_NOT_FOUND));
         if (!anniversary.getMember().getId().equals(memberId)) {
-            throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_ACCESS_DENIED);
+            throw new AnniversaryException(AnniversaryErrorCode.ANNIVERSARY_NOT_FOUND);
         }
         return anniversary;
     }

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -234,13 +234,13 @@ public interface RecordControllerDocs {
                     ),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "403",
-                            description = "아직 열리지 않았거나 이미 완료한 장",
+                            description = "아직 시작하지 않은 스토리북이거나, 아직 열리지 않았거나 이미 완료한 장",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ApiResponse.class),
                                     examples = {
                                             @ExampleObject(
-                                                    name = "아직 열리지 않은 장",
+                                                    name = "아직 시작하지 않은 스토리북 / 아직 열리지 않은 장",
                                                     value = """
                                                             {
                                                                 "isSuccess": false,
@@ -266,7 +266,7 @@ public interface RecordControllerDocs {
                     ),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "404",
-                            description = "존재하지 않는 회원 / 장 / 장 질문 / 장면 카드 / S3 이미지",
+                            description = "존재하지 않는 회원 / 장 / 장 질문 / 장면 카드 / 존재하지 않거나 본인 소유가 아닌 이미지",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ApiResponse.class),
@@ -316,7 +316,7 @@ public interface RecordControllerDocs {
                                                             """
                                             ),
                                             @ExampleObject(
-                                                    name = "S3에 해당 이미지가 존재하지 않음(imageKey)",
+                                                    name = "존재하지 않거나 본인 소유가 아닌 이미지(imageKey)",
                                                     value = """
                                                             {
                                                                 "isSuccess": false,

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -35,11 +35,12 @@ public interface RecordControllerDocs {
                     3. 오늘 이미 이 스토리북의 장을 완료했다면 409(CHAPTER409_1)를 반환합니다.
                     4. 진행 중인 장 순서를 기준으로 요청한 장에 접근 가능한지 검증합니다. 아직 열리지 않은 장이면 403(CHAPTER403_1), 이미 완료한 장이면 403(CHAPTER403_2)을 반환합니다.
                     5. coverType과 imageKey/sceneCardId 조합이 일치하는지 검증합니다. (CHAPTER400_1)
-                    6. status가 COMPLETED이면 coverType, emotion이 모두 입력되었는지, 장의 모든 질문에 답변했는지 검증합니다. (CHAPTER400_4~6)
-                    7. sceneCardId가 있으면 해당 장의 장면 카드가 맞는지 확인합니다. (CHAPTER400_2)
-                    8. 장 기록(MemberChapter)을 생성하거나 갱신합니다. 동시 요청으로 중복 저장이 발생하면 409(CHAPTER409_2)를 반환합니다.
-                    9. 기존 답변을 삭제하고 요청받은 답변을 새로 저장합니다. 각 답변의 chapterQuestionId가 해당 장의 질문인지 검증합니다. (CHAPTER400_3)
-                    10. status가 COMPLETED면 스토리북 진행 상태를 갱신하고 AI 요약 생성 이벤트를 발행합니다. 마지막 장(10번째)이면 isStorybookCompleted를 true로 반환합니다. status가 DRAFT면 임시저장 상태로 진행 정보를 갱신합니다.
+                    6. coverType이 IMAGE이고 새로 업로드한 imageKey(기존 기록과 다른 값)이면, 소유권 및 S3 실재 여부를 확인하고 최종 imageKey로 확정합니다. 본인이 업로드한 이미지가 아니거나 S3에 존재하지 않으면 404(IMAGE404_1), 용량 제한을 초과했으면 400(IMAGE400_2)을 반환합니다.
+                    7. status가 COMPLETED이면 coverType, emotion이 모두 입력되었는지, 장의 모든 질문에 답변했는지 검증합니다. (CHAPTER400_4~6)
+                    8. sceneCardId가 있으면 해당 장의 장면 카드가 맞는지 확인합니다. (CHAPTER400_2)
+                    9. 장 기록(MemberChapter)을 생성하거나 갱신합니다. 동시 요청으로 중복 저장이 발생하면 409(CHAPTER409_2)를 반환합니다.
+                    10. 기존 답변을 삭제하고 요청받은 답변을 새로 저장합니다. 각 답변의 chapterQuestionId가 해당 장의 질문인지 검증합니다. (CHAPTER400_3)
+                    11. status가 COMPLETED면 스토리북 진행 상태를 갱신하고 AI 요약 생성 이벤트를 발행합니다. 마지막 장(10번째)이면 isStorybookCompleted를 true로 반환합니다. status가 DRAFT면 임시저장 상태로 진행 정보를 갱신합니다.
                     """,
             responses = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -233,7 +234,7 @@ public interface RecordControllerDocs {
                     ),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "403",
-                            description = "아직 열리지 않았거나 이미 완료한 장 / 본인이 업로드한 이미지가 아님",
+                            description = "아직 열리지 않았거나 이미 완료한 장",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ApiResponse.class),
@@ -256,17 +257,6 @@ public interface RecordControllerDocs {
                                                                 "isSuccess": false,
                                                                 "code": "CHAPTER403_2",
                                                                 "message": "이미 완료한 장입니다.",
-                                                                "result": null
-                                                            }
-                                                            """
-                                            ),
-                                            @ExampleObject(
-                                                    name = "본인이 업로드한 이미지가 아님(imageKey)",
-                                                    value = """
-                                                            {
-                                                                "isSuccess": false,
-                                                                "code": "IMAGE403_1",
-                                                                "message": "본인이 업로드한 이미지가 아닙니다.",
                                                                 "result": null
                                                             }
                                                             """


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
  - Anniversary/Image 도메인에서 "존재하지 않음"과 "권한 없음"을 서로 다른 응답으로 구분하던 걸 "존재하지 않음"(404) 하나로 통일                                                                                                 
  - 응답 차이으로 타인 소유 리소스의 존재 여부를 유추할 수 있는 정보 노출 위험 제거
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `AnniversaryErrorCode.java` : `ANNIVERSARY_ACCESS_DENIED`(403) 제거, `ANNIVERSARY_NOT_FOUND`(404)로 통일                                                                                                                     
  - `AnnniersaryService.java` : `getOwnedAnniversary`(단건 수정), `deleteAnniversaries`(다건 삭제)에서 소유권 불일치 시 404 반환하도록 수정                                                                                      
  - `AnniversaryControllerDocs.java` : 위 변경에 맞춰 update/delete API의 403 응답 문서 제거, "동작 방식" 서술을 "본인 소유가 아니면 404 반환"으로 수정                                                                          
  - `ImageErrorCode.java` : `FORBIDDEN_IMAGE_KEY`(403) 제거                                                                                                                                                                      
  - `ImageService.java` : `finalizeImage`에서 소유권 불일치 시 `NOT_FOUND_IN_S3`(404)로 통일 (Anniversary와 동일한 정보 노출 위험이 있어 같이 수정)                                                                              
  - `RecordControllerDocs.java` : 제거된 `IMAGE403_1` 예시 정리, `writeChapterRecord`의 "동작 방식"에 누락되어 있던 이미지 검증 단계(소유권/S3 실재 여부 404, 용량 초과 400) 서술 추가 
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 기념일 수정 API
<img width="1079" height="1490" alt="image" src="https://github.com/user-attachments/assets/031de702-5d25-4b2b-a901-5ef2f892f8ee" />
- 장 작성 API
<img width="1079" height="1693" alt="image" src="https://github.com/user-attachments/assets/c118ed99-d1f9-4351-9dc0-9a8448b164a3" />

---

## ✅ 확인 사항

- [X] 서버 정상 기동 확인
- [X] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [X] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #187
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경 사항**
  * 본인 소유가 아닌 이미지·기념일에 접근할 때 권한 오류 대신 리소스 없음(404)으로 응답하도록 변경했습니다.
  * 이미지 및 기념일 API 문서의 오류 응답 설명을 404 기준으로 정리했습니다.
  * 장 기록 작성 과정에 이미지 소유권, 저장 여부, 용량 검증 및 이미지 키 확정 단계 안내를 추가했습니다.
  * 관련 403 오류 코드와 응답 예시를 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->