### PR TITLE
[feat] 오늘의 장 알림 기능 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/repository/ChapterRepository.java
@@ -1,6 +1,7 @@
 package com.umc.halo.domain.content.chapter.repository;
 
 import com.umc.halo.domain.content.chapter.entity.*;
+import com.umc.halo.domain.content.storybook.entity.Storybook;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
 
@@ -13,4 +14,6 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
     Optional<Chapter> findByStorybook_IdAndChapterOrder(Long storybookId, Integer chapterOrder);
 
     List<Chapter> findByStorybook_IdIn(List<Long> storybookIds);
+
+    List<Chapter> findByStorybookIn(List<Storybook> storybooks);
 }

--- a/src/main/java/com/umc/halo/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/umc/halo/domain/notification/converter/NotificationConverter.java
@@ -1,5 +1,6 @@
 package com.umc.halo.domain.notification.converter;
 
+import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.notification.entity.Anniversary;
 import com.umc.halo.domain.notification.entity.Notification;
 import com.umc.halo.domain.notification.enums.NotificationStatus;
@@ -24,6 +25,18 @@ public class NotificationConverter {
                 .status(NotificationStatus.SCHEDULED)
                 .settingEnabled(settingEnabled)
                 .anniversaryEnabled(anniversaryEnabled)
+                .build();
+    }
+
+    public static Notification toTodayChapterNotification(Member member, String title, String message, LocalDateTime scheduledAt, Boolean settingEnabled) {
+        return Notification.builder()
+                .member(member)
+                .notificationType(NotificationType.TODAY_CHAPTER)
+                .title(title)
+                .message(message)
+                .scheduledAt(scheduledAt)
+                .status(NotificationStatus.SCHEDULED)
+                .settingEnabled(settingEnabled)
                 .build();
     }
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
@@ -51,4 +51,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     """)
     List<Anniversary> findAllRepeatedAnniversaries();
     boolean existsByMemberAndNotificationTypeAndScheduledAt(Member member, NotificationType notificationType, LocalDateTime scheduledAt);
+
+    List<Notification> findByMemberIdAndNotificationTypeAndStatusIn(Long memberId, NotificationType notificationType, List<NotificationStatus> scheduled);
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/NotificationRepository.java
@@ -1,5 +1,6 @@
 package com.umc.halo.domain.notification.repository;
 
+import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.notification.entity.*;
 import com.umc.halo.domain.notification.enums.NotificationStatus;
 import com.umc.halo.domain.notification.enums.NotificationType;
@@ -49,4 +50,5 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         WHERE a.isRepeated = true
     """)
     List<Anniversary> findAllRepeatedAnniversaries();
+    boolean existsByMemberAndNotificationTypeAndScheduledAt(Member member, NotificationType notificationType, LocalDateTime scheduledAt);
 }

--- a/src/main/java/com/umc/halo/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/umc/halo/domain/notification/scheduler/NotificationScheduler.java
@@ -20,4 +20,9 @@ public class NotificationScheduler {
     public void createNextYearNotifications() {
         notificationService.createNextYearNotifications();
     }
+
+    @Scheduled(cron = "0 59 23 * * *")
+    public void createTodayChapterNotification() {
+        notificationService.createTodayChapterNotifications();
+    }
 }

--- a/src/main/java/com/umc/halo/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/umc/halo/domain/notification/scheduler/NotificationScheduler.java
@@ -21,7 +21,7 @@ public class NotificationScheduler {
         notificationService.createNextYearNotifications();
     }
 
-    @Scheduled(cron = "0 59 23 * * *")
+    @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
     public void createTodayChapterNotification() {
         notificationService.createTodayChapterNotifications();
     }

