### PR TITLE
[FEAT] 캘린더 일별 조회 chapters에 memberChapterId 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -136,7 +136,7 @@ public interface CalendarControllerDocs {
                                   { "storybookId": 1, "title": "오래전 당신", "storybookImageUrl": "https://image1" }
                                 ],
                                 "chapters": [
-                                  { "storybookId": 101, "title": "오래 전 당신", "completedChapterOrder": 5 }
+                                  { "memberChapterId": 10, storybookId": 101, "title": "오래 전 당신", "completedChapterOrder": 5 }
                                 ]
                               }
                             }

--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -136,7 +136,7 @@ public interface CalendarControllerDocs {
                                   { "storybookId": 1, "title": "오래전 당신", "storybookImageUrl": "https://image1" }
                                 ],
                                 "chapters": [
-                                  { "memberChapterId": 10, storybookId": 101, "title": "오래 전 당신", "completedChapterOrder": 5 }
+                                  { "memberChapterId": 10, "storybookId": 101, "title": "오래 전 당신", "completedChapterOrder": 5 }
                                 ]
                               }
                             }

--- a/src/main/java/com/umc/halo/domain/calendar/converter/CalendarConverter.java
+++ b/src/main/java/com/umc/halo/domain/calendar/converter/CalendarConverter.java
@@ -50,8 +50,9 @@ public class CalendarConverter {
                 .build();
     }
 
-    public static CalendarDailyResDTO.ChapterInfo toChapterInfo(Storybook storybook, Integer completedChapterOrder) {
+    public static CalendarDailyResDTO.ChapterInfo toChapterInfo(Long memberChapterId, Storybook storybook, Integer completedChapterOrder) {
         return CalendarDailyResDTO.ChapterInfo.builder()
+                .memberChapterId(memberChapterId)
                 .storybookId(storybook.getId())
                 .title(storybook.getTitle())
                 .completedChapterOrder(completedChapterOrder)

--- a/src/main/java/com/umc/halo/domain/calendar/dto/CalendarDailyResDTO.java
+++ b/src/main/java/com/umc/halo/domain/calendar/dto/CalendarDailyResDTO.java
@@ -21,6 +21,7 @@ public class CalendarDailyResDTO {
 
     @Builder
     public record ChapterInfo(
+            Long memberChapterId,
             Long storybookId,
             String title,
             Integer completedChapterOrder

--- a/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
@@ -114,7 +114,7 @@ public class CalendarService {
             if (chapterOrderOfDay == TOTAL_CHAPTER_COUNT) {
                 storybooks.add(CalendarConverter.toStorybookInfo(storybook));
             } else {
-                chapters.add(CalendarConverter.toChapterInfo(storybook, chapterOrderOfDay));
+                chapters.add(CalendarConverter.toChapterInfo(mc.getId(), storybook, chapterOrderOfDay));
             }
         }
 


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 캘린더 일별 조회 chapters[]에 memberChapterId 추가 (완료된 장 다시보기 API 연결용)
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
- ChapterInfo DTO에 memberChapterId 필드 추가
- Converter(toChapterInfo)·Service(getDaily)에서 mc.getId() 전달
- Swagger 문서 수정
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [X] 서버 정상 기동 확인
- [X] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [X] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #200 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- API 명세서: 일별 기록 조회


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 일별 캘린더의 챕터 정보에 `memberChapterId`가 추가되었습니다.
  * 일별 기록 조회 API 응답에서 각 챕터를 보다 정확하게 식별할 수 있습니다.
  * 기존 스토리북 ID, 제목, 완료 장 순서 정보는 그대로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->