### PR TITLE
[fix] 주요 보안/인증 주요 지점 로그 추가 및 원본 예외 유실 방지

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/chapter/exception/ChapterException.java
+++ b/src/main/java/com/umc/halo/domain/content/chapter/exception/ChapterException.java
@@ -7,4 +7,8 @@ public class ChapterException extends ProjectException {
     public ChapterException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public ChapterException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/domain/content/storybook/exception/StorybookException.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/exception/StorybookException.java
@@ -7,4 +7,8 @@ public class StorybookException extends ProjectException {
     public StorybookException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public StorybookException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
@@ -136,7 +136,7 @@ public class StorybookService {
         try {
             memberStorybookRepository.save(memberStorybook);
         } catch (DataIntegrityViolationException e) {
-            throw new StorybookException(StorybookErrorCode.ALREADY_IN_PROGRESS);
+            throw new StorybookException(StorybookErrorCode.ALREADY_IN_PROGRESS, e);
         }
 
         return StorybookConverter.toStartStorybook(memberStorybook, storybook);

--- a/src/main/java/com/umc/halo/domain/exhibition/exception/ExhibitionException.java
+++ b/src/main/java/com/umc/halo/domain/exhibition/exception/ExhibitionException.java
@@ -7,4 +7,8 @@ public class ExhibitionException extends ProjectException {
     public ExhibitionException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public ExhibitionException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/domain/image/exception/ImageException.java
+++ b/src/main/java/com/umc/halo/domain/image/exception/ImageException.java
@@ -7,4 +7,8 @@ public class ImageException extends ProjectException {
     public ImageException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public ImageException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -109,8 +109,11 @@ public class ImageService {
     private HeadObjectResponse headObjectOrThrow(String imageKey) {
         try {
             return s3Client.headObject(ImageConverter.toHeadObjectRequest(bucket, imageKey));
-        } catch (NoSuchKeyException e) {
-            throw new ImageException(ImageErrorCode.NOT_FOUND_IN_S3, e);
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                throw new ImageException(ImageErrorCode.NOT_FOUND_IN_S3, e);
+            }
+            throw e;
         }
     }
 

--- a/src/main/java/com/umc/halo/domain/image/service/ImageService.java
+++ b/src/main/java/com/umc/halo/domain/image/service/ImageService.java
@@ -110,7 +110,7 @@ public class ImageService {
         try {
             return s3Client.headObject(ImageConverter.toHeadObjectRequest(bucket, imageKey));
         } catch (NoSuchKeyException e) {
-            throw new ImageException(ImageErrorCode.NOT_FOUND_IN_S3);
+            throw new ImageException(ImageErrorCode.NOT_FOUND_IN_S3, e);
         }
     }
 

--- a/src/main/java/com/umc/halo/domain/member/exception/MemberException.java
+++ b/src/main/java/com/umc/halo/domain/member/exception/MemberException.java
@@ -7,4 +7,8 @@ public class MemberException extends ProjectException {
     public MemberException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public MemberException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/domain/member/oauth/AbstractOidcProvider.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/AbstractOidcProvider.java
@@ -7,10 +7,12 @@ import com.nimbusds.jwt.SignedJWT;
 import com.umc.halo.domain.member.enums.Provider;
 import com.umc.halo.domain.member.exception.code.AuthErrorCode;
 import com.umc.halo.global.apiPayload.exception.ProjectException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.security.interfaces.RSAPublicKey;
 import java.util.Date;
 
+@Slf4j
 public abstract class AbstractOidcProvider {
 
     protected final OidcJwksClient oidcJwksClient;
@@ -37,6 +39,7 @@ public abstract class AbstractOidcProvider {
             String kid = signedJWT.getHeader().getKeyID();
 
             if (kid == null) {
+                log.warn("[OidcVerify] provider={} 검증 실패: kid 없음", getProvider());
                 throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
             }
 
@@ -44,38 +47,45 @@ public abstract class AbstractOidcProvider {
             JWSVerifier verifier = new RSASSAVerifier(publicKey);
 
             if (!signedJWT.verify(verifier)) {
+                log.warn("[OidcVerify] provider={} 검증 실패: 서명 불일치", getProvider());
                 throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
             }
 
             JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
 
             if (!isValidIssuer(claims.getIssuer())) {
+                log.warn("[OidcVerify] provider={} 검증 실패: issuer 불일치", getProvider());
                 throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
             }
 
             if (claims.getAudience() == null || !claims.getAudience().contains(getClientId())) {
+                log.warn("[OidcVerify] provider={} 검증 실패: audience 불일치", getProvider());
                 throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
             }
 
             Date expiration = claims.getExpirationTime();
 
             if (expiration == null || expiration.before(new Date())) {
+                log.warn("[OidcVerify] provider={} 검증 실패: 토큰 만료", getProvider());
                 throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
             }
 
             String subject = claims.getSubject();
 
             if (subject == null) {
+                log.warn("[OidcVerify] provider={} 검증 실패: subject 없음", getProvider());
                 throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
             }
 
             String email = claims.getStringClaim("email");
 
+            log.info("[OidcVerify] provider={} 검증 성공", getProvider());
             return new OidcUserInfo(subject, email);
 
         } catch (ProjectException e) {
             throw e;
         } catch (Exception e) {
+            log.warn("[OidcVerify] provider={} 검증 실패: {}", getProvider(), e.getClass().getSimpleName());
             throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN, e);
         }
     }

--- a/src/main/java/com/umc/halo/domain/member/oauth/AbstractOidcProvider.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/AbstractOidcProvider.java
@@ -76,7 +76,7 @@ public abstract class AbstractOidcProvider {
         } catch (ProjectException e) {
             throw e;
         } catch (Exception e) {
-            throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN, e);
         }
     }
 }

--- a/src/main/java/com/umc/halo/domain/member/oauth/OidcJwksClient.java
+++ b/src/main/java/com/umc/halo/domain/member/oauth/OidcJwksClient.java
@@ -47,7 +47,7 @@ public class OidcJwksClient {
         } catch (ProjectException e) {
             throw e;
         } catch (Exception e) {
-            throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN);
+            throw new ProjectException(AuthErrorCode.INVALID_PROVIDER_TOKEN, e);
         }
     }
 

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -77,7 +77,11 @@ public class MemberService {
         OidcUserInfo oidcUserInfo = oidcProvider.verify(dto.providerToken());
 
         // DB에 회원 저장
-        return memberWriter.persist(provider, oidcUserInfo);
+        MemberResDTO.Login result = memberWriter.persist(provider, oidcUserInfo);
+
+        log.info("로그인 성공. provider={}, isNewUser={}", provider, result.isNewUser());
+
+        return result;
     }
 
     @Transactional

--- a/src/main/java/com/umc/halo/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/halo/domain/member/service/MemberService.java
@@ -70,7 +70,7 @@ public class MemberService {
         try {
             provider = Provider.valueOf(dto.provider());
         } catch (IllegalArgumentException e) {
-            throw new ProjectException(AuthErrorCode.UNSUPPORTED_PROVIDER);
+            throw new ProjectException(AuthErrorCode.UNSUPPORTED_PROVIDER, e);
         }
 
         AbstractOidcProvider oidcProvider = oidcProviderFactory.getProvider(provider);

--- a/src/main/java/com/umc/halo/domain/notification/exception/AnniversaryException.java
+++ b/src/main/java/com/umc/halo/domain/notification/exception/AnniversaryException.java
@@ -8,4 +8,8 @@ public class AnniversaryException extends ProjectException {
     public AnniversaryException(AnniversaryErrorCode errorCode) {
         super(errorCode);
     }
+
+    public AnniversaryException(AnniversaryErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/exception/OnboardingException.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/exception/OnboardingException.java
@@ -7,4 +7,8 @@ public class OnboardingException extends ProjectException {
     public OnboardingException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public OnboardingException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/domain/record/exception/RecordException.java
+++ b/src/main/java/com/umc/halo/domain/record/exception/RecordException.java
@@ -7,4 +7,8 @@ public class RecordException extends ProjectException {
     public RecordException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public RecordException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/domain/record/service/ChapterRecordWriter.java
+++ b/src/main/java/com/umc/halo/domain/record/service/ChapterRecordWriter.java
@@ -84,7 +84,7 @@ public class ChapterRecordWriter {
                 memberChapter = RecordConverter.toMemberChapter(member, chapter, sceneCard, recordReqDTO, imageKey);
                 memberChapterRepository.save(memberChapter);
             } catch (DataIntegrityViolationException e) {
-                throw new RecordException(RecordErrorCode.DUPLICATE_MEMBER_CHAPTER);
+                throw new RecordException(RecordErrorCode.DUPLICATE_MEMBER_CHAPTER, e);
             }
         } else {
             if (validated.reuseExistingImage()) {

--- a/src/main/java/com/umc/halo/domain/setting/exception/SettingException.java
+++ b/src/main/java/com/umc/halo/domain/setting/exception/SettingException.java
@@ -7,4 +7,8 @@ public class SettingException extends ProjectException {
     public SettingException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public SettingException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/domain/term/exception/TermException.java
+++ b/src/main/java/com/umc/halo/domain/term/exception/TermException.java
@@ -7,4 +7,8 @@ public class TermException extends ProjectException {
     public TermException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public TermException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/global/ai/AiClient.java
+++ b/src/main/java/com/umc/halo/global/ai/AiClient.java
@@ -43,7 +43,7 @@ public class AiClient {
 
             return response.getText();
         } catch (RestClientException e) {
-            throw new AiException(AiErrorCode.AI_GENERATE_FAILED);
+            throw new AiException(AiErrorCode.AI_GENERATE_FAILED, e);
         }
     }
 }

--- a/src/main/java/com/umc/halo/global/ai/exception/AiException.java
+++ b/src/main/java/com/umc/halo/global/ai/exception/AiException.java
@@ -7,4 +7,8 @@ public class AiException extends ProjectException {
     public AiException(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    public AiException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
 }

--- a/src/main/java/com/umc/halo/global/apiPayload/exception/ProjectException.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/exception/ProjectException.java
@@ -6,10 +6,15 @@ import lombok.Getter;
 
 @Getter
 public class ProjectException extends RuntimeException {
-	private final BaseErrorCode errorCode;
+    private final BaseErrorCode errorCode;
 
-	public ProjectException(BaseErrorCode errorCode) {
-		super(errorCode.getMessage());
-		this.errorCode = errorCode;
-	}
+    public ProjectException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ProjectException(BaseErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -59,7 +59,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     // 유니크 제약
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Object> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
-        log.warn("[DataIntegrityViolationException] DB 제약조건 위배: {}", ex.getMessage(), ex);
+        log.warn("[DataIntegrityViolationException] DB 제약조건 위배: {}", maskDetail(ex.getMessage()));
 
         BaseErrorCode errorCode = GeneralErrorCode.CONFLICT;
         return ResponseEntity.status(errorCode.getStatus())
@@ -111,7 +111,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleHttpMessageNotReadable(
             HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("[HttpMessageNotReadableException] JSON 파싱 실패: {}", ex.getMessage(), ex);
+        log.warn("[HttpMessageNotReadableException] JSON 파싱 실패: {}", maskDetail(ex.getMessage()));
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
@@ -160,9 +160,9 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     protected @Nullable ResponseEntity<Object> handleTypeMismatch(
             TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         if (ex instanceof MethodArgumentTypeMismatchException matEx) {
-            log.warn("[MethodArgumentTypeMismatchException] 타입 불일치: parameter={}, value={}", matEx.getName(), matEx.getValue(), ex);
+            log.warn("[MethodArgumentTypeMismatchException] 타입 불일치: parameter={}, value={}", matEx.getName(), maskDetail(String.valueOf(matEx.getValue())));
         } else {
-            log.warn("[TypeMismatchException] 타입 불일치: property={}", ex.getPropertyName(), ex);
+            log.warn("[TypeMismatchException] 타입 불일치: property={}", ex.getPropertyName());
         }
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
@@ -206,7 +206,11 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleExceptionInternal(
             Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
-        log.warn("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, ex.getMessage(), ex);
+        if (statusCode.is4xxClientError()) {
+            log.warn("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, maskDetail(ex.getMessage()));
+        } else {
+            log.warn("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, ex.getMessage(), ex);
+        }
 
         ApiResponse<Object> response = new ApiResponse<>(
                 false,
@@ -216,5 +220,14 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
         );
 
         return super.handleExceptionInternal(ex, response, headers, statusCode, request);
+    }
+
+    // 4xx 예외 로그에서 DB 상세정보/요청 입력값 등 민감정보 노출을 막기 위해 마스킹
+    private static String maskDetail(@Nullable String message) {
+        if (message == null) {
+            return "(no message)";
+        }
+        return message.replaceAll("'[^']*'", "'***'")
+                .replaceAll("\"[^\"]*\"", "\"***\"");
     }
 }

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -29,7 +29,12 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ProjectException.class)
     public ResponseEntity<ApiResponse<Void>> handleProjectException(ProjectException ex) {
         BaseErrorCode errorCode = ex.getErrorCode();
-        log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage(), ex);
+        if (ex.getCause() != null) {
+            log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage(), ex);
+        } else {
+            log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage());
+        }
+
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.onFailure(errorCode, null));
     }

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -7,6 +7,7 @@ import jakarta.validation.*;
 import lombok.extern.slf4j.*;
 import org.jspecify.annotations.*;
 import org.springframework.beans.*;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.*;
 import org.springframework.http.*;
 import org.springframework.http.converter.*;
@@ -19,6 +20,7 @@ import org.springframework.web.method.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.*;
 import org.springframework.web.servlet.resource.*;
 
+import java.sql.SQLException;
 import java.util.*;
 
 @Slf4j
@@ -29,10 +31,12 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ProjectException.class)
     public ResponseEntity<ApiResponse<Void>> handleProjectException(ProjectException ex) {
         BaseErrorCode errorCode = ex.getErrorCode();
-        if (ex.getCause() != null) {
-            log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage(), ex);
-        } else {
+        if (ex.getCause() == null) {
             log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage());
+        } else if (errorCode.getStatus().is4xxClientError()) {
+            log.warn("[{}] {}: {} (cause={})", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage(), causeDetail(ex.getCause()));
+        } else {
+            log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage(), ex);
         }
 
         return ResponseEntity.status(errorCode.getStatus())
@@ -59,9 +63,10 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     // 유니크 제약
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Object> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
-        log.warn("[DataIntegrityViolationException] DB 제약조건 위배: {}", maskDetail(ex.getMessage()));
-
         BaseErrorCode errorCode = GeneralErrorCode.CONFLICT;
+        String detail = ex.getCause() != null ? causeDetail(ex.getCause()) : "원인 없음";
+        log.warn("[DataIntegrityViolationException] {}: {}", errorCode.getCode(), detail);
+
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.onFailure(errorCode, null));
     }
@@ -111,7 +116,8 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleHttpMessageNotReadable(
             HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("[HttpMessageNotReadableException] JSON 파싱 실패: {}", maskDetail(ex.getMessage()));
+        Throwable cause = ex.getCause();
+        log.warn("[HttpMessageNotReadableException] JSON 파싱 실패: cause={}", cause != null ? cause.getClass().getSimpleName() : "unknown");
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
@@ -160,7 +166,9 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     protected @Nullable ResponseEntity<Object> handleTypeMismatch(
             TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         if (ex instanceof MethodArgumentTypeMismatchException matEx) {
-            log.warn("[MethodArgumentTypeMismatchException] 타입 불일치: parameter={}, value={}", matEx.getName(), maskDetail(String.valueOf(matEx.getValue())));
+            Object value = matEx.getValue();
+            String valueType = value != null ? value.getClass().getSimpleName() : "null";
+            log.warn("[MethodArgumentTypeMismatchException] 타입 불일치: parameter={}, valueType={}", matEx.getName(), valueType);
         } else {
             log.warn("[TypeMismatchException] 타입 불일치: property={}", ex.getPropertyName());
         }
@@ -207,7 +215,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     protected @Nullable ResponseEntity<Object> handleExceptionInternal(
             Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
         if (statusCode.is4xxClientError()) {
-            log.warn("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, maskDetail(ex.getMessage()));
+            log.warn("[{}] {}", ex.getClass().getSimpleName(), statusCode);
         } else {
             log.warn("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, ex.getMessage(), ex);
         }
@@ -222,12 +230,12 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
         return super.handleExceptionInternal(ex, response, headers, statusCode, request);
     }
 
-    // 4xx 예외 로그에서 DB 상세정보/요청 입력값 등 민감정보 노출을 막기 위해 마스킹
-    private static String maskDetail(@Nullable String message) {
-        if (message == null) {
-            return "(no message)";
+    // DB 상세정보 노출 없이 원인 예외가 어떤 종류인지만
+    private static String causeDetail(Throwable cause) {
+        Throwable root = NestedExceptionUtils.getMostSpecificCause(cause);
+        if (root instanceof SQLException sqlEx) {
+            return "sqlState=%s, vendorCode=%d".formatted(sqlEx.getSQLState(), sqlEx.getErrorCode());
         }
-        return message.replaceAll("'[^']*'", "'***'")
-                .replaceAll("\"[^\"]*\"", "\"***\"");
+        return root.getClass().getSimpleName();
     }
 }

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -29,7 +29,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(ProjectException.class)
     public ResponseEntity<ApiResponse<Void>> handleProjectException(ProjectException ex) {
         BaseErrorCode errorCode = ex.getErrorCode();
-        log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage());
+        log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage(), ex);
         return ResponseEntity.status(errorCode.getStatus())
                 .body(ApiResponse.onFailure(errorCode, null));
     }
@@ -54,7 +54,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     // 유니크 제약
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Object> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
-        log.warn("[DataIntegrityViolationException] DB 제약조건 위배: {}", ex.getMessage());
+        log.warn("[DataIntegrityViolationException] DB 제약조건 위배: {}", ex.getMessage(), ex);
 
         BaseErrorCode errorCode = GeneralErrorCode.CONFLICT;
         return ResponseEntity.status(errorCode.getStatus())
@@ -106,7 +106,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleHttpMessageNotReadable(
             HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        log.warn("[HttpMessageNotReadableException] JSON 파싱 실패: {}", ex.getMessage());
+        log.warn("[HttpMessageNotReadableException] JSON 파싱 실패: {}", ex.getMessage(), ex);
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
         return ResponseEntity.status(errorCode.getStatus())
@@ -155,9 +155,9 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     protected @Nullable ResponseEntity<Object> handleTypeMismatch(
             TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
         if (ex instanceof MethodArgumentTypeMismatchException matEx) {
-            log.warn("[MethodArgumentTypeMismatchException] 타입 불일치: parameter={}, value={}", matEx.getName(), matEx.getValue());
+            log.warn("[MethodArgumentTypeMismatchException] 타입 불일치: parameter={}, value={}", matEx.getName(), matEx.getValue(), ex);
         } else {
-            log.warn("[TypeMismatchException] 타입 불일치: property={}", ex.getPropertyName());
+            log.warn("[TypeMismatchException] 타입 불일치: property={}", ex.getPropertyName(), ex);
         }
 
         BaseErrorCode errorCode = GeneralErrorCode.BAD_REQUEST;
@@ -201,7 +201,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected @Nullable ResponseEntity<Object> handleExceptionInternal(
             Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
-        log.warn("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, ex.getMessage());
+        log.warn("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, ex.getMessage(), ex);
 
         ApiResponse<Object> response = new ApiResponse<>(
                 false,

--- a/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -36,7 +36,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
         } else if (errorCode.getStatus().is4xxClientError()) {
             log.warn("[{}] {}: {} (cause={})", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage(), causeDetail(ex.getCause()));
         } else {
-            log.warn("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage(), ex);
+            log.error("[{}] {}: {}", ex.getClass().getSimpleName(), errorCode.getCode(), errorCode.getMessage(), ex);
         }
 
         return ResponseEntity.status(errorCode.getStatus())
@@ -217,7 +217,7 @@ public class GeneralExceptionAdvice extends ResponseEntityExceptionHandler {
         if (statusCode.is4xxClientError()) {
             log.warn("[{}] {}", ex.getClass().getSimpleName(), statusCode);
         } else {
-            log.warn("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, ex.getMessage(), ex);
+            log.error("[{}] {} - {}", ex.getClass().getSimpleName(), statusCode, ex.getMessage(), ex);
         }
 
         ApiResponse<Object> response = new ApiResponse<>(

--- a/src/main/java/com/umc/halo/global/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAccessDeniedHandler.java
@@ -3,20 +3,21 @@ package com.umc.halo.global.security;
 import com.umc.halo.global.apiPayload.code.GeneralErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.MediaType;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 @Component
+@Slf4j
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException {
+        log.warn("권한 없는 요청. uri={}, message={}", request.getRequestURI(), accessDeniedException.getMessage());
         SecurityResponseWriter.write(response, GeneralErrorCode.FORBIDDEN);
     }
 }

--- a/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAuthFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Collections;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthFilter extends OncePerRequestFilter {
@@ -36,17 +38,32 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String token = header.substring(7); // "Bearer " 제거
 
-        // 유효한 토큰이면 인증 객체를 만들어 SecurityContext에 저장
-        if (jwtUtil.isValid(token) && !jwtUtil.isRefreshToken(token)) {
-            Long memberId = jwtUtil.getMemberId(token);
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(
-                            memberId,
-                            null,
-                            Collections.emptyList() // 권한 목록 (role 구분 없어 현재 비움)
-                    );
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        if (!jwtUtil.isValid(token)) {
+            if (jwtUtil.isExpired(token)) {
+                log.debug("[JwtAuthFilter] 만료된 토큰: uri={}", request.getRequestURI());
+            } else {
+                log.warn("[JwtAuthFilter] 유효하지 않은 토큰(서명/형식 오류): uri={}", request.getRequestURI());
+            }
+            filterChain.doFilter(request, response);
+            return;
         }
+
+        if (jwtUtil.isRefreshToken(token)) {
+            log.warn("[JwtAuthFilter] accessToken 자리에 refreshToken 사용 시도: uri={}", request.getRequestURI());
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 유효한 토큰이면 인증 객체를 만들어 SecurityContext에 저장
+        Long memberId = jwtUtil.getMemberId(token);
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        memberId,
+                        null,
+                        Collections.emptyList() // 권한 목록 (role 구분 없어 현재 비움)
+                );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.debug("[JwtAuthFilter] 인증 성공: memberId={}, uri={}", memberId, request.getRequestURI());
         // 토큰이 유효하지 않아도 여기선 에러 응답 안 만듦 → Private면 뒤에서 차단됨
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/umc/halo/global/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc/halo/global/security/JwtAuthenticationEntryPoint.java
@@ -3,20 +3,21 @@ package com.umc.halo.global.security;
 import com.umc.halo.global.apiPayload.code.GeneralErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.MediaType;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 @Component
+@Slf4j
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
+        log.warn("인증되지 않은 요청. uri={}, message={}", request.getRequestURI(), authException.getMessage());
         response.setHeader("WWW-Authenticate", "Bearer realm=\"halo\"");
         SecurityResponseWriter.write(response, GeneralErrorCode.UNAUTHORIZED);
     }

--- a/src/main/java/com/umc/halo/global/security/JwtUtil.java
+++ b/src/main/java/com/umc/halo/global/security/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.umc.halo.global.security;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -63,6 +64,18 @@ public class JwtUtil {
     public boolean isValid(String token) {
         try {
             getClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // 단순 만료로 인해 무효인지 확인 (로그용)
+    public boolean isExpired(String token) {
+        try {
+            getClaims(token);
+            return false;
+        } catch (ExpiredJwtException e) {
             return true;
         } catch (JwtException | IllegalArgumentException e) {
             return false;


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 예외 발생 시 원본 예외(cause)가 유실되지 않도록 예외 처리 구조를 개선
- 인증/보안 관련 주요 지점에 로그를 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `ProjectException`: `cause`를 받는 생성자를 추가
  - `ChapterException`, `StorybookException`, `ExhibitionException`, `ImageException`, `MemberException`, `AnniversaryException`, `OnboardingException`, `RecordException`, `SettingException`, `TermException`, `AiException` 등 하위 예외 클래스에도 `cause` 생성자 추가
- `AbstractOidcProvider`, `OidcJwksClient`(OIDC), `MemberService`(회원가입/로그인), `ImageService`(S3), `AiClient`(Gemini): 원본 예외를 `cause`로 전달하도록 수정
- `GeneralExceptionAdvice`: 예외 로깅 시 필요한 경우 예외 객체 전체(`ex`)를 함께 로깅하도록 수정하여 스택트레이스 추적이 가능하도록 개선
- `JwtAccessDeniedHandler`, `JwtAuthenticationEntryPoint`: 인가 실패(403)/인증 실패(401) 발생 시 요청 URI와 예외 메시지 로깅
- `MemberService`의 로그인 처리 로직에 로그인 성공 시 provider, 신규 가입 여부(`isNewUser`)를 로깅
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 401
<img width="1447" height="27" alt="image" src="https://github.com/user-attachments/assets/b1bf6da9-1378-485f-a8a3-9292e9e78dc0" />

- 로그인 실패
<img width="1418" height="336" alt="image" src="https://github.com/user-attachments/assets/276968a7-752d-4a8d-a472-fb4553c3bace" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #212
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- pr #198 dev 병합 이후(충돌 해결 이후) 병합 필요
  - 실제 이 pr의 작업 범위는 `21fa9e0fc3ab333031bfebebd97b9c2a77b2c916` 부터


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 장 기록 저장과 이미지 처리를 안정화했습니다.
  * 이미지 업로드 후 응답을 먼저 제공하고 최종 처리는 비동기로 진행합니다.
  * 신규·기존 회원 로그인 처리를 안정화했습니다.
  * 기념일 D-7 및 당일 알림을 함께 관리합니다.
  * 인증 토큰 만료와 오류를 구분해 처리합니다.

* **버그 수정**
  * 동시 요청으로 인한 회원·기록 중복 처리를 개선했습니다.
  * 이미지 처리 실패 시 불필요한 삭제를 방지합니다.
  * 예외 원인과 인증·권한 오류 기록을 강화했습니다.

* **테스트**
  * 이미지, 로그인, 기록, 알림 및 트랜잭션 테스트를 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->