--- a/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
@@ -31,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +54,8 @@ public class NotificationService {
     private final FcmService fcmService;
     private final AnniversaryNotificationListener anniversaryNotificationListener;
     private final StorybookService storybookService;
+
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
 
     public void sendScheduledNotifications() {
 
@@ -129,7 +132,7 @@ public class NotificationService {
                         c -> c
                 ));
 
-        LocalDateTime scheduledAt = LocalDate.now().plusDays(1).atStartOfDay();
+        LocalDateTime scheduledAt = LocalDate.now(ZONE_ID).plusDays(1).atStartOfDay();
 
         for (MemberSetting memberSetting : memberSettings) {
 

--- a/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
@@ -1,12 +1,24 @@
 package com.umc.halo.domain.notification.service;
 
+import com.umc.halo.domain.content.chapter.entity.Chapter;
+import com.umc.halo.domain.content.chapter.repository.ChapterRepository;
+import com.umc.halo.domain.content.storybook.dto.StorybookResDTO;
+import com.umc.halo.domain.content.storybook.entity.Storybook;
+import com.umc.halo.domain.content.storybook.service.StorybookService;
+import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.member.entity.MemberDevice;
 import com.umc.halo.domain.member.repository.MemberDeviceRepository;
+import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.domain.notification.converter.NotificationConverter;
 import com.umc.halo.domain.notification.entity.Anniversary;
 import com.umc.halo.domain.notification.entity.Notification;
-import com.umc.halo.domain.notification.enums.NotificationStatus;
 import com.umc.halo.domain.notification.enums.NotificationType;
 import com.umc.halo.domain.notification.repository.NotificationRepository;
+import com.umc.halo.domain.record.entity.MemberChapter;
+import com.umc.halo.domain.record.entity.MemberStorybook;
+import com.umc.halo.domain.record.enums.Status;
+import com.umc.halo.domain.record.repository.MemberChapterRepository;
+import com.umc.halo.domain.record.repository.MemberStorybookRepository;
 import com.umc.halo.domain.setting.entity.MemberSetting;
 import com.umc.halo.domain.setting.exception.SettingException;
 import com.umc.halo.domain.setting.exception.code.SettingErrorCode;
@@ -19,8 +31,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,8 +46,13 @@ public class NotificationService {
     private final MemberDeviceRepository memberDeviceRepository;
     private final MemberSettingRepository memberSettingRepository;
     private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+    private final MemberChapterRepository memberChapterRepository;
+    private final MemberStorybookRepository memberStorybookRepository;
+    private final ChapterRepository chapterRepository;
     private final FcmService fcmService;
     private final AnniversaryNotificationListener anniversaryNotificationListener;
+    private final StorybookService storybookService;
 
     public void sendScheduledNotifications() {
 
@@ -78,6 +98,74 @@ public class NotificationService {
         }
     }
 
+    @Transactional
+    public void createTodayChapterNotifications() {
+
+        List<MemberSetting> memberSettings = memberSettingRepository.findAllWithMember();
+
+        List<Member> members = memberSettings.stream().map(MemberSetting::getMember).toList();
+
+        List<MemberStorybook> allMemberStorybooks = memberStorybookRepository.findAllByMemberIn(members);
+
+        Map<Long, List<MemberStorybook>> memberStorybookMap = allMemberStorybooks.stream()
+                .collect(Collectors.groupingBy(
+                        ms -> ms.getMember().getId()
+                ));
+
+        List<MemberChapter> allMemberChapters = memberChapterRepository.findAllByMemberIn(members);
+
+        Map<Long, List<MemberChapter>> memberChapterMap = allMemberChapters.stream()
+                .collect(Collectors.groupingBy(
+                        mc -> mc.getMember().getId()
+                ));
+
+        List<Storybook> storybooks = allMemberStorybooks.stream().map(MemberStorybook::getStorybook).distinct().toList();
+
+        List<Chapter> chapters = chapterRepository.findByStorybookIn(storybooks);
+
+        Map<String, Chapter> chapterMap = chapters.stream()
+                .collect(Collectors.toMap(
+                        c -> c.getStorybook().getId() + "_" + c.getChapterOrder(),
+                        c -> c
+                ));
+
+        LocalDateTime scheduledAt = LocalDate.now().plusDays(1).atStartOfDay();
+
+        for (MemberSetting memberSetting : memberSettings) {
+
+            Member member = memberSetting.getMember();
+
+            List<MemberStorybook> memberStorybooks = memberStorybookMap.getOrDefault(member.getId(), List.of());
+
+            if (memberStorybooks.isEmpty()) {
+                createRecommendNotification(member, memberSetting, scheduledAt);
+                continue;
+            }
+
+            List<MemberChapter> memberChapters = memberChapterMap.getOrDefault(member.getId(), List.of());
+
+            Map<Long, List<MemberChapter>> storybookChapterMap = memberChapters.stream()
+                    .collect(Collectors.groupingBy(
+                            mc -> mc.getChapter().getStorybook().getId()
+                    ));
+
+            Map<Long, MemberChapter> chapterStatusMap =
+                    memberChapters.stream()
+                            .collect(Collectors.toMap(
+                                    mc -> mc.getChapter().getId(),
+                                    mc -> mc
+                            ));
+
+            List<Chapter> todayChapters = findTodayChapters(memberStorybooks, storybookChapterMap, chapterStatusMap, chapterMap);
+
+            if (todayChapters.isEmpty()) {
+                continue;
+            }
+
+            createTodayChapterNotification(member, todayChapters, memberSetting, scheduledAt);
+        }
+    }
+
     private boolean canSend(Notification notification) {
         MemberSetting memberSetting = memberSettingRepository.findByMemberId(notification.getMember().getId()).orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
 
@@ -106,5 +194,82 @@ public class NotificationService {
         }
 
         return successCount > 0;
+    }
+
+    private List<Chapter> findTodayChapters(List<MemberStorybook> memberStorybooks, Map<Long, List<MemberChapter>> storybookChapterMap, Map<Long, MemberChapter> memberChapterMap, Map<String, Chapter> chapterMap) {
+
+        List<Chapter> result = new ArrayList<>();
+
+        for (MemberStorybook memberStorybook : memberStorybooks) {
+
+            Storybook storybook = memberStorybook.getStorybook();
+
+            List<MemberChapter> memberChapters = storybookChapterMap.getOrDefault(storybook.getId(), List.of());
+
+            Integer todayChapterOrder = memberStorybook.resolveTodayChapterOrder(memberChapters);
+            if (todayChapterOrder == null) {
+                continue;
+            }
+
+            Chapter chapter = chapterMap.get(storybook.getId() + "_" + todayChapterOrder);
+            if (chapter == null) {
+                continue;
+            }
+
+            MemberChapter memberChapter = memberChapterMap.get(chapter.getId());
+
+            if (memberChapter == null || memberChapter.getStatus() == Status.DRAFT) {
+                result.add(chapter);
+            }
+        }
+
+        return result;
+    }
+
+    private void createTodayChapterNotification(Member member, List<Chapter> chapters, MemberSetting memberSetting, LocalDateTime scheduledAt) {
+
+        boolean exists = notificationRepository.existsByMemberAndNotificationTypeAndScheduledAt(member, NotificationType.TODAY_CHAPTER, scheduledAt);
+
+        if (exists) {
+            return;
+        }
+
+        Notification notification;
+        Boolean settingEnabled = memberSetting.getTodayChapterNotificationEnabled();
+
+        if (chapters.size() == 1) {
+            Chapter chapter = chapters.get(0);
+            notification = NotificationConverter.toTodayChapterNotification(member, "📖 [" + chapter.getStorybook().getTitle() + "] 오늘의 새로운 페이지가 열렸어요.", "오늘도 부모님과의 이야기를 이어가 볼까요?", scheduledAt, settingEnabled);
+        } else {
+            notification = NotificationConverter.toTodayChapterNotification(member, "📖 오늘 작성할 새로운 페이지가 " + chapters.size() + "장 열렸어요.", "오늘도 부모님과의 이야기를 이어가 볼까요?", scheduledAt, settingEnabled);
+        }
+
+        notificationRepository.save(notification);
+    }
+
+    private void createRecommendNotification(Member member, MemberSetting memberSetting, LocalDateTime scheduledAt) {
+
+        boolean exists = notificationRepository.existsByMemberAndNotificationTypeAndScheduledAt(member, NotificationType.TODAY_CHAPTER, scheduledAt);
+
+        if (exists) {
+            return;
+        }
+
+        List<StorybookResDTO.RecommendedStorybook> storybooks = storybookService.getRecommendedStorybooks(member.getId()).storybooks();
+
+        if (storybooks.isEmpty()) {
+            return;
+        }
+
+        String title = "📚 새로운 이야기를 시작해 볼까요?";
+        String message = "오늘은 [" + storybooks.get(0).title();
+        if (storybooks.size() >= 2) {
+            message += "] 또는 [" + storybooks.get(1).title();
+        }
+        message += "] 추천드려요.";
+
+        Notification notification = NotificationConverter.toTodayChapterNotification(member, title, message, scheduledAt, memberSetting.getTodayChapterNotificationEnabled());
+
+        notificationRepository.save(notification);
     }
 }

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
@@ -62,4 +62,17 @@ public class MemberStorybook extends BaseEntity {
                         && mc.getStatus() == Status.COMPLETED);
         return (lastCompleted && lastChapterOrder < 10) ? lastChapterOrder + 1 : lastChapterOrder;
     }
+
+    public Integer resolveTodayChapterOrder(List<MemberChapter> memberChapters) {
+        boolean lastCompleted = memberChapters.stream()
+                .anyMatch(mc -> lastChapterOrder.equals(mc.getChapter().getChapterOrder())
+                        && mc.getStatus() == Status.COMPLETED);
+        if (lastCompleted) {
+            if (lastChapterOrder >= 10) {
+                return null;
+            }
+            return lastChapterOrder + 1;
+        }
+        return lastChapterOrder;
+    }
 }

