### PR TITLE
[fix] prod 환경에서 Hibernate SQL 로그 차단

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,6 +3,11 @@ spring:
     activate:
       on-profile: dev
 
+logging:
+  level:
+    root: info
+    org.hibernate.SQL: !!str debug
+
 springdoc:
   api-docs:
     enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,6 +3,11 @@ spring:
     activate:
       on-profile: local
 
+logging:
+  level:
+    root: info
+    org.hibernate.SQL: !!str debug
+
 springdoc:
   api-docs:
     enabled: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,7 +8,8 @@ spring:
 
 
 logging:
-  org.hibernate.SQL: !!str info
+  level:
+    org.hibernate.SQL: !!str info
 
 springdoc:
   api-docs:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -3,6 +3,13 @@ spring:
     activate:
       on-profile: prod
 
+  jpa:
+    show-sql: false
+
+
+logging:
+  org.hibernate.SQL: !!str info
+
 springdoc:
   api-docs:
     enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,6 @@ spring:
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
-    show-sql: true
     hibernate:
       ddl-auto: validate
 
@@ -35,7 +34,6 @@ spring:
 logging:
   level:
     root: info
-    org.hibernate.SQL: !!str debug
 
 # 프로필별로 명시적으로 켜는 곳(dev/local)에서만 노출, 그 외엔 기본 차단
 springdoc:


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
-  prod  환경에서 Hibernate가 실행하는 SQL이 로그에 그대로 남던 문제를 수정
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
  - `src/main/resources/application.yml`: `spring.jpa.show-sql`, `logging.level.org.hibernate.SQL` 제거 (base를 안전한 기본값으로 변경)                                                                                          
  - `src/main/resources/application-dev.yml`: `logging.level.org.hibernate.SQL: debug` 추가                                                                                                                                      
  - `src/main/resources/application-local.yml`: `logging.level.org.hibernate.SQL: debug` 추가                                                                                                                                    
  - `src/main/resources/application-prod.yml`: `spring.jpa.show-sql: false`, `logging.level.org.hibernate.SQL: info` 명시적으로 추가 (base 변경에 대한 회귀 방지) 
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

- close #214
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-
