### PR TITLE
[feat] 공통 기념일 알림 기능 구현

### DIFF
--- a/src/main/java/com/umc/halo/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/umc/halo/domain/notification/converter/NotificationConverter.java
@@ -51,4 +51,16 @@ public class NotificationConverter {
                 .settingEnabled(settingEnabled)
                 .build();
     }
+
+    public static Notification toCommonAnniversaryNotification(Member member, String title, String message, LocalDateTime scheduledAt, Boolean settingEnabled) {
+        return Notification.builder()
+                .member(member)
+                .notificationType(NotificationType.COMMON_ANNIVERSARY)
+                .title(title)
+                .message(message)
+                .scheduledAt(scheduledAt)
+                .status(NotificationStatus.SCHEDULED)
+                .settingEnabled(settingEnabled)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/halo/domain/notification/enums/NotificationType.java
+++ b/src/main/java/com/umc/halo/domain/notification/enums/NotificationType.java
@@ -4,5 +4,6 @@ public enum NotificationType {
     ANNIVERSARY_D7,   // 기념일 7일 전
     ANNIVERSARY_DDAY, // 기념일 당일
     TODAY_CHAPTER,    // 오늘의 장 알림
-    RETENTION         // 리텐션 알림
+    RETENTION,         // 리텐션 알림
+    COMMON_ANNIVERSARY  //공통 기념일 당일
 }

--- a/src/main/java/com/umc/halo/domain/notification/repository/CommonAnniversaryRepository.java
+++ b/src/main/java/com/umc/halo/domain/notification/repository/CommonAnniversaryRepository.java
@@ -3,5 +3,8 @@ package com.umc.halo.domain.notification.repository;
 import com.umc.halo.domain.notification.entity.CommonAnniversary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommonAnniversaryRepository extends JpaRepository<CommonAnniversary, Long> {
+    List<CommonAnniversary> findByMonthAndDay(Integer month, Integer day);
 }

--- a/src/main/java/com/umc/halo/domain/notification/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/umc/halo/domain/notification/scheduler/NotificationScheduler.java
@@ -30,4 +30,9 @@ public class NotificationScheduler {
     public void createRetentionNotifications() {
         notificationService.createRetentionNotifications();
     }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void createCommonAnniversaryNotifications() {
+        notificationService.createCommonAnniversaryNotifications();
+    }
 }

--- a/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
@@ -11,8 +11,10 @@ import com.umc.halo.domain.member.repository.MemberDeviceRepository;
 import com.umc.halo.domain.member.repository.MemberRepository;
 import com.umc.halo.domain.notification.converter.NotificationConverter;
 import com.umc.halo.domain.notification.entity.Anniversary;
+import com.umc.halo.domain.notification.entity.CommonAnniversary;
 import com.umc.halo.domain.notification.entity.Notification;
 import com.umc.halo.domain.notification.enums.NotificationType;
+import com.umc.halo.domain.notification.repository.CommonAnniversaryRepository;
 import com.umc.halo.domain.notification.repository.NotificationRepository;
 import com.umc.halo.domain.record.entity.MemberChapter;
 import com.umc.halo.domain.record.entity.MemberStorybook;
@@ -31,6 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -48,6 +51,7 @@ public class NotificationService {
     private final MemberChapterRepository memberChapterRepository;
     private final MemberStorybookRepository memberStorybookRepository;
     private final ChapterRepository chapterRepository;
+    private final CommonAnniversaryRepository commonAnniversaryRepository;
     private final FcmService fcmService;
     private final AnniversaryNotificationListener anniversaryNotificationListener;
     private final StorybookService storybookService;
@@ -175,6 +179,24 @@ public class NotificationService {
         }
     }
 
+    @Transactional
+    public void createCommonAnniversaryNotifications() {
+
+        LocalDate today = LocalDate.now(ZONE_ID);
+
+        List<CommonAnniversary> commonAnniversaries = commonAnniversaryRepository.findByMonthAndDay(today.getMonthValue(), today.getDayOfMonth());
+
+        if (commonAnniversaries.isEmpty()) {
+            return;
+        }
+
+        List<MemberSetting> memberSettings = memberSettingRepository.findAllWithMember();
+
+        for (MemberSetting memberSetting : memberSettings) {
+            notificationTransactionService.createCommonAnniversaryNotification(memberSetting, commonAnniversaries, today);
+        }
+    }
+
     private boolean canSend(Notification notification) {
         MemberSetting memberSetting = memberSettingRepository.findByMemberId(notification.getMember().getId()).orElseThrow(() -> new SettingException(SettingErrorCode.SETTING_NOT_FOUND));
 
@@ -184,7 +206,7 @@ public class NotificationService {
 
         return switch (notification.getNotificationType()) {
             case ANNIVERSARY_D7, ANNIVERSARY_DDAY -> Boolean.TRUE.equals(notification.getAnniversaryEnabled()) && Boolean.TRUE.equals(notification.getSettingEnabled());
-            case TODAY_CHAPTER, RETENTION -> Boolean.TRUE.equals(notification.getSettingEnabled());
+            case TODAY_CHAPTER, RETENTION, COMMON_ANNIVERSARY -> Boolean.TRUE.equals(notification.getSettingEnabled());
         };
     }
 

--- a/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
@@ -33,7 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/com/umc/halo/domain/notification/service/NotificationTransactionService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/NotificationTransactionService.java
@@ -5,6 +5,7 @@ import com.umc.halo.domain.member.exception.MemberException;
 import com.umc.halo.domain.member.exception.code.MemberErrorCode;
 import com.umc.halo.domain.member.repository.MemberRepository;
 import com.umc.halo.domain.notification.converter.NotificationConverter;
+import com.umc.halo.domain.notification.entity.CommonAnniversary;
 import com.umc.halo.domain.notification.entity.Notification;
 import com.umc.halo.domain.notification.enums.NotificationStatus;
 import com.umc.halo.domain.notification.enums.NotificationType;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -85,6 +87,31 @@ public class NotificationTransactionService {
         Notification notification = NotificationConverter.toRetentionNotification(member, title, message, scheduledAt, memberSetting.getRetentionNotificationEnabled());
 
         notificationRepository.save(notification);
+    }
+
+    @Transactional
+    public void createCommonAnniversaryNotification(MemberSetting memberSetting, List<CommonAnniversary> commonAnniversaries, LocalDate today) {
+
+        Member member = memberSetting.getMember();
+
+        LocalTime notifyTime = memberSetting.getRegularNotificationTime();
+        if (notifyTime == null) {
+            return;
+        }
+        LocalDateTime scheduledAt = today.atTime(notifyTime);
+
+        for (CommonAnniversary commonAnniversary : commonAnniversaries) {
+
+            boolean exists = notificationRepository.existsByMemberAndNotificationTypeAndScheduledAt(member, NotificationType.COMMON_ANNIVERSARY, scheduledAt);
+
+            if (exists) {
+                continue;
+            }
+
+            Notification notification = NotificationConverter.toCommonAnniversaryNotification(member, commonAnniversary.getTitle(), commonAnniversary.getMemo(), scheduledAt, memberSetting.getAnniversaryNotificationEnabled());
+
+            notificationRepository.save(notification);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 
@@ -32,6 +33,8 @@ public class SettingService {
     private final MemberSettingRepository memberSettingRepository;
     private final BgmRepository bgmRepository;
     private final NotificationRepository notificationRepository;
+
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
 
     @Transactional(readOnly = true)
     public SettingResDTO.NotificationSettings getNotificationSettings(Long memberId) {
@@ -234,7 +237,12 @@ public class SettingService {
     private void updateCommonAnniversaryNotificationScheduledTime(Long memberId, LocalTime notifyTime) {
         List<Notification> notifications = notificationRepository.findByMemberIdAndNotificationTypeAndStatusIn(memberId, NotificationType.COMMON_ANNIVERSARY, List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED));
 
-        LocalDateTime now = LocalDateTime.now();
+        if (notifyTime == null) {
+            notifications.forEach(Notification::expire);
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now(ZONE_ID);
 
         for (Notification notification : notifications) {
             LocalDateTime scheduledAt = notification.getScheduledAt().toLocalDate().atTime(notifyTime);

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -237,11 +237,6 @@ public class SettingService {
     private void updateCommonAnniversaryNotificationScheduledTime(Long memberId, LocalTime notifyTime) {
         List<Notification> notifications = notificationRepository.findByMemberIdAndNotificationTypeAndStatusIn(memberId, NotificationType.COMMON_ANNIVERSARY, List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED));
 
-        if (notifyTime == null) {
-            notifications.forEach(Notification::expire);
-            return;
-        }
-
         LocalDateTime now = LocalDateTime.now(ZONE_ID);
 
         for (Notification notification : notifications) {

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -76,10 +76,12 @@ public class SettingService {
 
         if (!Objects.equals(previousNotificationTime, dto.regularNotificationTime())) {
             updateAnniversaryNotificationScheduledTime(memberId, dto.regularNotificationTime());
+            updateCommonAnniversaryNotificationScheduledTime(memberId, dto.regularNotificationTime());
         }
 
         if (previousAnniversaryEnabled != dto.anniversaryNotificationEnabled() || (!previousAllNotificationEnabled && dto.isAllNotificationEnabled())) {
             updateAnniversaryNotifications(memberId, dto.anniversaryNotificationEnabled(), memberSetting);
+            updateCommonAnniversaryNotifications(memberId, dto.anniversaryNotificationEnabled());
         }
 
         if (previousTodayChapterEnabled != dto.todayChapterNotificationEnabled() || (!previousAllNotificationEnabled && dto.isAllNotificationEnabled())) {
@@ -226,6 +228,35 @@ public class SettingService {
 
         for (Notification notification : notifications) {
             notification.updateSettingEnabled(enabled);
+        }
+    }
+
+    private void updateCommonAnniversaryNotificationScheduledTime(Long memberId, LocalTime notifyTime) {
+        List<Notification> notifications = notificationRepository.findByMemberIdAndNotificationTypeAndStatusIn(memberId, NotificationType.COMMON_ANNIVERSARY, List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        for (Notification notification : notifications) {
+            LocalDateTime scheduledAt = notification.getScheduledAt().toLocalDate().atTime(notifyTime);
+
+            if (!scheduledAt.isAfter(now)) {
+                notification.expire();
+                continue;
+            }
+
+            if (notification.getStatus() == NotificationStatus.EXPIRED) {
+                notification.reserve(scheduledAt);
+            } else {
+                notification.updateScheduledAt(scheduledAt);
+            }
+        }
+    }
+
+    private void updateCommonAnniversaryNotifications(Long memberId, boolean enabled) {
+        List<Notification> notifications = notificationRepository.findByMemberIdAndNotificationTypeAndStatusIn(memberId, NotificationType.COMMON_ANNIVERSARY, List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED));
+
+        for (Notification notification : notifications) {
+                notification.updateSettingEnabled(enabled);
         }
     }
 


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 공통 기념일 알림 기능 구현
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- NotificationConverter에 toCommonAnniversaryNotification(공통 기념일 알림 변환) 추가
- NotificationType에 COMMON_ANNIVERSARY 추가
- CommonAnniversaryRepository에 findByMonthAndDay 추가
- NotificationScheduler, NotificationService에 createCommonAnniversaryNotifications 추가
- NotificationTransactionService에 createCommonAnniversaryNotification 메서드 추가
- SettingService에 설정 변경 -> 공통 기념일에 적용 로직 추가
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
---

## ✅ 확인 사항

- [ ] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #199 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/RoEN8CRQz3uSHCBGY
- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 공통 기념일 알림을 지원합니다.
  * 매일 자정에 당일 기념일 알림이 자동 생성됩니다.
  * 회원별 알림 설정과 예약 시간이 공통 기념일 알림에도 적용됩니다.
  * 중복 알림 생성을 방지합니다.

* **개선**
  * 알림 설정 변경 시 공통 기념일 알림의 활성화 상태와 예약 시간이 함께 갱신됩니다.
  * 발송 가능한 알림 유형에 공통 기념일이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->