--- a/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
+++ b/src/main/java/com/umc/halo/domain/record/entity/MemberStorybook.java
@@ -57,22 +57,17 @@ public class MemberStorybook extends BaseEntity {
     }
 
     public Integer resolveDisplayChapterOrder(List<MemberChapter> memberChapters) {
-        boolean lastCompleted = memberChapters.stream()
-                .anyMatch(mc -> lastChapterOrder.equals(mc.getChapter().getChapterOrder())
-                        && mc.getStatus() == Status.COMPLETED);
-        return (lastCompleted && lastChapterOrder < 10) ? lastChapterOrder + 1 : lastChapterOrder;
+        return (isLastChapterCompleted(memberChapters) && lastChapterOrder < 10) ? lastChapterOrder + 1 : lastChapterOrder;
     }
 
     public Integer resolveTodayChapterOrder(List<MemberChapter> memberChapters) {
-        boolean lastCompleted = memberChapters.stream()
+        return !isLastChapterCompleted(memberChapters) ? lastChapterOrder : lastChapterOrder < 10 ? lastChapterOrder + 1 : null;
+    }
+
+    private boolean isLastChapterCompleted(List<MemberChapter> memberChapters) {
+        return memberChapters.stream()
                 .anyMatch(mc -> lastChapterOrder.equals(mc.getChapter().getChapterOrder())
-                        && mc.getStatus() == Status.COMPLETED);
-        if (lastCompleted) {
-            if (lastChapterOrder >= 10) {
-                return null;
-            }
-            return lastChapterOrder + 1;
-        }
-        return lastChapterOrder;
+                        && mc.getStatus() == Status.COMPLETED
+                );
     }
 }

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberChapterRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberChapterRepository.java
@@ -46,4 +46,8 @@ public interface MemberChapterRepository extends JpaRepository<MemberChapter, Lo
             "where mc.member = :member and chapter.storybook.id = :storybookId")
     List<MemberChapter> findAllByMemberAndStorybookIdWithSceneCard(
             @Param("member") Member member, @Param("storybookId") Long storybookId);
