### PR TITLE
[fix] pending prefix를 제외한 부분으로 기존 기록의 imageKey와 비교하도록 수정

### DIFF
--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -114,6 +114,17 @@ public class ImageService {
         return new FinalizedImage(finalKey, buildImageUrl(finalKey));
     }
 
+    // pending prefix 유무와 무관하게 같은 이미지인지 비교
+    public boolean isSameImage(String requestImageKey, String storedImageKey) {
+        if (requestImageKey == null || storedImageKey == null) {
+            return false;
+        }
+        String normalizedKey = requestImageKey.startsWith(PENDING_PREFIX)
+                ? requestImageKey.substring(PENDING_PREFIX.length())
+                : requestImageKey;
+        return normalizedKey.equals(storedImageKey);
+    }
+
     // imageKey로 조회용 presigned URL 발급
     public String getImage(String imageKey) {
         GetObjectRequest getObjectRequest = ImageConverter.toGetObjectRequest(bucket, imageKey);

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -84,7 +84,7 @@ public class RecordService {
                     throw new RecordException(RecordErrorCode.INCORRECT_COVER_TYPE);
                 }
                 // 기존 기록의 imageKey와 동일하면 그대로 사용
-                if (memberChapter != null && recordReqDTO.imageKey().equals(memberChapter.getImageKey())) {
+                if (memberChapter != null && imageService.isSameImage(recordReqDTO.imageKey(), memberChapter.getImageKey())) {
                     imageKey = memberChapter.getImageKey();
                 } else {
                     imageKey = imageService.finalizeImage(memberId, recordReqDTO.imageKey()).finalKey();


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- pending prefix를 제외한 부분으로 기존 기록의 imageKey와 비교하도록 수정
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `ImageService`: pending prefix가 있을 경우 제외하고 저장되어 있는 imageKey와 비교하는 헬퍼(`isSameImage`) 생성
- `RecordService`: 단순 imageKey 문자열 비교가 아닌 ImageService의 isSameImage를 사용하여 prefix와 무관하게 검사하도록 수정
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #205
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 기록에 연결된 이미지 비교가 `pending/` 접두사가 포함된 요청 이미지 키도 올바르게 처리하도록 개선되었습니다.
  * 이미지 키가 존재하는지 확인한 후 저장된 이미지와 정확히 비교합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->