### PR TITLE
[refactor] 앱 삭제 시 FCM 토큰 삭제 로직 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/notification/service/FcmService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/FcmService.java
@@ -1,8 +1,8 @@
 package com.umc.halo.domain.notification.service;
 
-import com.google.firebase.messaging.FirebaseMessaging;
-import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.*;
+import com.umc.halo.domain.member.entity.MemberDevice;
+import com.umc.halo.domain.member.repository.MemberDeviceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,16 +12,24 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class FcmService {
 
-    public void send(String token, String title, String body) {
+    private final MemberDeviceRepository memberDeviceRepository;
+
+    public void send(MemberDevice memberDevice, String title, String body) {
         Notification notification = Notification.builder().setTitle(title).setBody(body).build();
 
-        Message message = Message.builder().setToken(token).setNotification(notification).build();
+        Message message = Message.builder().setToken(memberDevice.getFcmToken()).setNotification(notification).build();
 
         try {
             String response = FirebaseMessaging.getInstance().send(message);
             log.info("FCM 전송 성공 : response={}", response);
+        } catch (FirebaseMessagingException e) {
+            if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
+                log.info("만료된 FCM 토큰 삭제 : token={}", memberDevice.getFcmToken());
+                memberDeviceRepository.delete(memberDevice);
+            }
+            log.error("FCM 전송 실패 token={}", memberDevice.getFcmToken(), e);
         } catch (Exception e) {
-            log.error("FCM 전송 실패 token={}", token, e);
+            log.error("FCM 전송 실패 token={}", memberDevice.getFcmToken(), e);
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/com/umc/halo/domain/notification/service/FcmService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/FcmService.java
@@ -14,7 +14,7 @@ public class FcmService {
 
     private final MemberDeviceRepository memberDeviceRepository;
 
-    public void send(MemberDevice memberDevice, String title, String body) {
+    public boolean send(MemberDevice memberDevice, String title, String body) {
         Notification notification = Notification.builder().setTitle(title).setBody(body).build();
 
         Message message = Message.builder().setToken(memberDevice.getFcmToken()).setNotification(notification).build();
@@ -22,14 +22,16 @@ public class FcmService {
         try {
             String response = FirebaseMessaging.getInstance().send(message);
             log.info("FCM 전송 성공 : response={}", response);
+            return true;
         } catch (FirebaseMessagingException e) {
             if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
-                log.info("만료된 FCM 토큰 삭제 : token={}", memberDevice.getFcmToken());
+                log.info("만료된 FCM 토큰 삭제 : deviceId={}", memberDevice.getId());
                 memberDeviceRepository.delete(memberDevice);
             }
-            log.error("FCM 전송 실패 token={}", memberDevice.getFcmToken(), e);
+            log.error("FCM 전송 실패 deviceId={}, errorCode={}", memberDevice.getId(), e.getMessagingErrorCode(), e);
+            return false;
         } catch (Exception e) {
-            log.error("FCM 전송 실패 token={}", memberDevice.getFcmToken(), e);
+            log.error("FCM 전송 실패 deviceId={}", memberDevice.getId(), e);
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
@@ -216,7 +216,7 @@ public class NotificationService {
 
         for (MemberDevice memberDevice : memberDevices) {
             try {
-                fcmService.send(memberDevice.getFcmToken(), notification.getTitle(), notification.getMessage());
+                fcmService.send(memberDevice, notification.getTitle(), notification.getMessage());
                 successCount++;
             } catch (Exception e) {
                 log.error("FCM 전송 실패 memberId={}, deviceId={}, notificationId={}", notification.getMember().getId(), memberDevice.getId(), notification.getId(), e);

--- a/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/NotificationService.java
@@ -216,8 +216,10 @@ public class NotificationService {
 
         for (MemberDevice memberDevice : memberDevices) {
             try {
-                fcmService.send(memberDevice, notification.getTitle(), notification.getMessage());
-                successCount++;
+                boolean success = fcmService.send(memberDevice, notification.getTitle(), notification.getMessage());
+                if (success) {
+                    successCount++;
+                }
             } catch (Exception e) {
                 log.error("FCM 전송 실패 memberId={}, deviceId={}, notificationId={}", notification.getMember().getId(), memberDevice.getId(), notification.getId(), e);
             }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 앱 삭제 시 회원 디바이스 삭제 로직 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- FcmService 파일 (FirebaseMessagingException에서 에러코드가 UNREGISTERED면 회원 디바이스 삭제)
- FcmService.send의 파라미터 타입 변경 (String token -> MemberDevice memberDevice)
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #203 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/RoEN8CRQz3uSHCBGY
- API 명세서: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 등록 해제되었거나 유효하지 않은 기기로 푸시 알림을 전송할 때 해당 기기 정보를 자동으로 정리합니다.
  * 푸시 알림 전송 오류를 상황에 맞게 처리해 불필요한 반복 실패를 줄였습니다.
  * 정상적인 기기에는 기존과 동일하게 푸시 알림을 전송합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->