+
+    List<MemberChapter> findByMember(Member member);
+
+    List<MemberChapter> findAllByMemberIn(List<Member> members);
 }

--- a/src/main/java/com/umc/halo/domain/record/repository/MemberStorybookRepository.java
+++ b/src/main/java/com/umc/halo/domain/record/repository/MemberStorybookRepository.java
@@ -25,4 +25,6 @@ public interface MemberStorybookRepository extends JpaRepository<MemberStorybook
             "join fetch ms.storybook " +
             "where ms.member = :member")
     List<MemberStorybook> findAllByMemberWithStorybook(@Param("member") Member member);
+
+    List<MemberStorybook> findAllByMemberIn(List<Member> members);
 }

--- a/src/main/java/com/umc/halo/domain/setting/repository/MemberSettingRepository.java
+++ b/src/main/java/com/umc/halo/domain/setting/repository/MemberSettingRepository.java
@@ -4,6 +4,7 @@ import com.umc.halo.domain.setting.entity.*;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +12,10 @@ public interface MemberSettingRepository extends JpaRepository<MemberSetting, Lo
 
     void deleteByMemberId(Long memberId);
     Optional<MemberSetting> findByMemberId(Long memberId);
+    @Query("""
+        select ms
+        from MemberSetting ms
+        join fetch ms.member
+    """)
+    List<MemberSetting> findAllWithMember();
 }

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -62,6 +62,7 @@ public class SettingService {
         LocalTime previousNotificationTime = memberSetting.getRegularNotificationTime();
         boolean previousAllNotificationEnabled = memberSetting.getIsAllNotificationEnabled();
         boolean previousAnniversaryEnabled = memberSetting.getAnniversaryNotificationEnabled();
+        boolean previousTodayChapterEnabled = memberSetting.getTodayChapterNotificationEnabled();
 
         memberSetting.updateNotificationSettings(
                 dto.isAllNotificationEnabled(),
@@ -77,6 +78,10 @@ public class SettingService {
 
         if (previousAnniversaryEnabled != dto.anniversaryNotificationEnabled() || (!previousAllNotificationEnabled && dto.isAllNotificationEnabled())) {
             updateAnniversaryNotifications(memberId, dto.anniversaryNotificationEnabled(), memberSetting);
+        }
+
+        if (previousTodayChapterEnabled != dto.todayChapterNotificationEnabled() || (!previousAllNotificationEnabled && dto.isAllNotificationEnabled())) {
+            updateTodayChapterNotifications(memberId, dto.todayChapterNotificationEnabled());
         }
 
         return SettingConverter.toNotificationSettings(memberSetting);
@@ -199,6 +204,14 @@ public class SettingService {
             } else {
                 notification.updateScheduledAt(scheduledAt);
             }
+        }
+    }
+
+    private void updateTodayChapterNotifications(Long memberId, boolean enabled) {
+        List<Notification> notifications = notificationRepository.findByMemberIdAndNotificationTypeAndStatusIn(memberId, NotificationType.TODAY_CHAPTER, List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED));
+
+        for (Notification notification : notifications) {
+            notification.updateSettingEnabled(enabled);
         }
     }
 


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 오늘의 장 알림 기능 구현
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- NotificationConverter에 toTodayChapterNotification 추가
- NotificationScheduler에 오늘의 장 알림 생성 스케쥴러 구현
- NotificationService에 오늘의 장 알림 생성 로직 구현
- MemberStorybook 엔티티에 resolveTodayChapterOrder(오늘의 장 계산 메서드) 추가
- SettingService에서 todayChapterNotificationEnabled 수정 시 오늘의 장 알림에 적용 로직 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)

---

## ✅ 확인 사항

- [ ] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [ ] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #188
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/RoEN8CRQz3uSHCBGY
- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 회원별 학습 진행 상황과 보유 콘텐츠를 바탕으로 오늘의 챕터 알림을 자동 생성합니다.
  * 진행 가능한 챕터가 없으면 추천 스토리북 알림을 제공합니다.
  * 챕터 수에 따라 알림 내용을 구분하고, 매일 정해진 시간에 예약합니다.

* **개선**
  * 오늘의 챕터 알림 설정 변경 시 기존 예약·만료 알림 상태를 동기화합니다.
  * 학습 완료 여부에 따라 오늘 표시할 챕터를 자동으로 결정합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->