### PR TITLE
[fix] 반복하지 않는 기념일의 과거 날짜 생성/수정 방지 검증 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -259,6 +259,17 @@ public interface AnniversaryControllerDocs {
                                                       "result": null
                                                     }
                                                     """
+                                    ),
+                                    @ExampleObject(
+                                            name = "반복하지 않는 기념일 과거 날짜",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "ANNIVERSARY400_2",
+                                                      "message": "반복하지 않는 기념일은 지난 날짜로 등록할 수 없습니다.",
+                                                      "result": null
+                                                    }
+                                                    """
                                     )
                             }
                     )
@@ -460,6 +471,17 @@ public interface AnniversaryControllerDocs {
                                                       "isSuccess": false,
                                                       "code": "ANNIVERSARY400_1",
                                                       "message": "존재하지 않는 음력 날짜입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "반복하지 않는 기념일 과거 날짜",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "ANNIVERSARY400_2",
+                                                      "message": "반복하지 않는 기념일은 지난 날짜로 등록할 수 없습니다.",
                                                       "result": null
                                                     }
                                                     """

--- a/src/main/java/com/umc/halo/domain/notification/exception/code/AnniversaryErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/code/AnniversaryErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AnniversaryErrorCode implements BaseErrorCode {
 
-    ANNIVERSARY_NOT_FOUND(HttpStatus.NOT_FOUND, "ANNIVERSARY404_1", "존재하지 않는 기념일입니다.");
+    ANNIVERSARY_NOT_FOUND(HttpStatus.NOT_FOUND, "ANNIVERSARY404_1", "존재하지 않는 기념일입니다."),
+    PAST_DATE_NOT_REPEATED(HttpStatus.BAD_REQUEST, "ANNIVERSARY400_2", "반복하지 않는 기념일은 지난 날짜로 등록할 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -141,6 +141,16 @@ public class AnniversaryService {
                 .orElse(null);
     }
 
+    // 생성/수정 시 반복하지 않는 기념일이 과거 날짜인지 검증
+    private void validatePastDateNotRepeated(LocalDate anniversaryDate, Boolean isRepeated) {
+        if (Boolean.TRUE.equals(isRepeated)) {
+            return;
+        }
+        if (anniversaryDate.isBefore(LocalDate.now())) {
+            throw new AnniversaryException(AnniversaryErrorCode.PAST_DATE_NOT_REPEATED);
+        }
+    }
+
     // 음력 날짜(윤달 아님)를 해당 연도의 양력 날짜로 변환. 지원 범위를 벗어나거나 변환 실패 시 null 반환
     private LocalDate convertLunarToSolar(int lunarYear, int lunarMonth, int lunarDay) {
         KoreanLunarCalendar calendar = KoreanLunarCalendar.getInstance();
@@ -156,6 +166,8 @@ public class AnniversaryService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
+        validatePastDateNotRepeated(request.anniversaryDate(), request.isRepeated());
+
         Anniversary anniversary = AnniversaryConverter.toAnniversary(member, request);
         Anniversary savedAnniversary = anniversaryRepository.save(anniversary);
 
@@ -168,6 +180,8 @@ public class AnniversaryService {
     public AnniversaryResDTO.UpdateAnniversary updateAnniversary(Long memberId, Long anniversaryId, AnniversaryReqDTO.Update request) {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        validatePastDateNotRepeated(request.anniversaryDate(), request.isRepeated());
 
         Anniversary anniversary = getOwnedAnniversary(memberId, anniversaryId);
 

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -154,11 +154,20 @@ public class AnniversaryService {
     }
 
     // 생성/수정 시 반복하지 않는 기념일이 과거 날짜인지 검증
-    private void validatePastDateNotRepeated(LocalDate anniversaryDate, Boolean isRepeated) {
+    private void validatePastDateNotRepeated(LocalDate anniversaryDate, Boolean isRepeated, Boolean isLunar) {
         if (Boolean.TRUE.equals(isRepeated)) {
             return;
         }
-        if (anniversaryDate.isBefore(LocalDate.now())) {
+        LocalDate targetDate = anniversaryDate;
+        if (Boolean.TRUE.equals(isLunar)) {
+            LocalDate converted = convertLunarToSolar(
+                    anniversaryDate.getYear(), anniversaryDate.getMonthValue(), anniversaryDate.getDayOfMonth());
+            if (converted == null) {
+                return;
+            }
+            targetDate = converted;
+        }
+        if (targetDate.isBefore(LocalDate.now())) {
             throw new AnniversaryException(AnniversaryErrorCode.PAST_DATE_NOT_REPEATED);
         }
     }
@@ -194,8 +203,8 @@ public class AnniversaryService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
-        validatePastDateNotRepeated(request.anniversaryDate(), request.isRepeated());
         validateLunarDate(request.anniversaryDate(), request.isLunar());
+        validatePastDateNotRepeated(request.anniversaryDate(), request.isRepeated(), request.isLunar());
 
         Anniversary anniversary = AnniversaryConverter.toAnniversary(member, request);
         Anniversary savedAnniversary = anniversaryRepository.save(anniversary);
@@ -210,11 +219,10 @@ public class AnniversaryService {
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
-        validatePastDateNotRepeated(request.anniversaryDate(), request.isRepeated());
-
         Anniversary anniversary = getOwnedAnniversary(memberId, anniversaryId);
 
         validateLunarDate(request.anniversaryDate(), request.isLunar());
+        validatePastDateNotRepeated(request.anniversaryDate(), request.isRepeated(), request.isLunar());
 
         boolean titleChanged = !Objects.equals(anniversary.getTitle(), request.title());
         boolean memoChanged = !Objects.equals(anniversary.getMemo(), request.memo());


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
반복하지 않는(isRepeated=false) 기념일을 과거 날짜로 생성/수정하지 못하도록 검증 추가

- AnniversaryErrorCode에 PAST_DATE_NOT_REPEATED(ANNIVERSARY400_2) 추가
- createAnniversary/updateAnniversary에 과거 날짜 검증 로직 추가

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `AnniversaryErrorCode.java` : PAST_DATE_NOT_REPEATED(ANNIVERSARY400_2) 추가
- `AnniversaryService.java` : validatePastDateNotRepeated() 추가, createAnniversary/updateAnniversary에서 호출

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 과거 날짜 + isRepeated=false → 400 (ANNIVERSARY400_2) 확인
<img width="870" height="1061" alt="스크린샷 2026-08-07 오후 8 36 24" src="https://github.com/user-attachments/assets/f20662a1-9409-4cc6-a03d-bf94c5eb24fe" />

- 과거 날짜 + isRepeated=true → 200 성공 확인 (정상 케이스 회귀 없음
<img width="870" height="1061" alt="스크린샷 2026-08-07 오후 8 36 41" src="https://github.com/user-attachments/assets/e507ecf2-eb09-4afe-af2b-ba9730373664" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #196
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 반복하지 않는 기념일을 과거 날짜로 등록하거나 수정할 수 없도록 검증을 추가했습니다.
  - 양력 및 음력 날짜를 기준으로 과거 여부를 확인합니다.
  - 해당 조건에 맞지 않는 경우 명확한 오류 안내를 제공합니다.
  - 반복 기념일은 기존과 동일하게 처리됩니다.
- **문서**
  - 기념일 등록 및 수정 API의 오류 응답 예시를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->