### PR TITLE
[fix] 반복 기념일 윤년(2/29) 다음해 계산 크래시 방지 및 중복 로직 공통화

### DIFF
--- a/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
@@ -64,29 +64,23 @@ public class Anniversary extends BaseEntity {
 
     // 반복 기념일의 다음(오늘 이후) 발생일 계산. 윤년(2/29) 기념일은 평년엔 2/28로 대체
     public LocalDate resolveNextOccurrence(LocalDate today) {
-
         if (!Boolean.TRUE.equals(isRepeated)) {
             return anniversaryDate.isBefore(today) ? null : anniversaryDate;
         }
-
-        LocalDate thisYear;
-
-        try {
-            thisYear = anniversaryDate.withYear(today.getYear());
-        } catch (DateTimeException e) {
-            log.warn("윤년 기념일 올해 날짜 계산 실패, 2/28로 대체. anniversaryId={}, year={}", id, today.getYear());
-            thisYear = LocalDate.of(today.getYear(), 2, 28);
-        }
-
+        LocalDate thisYear = resolveForYear(today.getYear());
         if (!thisYear.isBefore(today)) {
             return thisYear;
         }
+        return resolveForYear(today.getYear() + 1);
+    }
 
-        try {
-            return anniversaryDate.withYear(today.getYear() + 1);
-        } catch (DateTimeException e) {
-            log.warn("윤년 기념일 다음 해 날짜 계산 실패, 2/28로 대체. anniversaryId={}, year={}", id, today.getYear() + 1);
-            return LocalDate.of(today.getYear() + 1, 2, 28);
+    private LocalDate resolveForYear(int targetYear) {
+        if (anniversaryDate.getMonth() == Month.FEBRUARY
+                && anniversaryDate.getDayOfMonth() == 29
+                && !Year.isLeap(targetYear)) {
+            log.warn("윤년 기념일 {}년 날짜 계산, 2/28로 대체. anniversaryId={}", targetYear, id);
+            return LocalDate.of(targetYear, 2, 28);
         }
+        return anniversaryDate.withYear(targetYear);
     }
 }

--- a/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
+++ b/src/main/java/com/umc/halo/domain/notification/entity/Anniversary.java
@@ -4,9 +4,11 @@ import com.umc.halo.domain.member.entity.*;
 import com.umc.halo.global.entity.*;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.*;
 
+@Slf4j
 @Entity
 @Table(name = "anniversary")
 @Getter
@@ -58,5 +60,33 @@ public class Anniversary extends BaseEntity {
         this.sevenDaysAlarmEnabled = sevenDaysAlarmEnabled;
         this.dayAlarmEnabled = dayAlarmEnabled;
         this.memo = memo;
+    }
+
+    // 반복 기념일의 다음(오늘 이후) 발생일 계산. 윤년(2/29) 기념일은 평년엔 2/28로 대체
+    public LocalDate resolveNextOccurrence(LocalDate today) {
+
+        if (!Boolean.TRUE.equals(isRepeated)) {
+            return anniversaryDate.isBefore(today) ? null : anniversaryDate;
+        }
+
+        LocalDate thisYear;
+
+        try {
+            thisYear = anniversaryDate.withYear(today.getYear());
+        } catch (DateTimeException e) {
+            log.warn("윤년 기념일 올해 날짜 계산 실패, 2/28로 대체. anniversaryId={}, year={}", id, today.getYear());
+            thisYear = LocalDate.of(today.getYear(), 2, 28);
+        }
+
+        if (!thisYear.isBefore(today)) {
+            return thisYear;
+        }
+
+        try {
+            return anniversaryDate.withYear(today.getYear() + 1);
+        } catch (DateTimeException e) {
+            log.warn("윤년 기념일 다음 해 날짜 계산 실패, 2/28로 대체. anniversaryId={}, year={}", id, today.getYear() + 1);
+            return LocalDate.of(today.getYear() + 1, 2, 28);
+        }
     }
 }

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -1,6 +1,5 @@
 package com.umc.halo.domain.notification.service;
 
-import com.github.usingsky.calendar.KoreanLunarCalendar;
 import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.member.exception.MemberException;
 import com.umc.halo.domain.member.exception.code.MemberErrorCode;
@@ -17,6 +16,7 @@ import com.umc.halo.domain.notification.repository.CommonAnniversaryRepository;
 import com.umc.halo.domain.notification.repository.NotificationRepository;
 import com.umc.halo.global.ai.event.AnniversaryCreatedEvent;
 import com.umc.halo.global.ai.event.AnniversaryUpdatedEvent;
+import com.umc.halo.global.util.AnniversaryOccurrenceResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -69,7 +69,7 @@ public class AnniversaryService {
     ) {
         List<AnniversaryResDTO.Upcoming> upcomingFromMyAnniversaries = myAnniversaryEntities.stream()
                 .map(anniversary -> {
-                    LocalDate nextOccurrence = resolveNextOccurrence(anniversary, today);
+                    LocalDate nextOccurrence = AnniversaryOccurrenceResolver.resolveNextOccurrence(anniversary, today);
                     if (nextOccurrence == null) {
                         return null;
                     }
@@ -99,35 +99,11 @@ public class AnniversaryService {
         if (!Boolean.TRUE.equals(anniversary.getIsLunar())) {
             return anniversary.getAnniversaryDate();
         }
-        LocalDate converted = convertLunarToSolar(
+        LocalDate converted = AnniversaryOccurrenceResolver.convertLunarToSolar(
                 anniversary.getAnniversaryDate().getYear(),
                 anniversary.getAnniversaryDate().getMonthValue(),
                 anniversary.getAnniversaryDate().getDayOfMonth());
         return converted != null ? converted : anniversary.getAnniversaryDate();
-    }
-
-    private LocalDate resolveNextOccurrence(Anniversary anniversary, LocalDate today) {
-        if (Boolean.TRUE.equals(anniversary.getIsLunar())) {
-            return resolveNextOccurrenceLunar(anniversary, today);
-        }
-        return anniversary.resolveNextOccurrence(today);
-    }
-
-    private LocalDate resolveNextOccurrenceLunar(Anniversary anniversary, LocalDate today) {
-        int lunarMonth = anniversary.getAnniversaryDate().getMonthValue();
-        int lunarDay = anniversary.getAnniversaryDate().getDayOfMonth();
-
-        if (!Boolean.TRUE.equals(anniversary.getIsRepeated())) {
-            LocalDate solarDate = convertLunarToSolar(anniversary.getAnniversaryDate().getYear(), lunarMonth, lunarDay);
-            return (solarDate != null && !solarDate.isBefore(today)) ? solarDate : null;
-        }
-
-        return java.util.stream.Stream.of(today.getYear() - 1, today.getYear(), today.getYear() + 1)
-                .map(year -> convertLunarToSolar(year, lunarMonth, lunarDay))
-                .filter(java.util.Objects::nonNull)
-                .filter(date -> !date.isBefore(today))
-                .min(Comparator.naturalOrder())
-                .orElse(null);
     }
 
     private LocalDate resolveNextOccurrence(CommonAnniversary commonAnniversary, LocalDate today) {
@@ -141,7 +117,7 @@ public class AnniversaryService {
 
     private LocalDate resolveNextLunarOccurrence(CommonAnniversary commonAnniversary, LocalDate today) {
         return java.util.stream.Stream.of(today.getYear() - 1, today.getYear(), today.getYear() + 1)
-                .map(year -> convertLunarToSolar(year, commonAnniversary.getMonth(), commonAnniversary.getDay()))
+                .map(year -> AnniversaryOccurrenceResolver.convertLunarToSolar(year, commonAnniversary.getMonth(), commonAnniversary.getDay()))
                 .filter(java.util.Objects::nonNull)
                 .filter(date -> !date.isBefore(today))
                 .min(Comparator.naturalOrder())
@@ -155,7 +131,7 @@ public class AnniversaryService {
         }
         LocalDate targetDate = anniversaryDate;
         if (Boolean.TRUE.equals(isLunar)) {
-            LocalDate converted = convertLunarToSolar(
+            LocalDate converted = AnniversaryOccurrenceResolver.convertLunarToSolar(
                     anniversaryDate.getYear(), anniversaryDate.getMonthValue(), anniversaryDate.getDayOfMonth());
             if (converted == null) {
                 return;
@@ -172,24 +148,10 @@ public class AnniversaryService {
         if (!Boolean.TRUE.equals(isLunar)) {
             return;
         }
-        LocalDate converted = convertLunarToSolar(
+        LocalDate converted = AnniversaryOccurrenceResolver.convertLunarToSolar(
                 anniversaryDate.getYear(), anniversaryDate.getMonthValue(), anniversaryDate.getDayOfMonth());
         if (converted == null) {
             throw new AnniversaryException(AnniversaryErrorCode.INVALID_LUNAR_DATE);
-        }
-    }
-
-    private static final Object LUNAR_CALENDAR_LOCK = new Object();
-
-    // 음력 날짜(윤달 아님)를 해당 연도의 양력 날짜로 변환. 지원 범위를 벗어나거나 변환 실패 시 null 반환
-    private LocalDate convertLunarToSolar(int lunarYear, int lunarMonth, int lunarDay) {
-        synchronized (LUNAR_CALENDAR_LOCK) {
-            KoreanLunarCalendar calendar = KoreanLunarCalendar.getInstance();
-            boolean success = calendar.setLunarDate(lunarYear, lunarMonth, lunarDay, false);
-            if (!success) {
-                return null;
-            }
-            return LocalDate.of(calendar.getSolarYear(), calendar.getSolarMonth(), calendar.getSolarDay());
         }
     }
 
@@ -293,7 +255,7 @@ public class AnniversaryService {
     }
 
     private boolean isExpiredNonRepeatingLunar(Anniversary anniversary, LocalDate today) {
-        LocalDate solarDate = convertLunarToSolar(
+        LocalDate solarDate = AnniversaryOccurrenceResolver.convertLunarToSolar(
                 anniversary.getAnniversaryDate().getYear(),
                 anniversary.getAnniversaryDate().getMonthValue(),
                 anniversary.getAnniversaryDate().getDayOfMonth());

--- a/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
+++ b/src/main/java/com/umc/halo/domain/notification/service/AnniversaryService.java
@@ -110,12 +110,7 @@ public class AnniversaryService {
         if (Boolean.TRUE.equals(anniversary.getIsLunar())) {
             return resolveNextOccurrenceLunar(anniversary, today);
         }
-        if (!Boolean.TRUE.equals(anniversary.getIsRepeated())) {
-            LocalDate date = anniversary.getAnniversaryDate();
-            return date.isBefore(today) ? null : date;
-        }
-        LocalDate thisYear = anniversary.getAnniversaryDate().withYear(today.getYear());
-        return thisYear.isBefore(today) ? anniversary.getAnniversaryDate().withYear(today.getYear() + 1) : thisYear;
+        return anniversary.resolveNextOccurrence(today);
     }
 
     private LocalDate resolveNextOccurrenceLunar(Anniversary anniversary, LocalDate today) {

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -14,6 +14,7 @@ import com.umc.halo.domain.setting.exception.SettingException;
 import com.umc.halo.domain.setting.exception.code.SettingErrorCode;
 import com.umc.halo.domain.setting.repository.BgmRepository;
 import com.umc.halo.domain.setting.repository.MemberSettingRepository;
+import com.umc.halo.global.util.AnniversaryOccurrenceResolver;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -141,7 +142,7 @@ public class SettingService {
                 continue;
             }
 
-            LocalDate nextOccurrence = anniversary.resolveNextOccurrence(today);
+            LocalDate nextOccurrence = AnniversaryOccurrenceResolver.resolveNextOccurrence(anniversary, today);
 
             if(nextOccurrence == null) {
                 continue;
@@ -189,7 +190,7 @@ public class SettingService {
                 continue;
             }
 
-            LocalDate nextOccurrence = anniversary.resolveNextOccurrence(today);
+            LocalDate nextOccurrence = AnniversaryOccurrenceResolver.resolveNextOccurrence(anniversary, today);
 
             if(nextOccurrence == null) {
                 continue;
@@ -259,7 +260,7 @@ public class SettingService {
         List<Notification> notifications = notificationRepository.findByMemberIdAndNotificationTypeAndStatusIn(memberId, NotificationType.COMMON_ANNIVERSARY, List.of(NotificationStatus.SCHEDULED, NotificationStatus.EXPIRED));
 
         for (Notification notification : notifications) {
-                notification.updateSettingEnabled(enabled);
+            notification.updateSettingEnabled(enabled);
         }
     }
 }

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -22,10 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.DateTimeException;
+import lombok.extern.slf4j.Slf4j;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SettingService {
@@ -275,9 +278,20 @@ public class SettingService {
 
         try {
             thisYear = anniversaryDate.withYear(today.getYear());
-        } catch (Exception e) {
+        } catch (DateTimeException e) {
+            log.warn("윤년 기념일 올해 날짜 계산 실패, 2/28로 대체. anniversaryId={}, year={}", anniversary.getId(), today.getYear());
             thisYear = LocalDate.of(today.getYear(), 2, 28);
         }
-        return thisYear.isBefore(today) ? anniversaryDate.withYear(today.getYear() + 1) : thisYear;
+
+        if (!thisYear.isBefore(today)) {
+            return thisYear;
+        }
+
+        try {
+            return anniversaryDate.withYear(today.getYear() + 1);
+        } catch (DateTimeException e) {
+            log.warn("윤년 기념일 다음 해 날짜 계산 실패, 2/28로 대체. anniversaryId={}, year={}", anniversary.getId(), today.getYear() + 1);
+            return LocalDate.of(today.getYear() + 1, 2, 28);
+        }
     }
 }

--- a/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
+++ b/src/main/java/com/umc/halo/domain/setting/service/SettingService.java
@@ -22,13 +22,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.DateTimeException;
-import lombok.extern.slf4j.Slf4j;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Objects;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SettingService {
@@ -144,7 +141,7 @@ public class SettingService {
                 continue;
             }
 
-            LocalDate nextOccurrence = resolveNextOccurrence(anniversary, today);
+            LocalDate nextOccurrence = anniversary.resolveNextOccurrence(today);
 
             if(nextOccurrence == null) {
                 continue;
@@ -192,7 +189,7 @@ public class SettingService {
                 continue;
             }
 
-            LocalDate nextOccurrence = resolveNextOccurrence(anniversary, today);
+            LocalDate nextOccurrence = anniversary.resolveNextOccurrence(today);
 
             if(nextOccurrence == null) {
                 continue;
@@ -263,35 +260,6 @@ public class SettingService {
 
         for (Notification notification : notifications) {
                 notification.updateSettingEnabled(enabled);
-        }
-    }
-
-    private LocalDate resolveNextOccurrence(Anniversary anniversary, LocalDate today) {
-
-        LocalDate anniversaryDate = anniversary.getAnniversaryDate();
-
-        if (!Boolean.TRUE.equals(anniversary.getIsRepeated())) {
-            return anniversaryDate.isBefore(today) ? null : anniversaryDate;
-        }
-
-        LocalDate thisYear;
-
-        try {
-            thisYear = anniversaryDate.withYear(today.getYear());
-        } catch (DateTimeException e) {
-            log.warn("윤년 기념일 올해 날짜 계산 실패, 2/28로 대체. anniversaryId={}, year={}", anniversary.getId(), today.getYear());
-            thisYear = LocalDate.of(today.getYear(), 2, 28);
-        }
-
-        if (!thisYear.isBefore(today)) {
-            return thisYear;
-        }
-
-        try {
-            return anniversaryDate.withYear(today.getYear() + 1);
-        } catch (DateTimeException e) {
-            log.warn("윤년 기념일 다음 해 날짜 계산 실패, 2/28로 대체. anniversaryId={}, year={}", anniversary.getId(), today.getYear() + 1);
-            return LocalDate.of(today.getYear() + 1, 2, 28);
         }
     }
 }

--- a/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
+++ b/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
@@ -15,6 +15,7 @@ import com.umc.halo.global.ai.event.AnniversaryUpdatedEvent;
 import com.umc.halo.global.ai.event.CreateNextYearNotificationEvent;
 import com.umc.halo.global.ai.exception.AiException;
 import com.umc.halo.global.ai.service.AiService;
+import com.umc.halo.global.util.AnniversaryOccurrenceResolver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -50,7 +51,7 @@ public class AnniversaryNotificationListener {
         LocalDateTime now = LocalDateTime.now();
         LocalTime notifyTime = memberSetting.getRegularNotificationTime();
 
-        LocalDate nextOccurrence = anniversary.resolveNextOccurrence(now.toLocalDate());
+        LocalDate nextOccurrence = AnniversaryOccurrenceResolver.resolveNextOccurrence(anniversary, now.toLocalDate());
         if (nextOccurrence == null) {
             return;
         }
@@ -79,7 +80,7 @@ public class AnniversaryNotificationListener {
         LocalDateTime now = LocalDateTime.now();
         LocalTime notifyTime = memberSetting.getRegularNotificationTime();
 
-        LocalDate nextOccurrence = anniversary.resolveNextOccurrence(now.toLocalDate());
+        LocalDate nextOccurrence = AnniversaryOccurrenceResolver.resolveNextOccurrence(anniversary, now.toLocalDate());
         if (nextOccurrence == null) {
             notificationTransactionService.cancelBoth(anniversary);
             return;
@@ -123,7 +124,7 @@ public class AnniversaryNotificationListener {
         LocalTime notifyTime = memberSetting.getRegularNotificationTime();
 
         LocalDateTime now = LocalDateTime.now();
-        LocalDate nextOccurrence = anniversary.resolveNextOccurrence(now.toLocalDate());
+        LocalDate nextOccurrence = AnniversaryOccurrenceResolver.resolveNextOccurrence(anniversary, now.toLocalDate());
         if (nextOccurrence == null) {
             return;
         }

--- a/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
+++ b/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
@@ -51,7 +51,7 @@ public class AnniversaryNotificationListener {
         LocalDateTime now = LocalDateTime.now();
         LocalTime notifyTime = memberSetting.getRegularNotificationTime();
 
-        LocalDate nextOccurrence = resolveNextOccurrence(anniversary, now.toLocalDate());
+        LocalDate nextOccurrence = anniversary.resolveNextOccurrence(now.toLocalDate());
         if (nextOccurrence == null) {
             return;
         }
@@ -87,7 +87,7 @@ public class AnniversaryNotificationListener {
         LocalDateTime now = LocalDateTime.now();
         LocalTime notifyTime = memberSetting.getRegularNotificationTime();
 
-        LocalDate nextOccurrence = resolveNextOccurrence(anniversary, now.toLocalDate());
+        LocalDate nextOccurrence = anniversary.resolveNextOccurrence(now.toLocalDate());
         if (nextOccurrence == null) {
             notificationTransactionService.cancelNotification(anniversary, NotificationType.ANNIVERSARY_D7);
             notificationTransactionService.cancelNotification(anniversary, NotificationType.ANNIVERSARY_DDAY);
@@ -131,7 +131,7 @@ public class AnniversaryNotificationListener {
         LocalTime notifyTime = memberSetting.getRegularNotificationTime();
 
         LocalDateTime now = LocalDateTime.now();
-        LocalDate nextOccurrence = resolveNextOccurrence(anniversary, now.toLocalDate());
+        LocalDate nextOccurrence = anniversary.resolveNextOccurrence(now.toLocalDate());
         if (nextOccurrence == null) {
             return;
         }
@@ -182,32 +182,5 @@ public class AnniversaryNotificationListener {
         }
 
         return "오늘의 따뜻한 안녕을 전해보세요.";
-    }
-
-    private LocalDate resolveNextOccurrence(Anniversary anniversary, LocalDate today) {
-
-        LocalDate anniversaryDate = anniversary.getAnniversaryDate();
-
-        if (!Boolean.TRUE.equals(anniversary.getIsRepeated())) {
-            return anniversaryDate.isBefore(today) ? null : anniversaryDate;
-        }
-
-        LocalDate thisYear;
-
-        try {
-            thisYear = anniversaryDate.withYear(today.getYear());
-        } catch (Exception e) {
-            thisYear = LocalDate.of(today.getYear(), 2, 28);
-        }
-
-        if (thisYear.isBefore(today)) {
-            try {
-                return anniversaryDate.withYear(today.getYear() + 1);
-            } catch (Exception e) {
-                return LocalDate.of(today.getYear() + 1, 2, 28);
-            }
-        }
-
-        return thisYear;
     }
 }

--- a/src/main/java/com/umc/halo/global/util/AnniversaryOccurrenceResolver.java
+++ b/src/main/java/com/umc/halo/global/util/AnniversaryOccurrenceResolver.java
@@ -1,0 +1,54 @@
+package com.umc.halo.global.util;
+
+import com.github.usingsky.calendar.KoreanLunarCalendar;
+import com.umc.halo.domain.notification.entity.Anniversary;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+public class AnniversaryOccurrenceResolver {
+
+    private static final Object LUNAR_CALENDAR_LOCK = new Object();
+
+    private AnniversaryOccurrenceResolver() {
+    }
+
+    // isLunar 여부에 따라 양력/음력 분기해서 다음 발생일 계산
+    public static LocalDate resolveNextOccurrence(Anniversary anniversary, LocalDate today) {
+        if (Boolean.TRUE.equals(anniversary.getIsLunar())) {
+            return resolveNextOccurrenceLunar(anniversary, today);
+        }
+        return anniversary.resolveNextOccurrence(today);
+    }
+
+    private static LocalDate resolveNextOccurrenceLunar(Anniversary anniversary, LocalDate today) {
+        int lunarMonth = anniversary.getAnniversaryDate().getMonthValue();
+        int lunarDay = anniversary.getAnniversaryDate().getDayOfMonth();
+
+        if (!Boolean.TRUE.equals(anniversary.getIsRepeated())) {
+            LocalDate solarDate = convertLunarToSolar(anniversary.getAnniversaryDate().getYear(), lunarMonth, lunarDay);
+            return (solarDate != null && !solarDate.isBefore(today)) ? solarDate : null;
+        }
+
+        return Stream.of(today.getYear() - 1, today.getYear(), today.getYear() + 1)
+                .map(year -> convertLunarToSolar(year, lunarMonth, lunarDay))
+                .filter(Objects::nonNull)
+                .filter(date -> !date.isBefore(today))
+                .min(Comparator.naturalOrder())
+                .orElse(null);
+    }
+
+    // 음력 날짜(윤달 아님)를 해당 연도의 양력 날짜로 변환. 지원 범위를 벗어나거나 변환 실패 시 null 반환
+    public static LocalDate convertLunarToSolar(int lunarYear, int lunarMonth, int lunarDay) {
+        synchronized (LUNAR_CALENDAR_LOCK) {
+            KoreanLunarCalendar calendar = KoreanLunarCalendar.getInstance();
+            boolean success = calendar.setLunarDate(lunarYear, lunarMonth, lunarDay, false);
+            if (!success) {
+                return null;
+            }
+            return LocalDate.of(calendar.getSolarYear(), calendar.getSolarMonth(), calendar.getSolarDay());
+        }
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 반복 기념일이 2/29(윤년)일 때 다음 해가 평년이면 DateTimeException이 그대로 터져서 기념일 목록 조회/알림 설정 변경이 500 에러로 실패하는 버그 수정. 또한 동일 로직이 3곳(SettingService, AnniversaryNotificationListener, AnniversaryService)에 중복 구현돼 있던 것을 Anniversary 엔티티 메서드로 공통화함.

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.

- `Anniversary.java` : resolveNextOccurrence(LocalDate today) 메서드 추가 (윤년 날짜 계산 시 DateTimeException 발생하면 2/28로 대체, log.warn 추가)
- `SettingService.java` : 중복된 private resolveNextOccurrence() 삭제, anniversary.resolveNextOccurrence() 호출로 교체
- `AnniversaryNotificationListener.java` : 동일하게 중복 메서드 삭제 및 호출부 교체
- `AnniversaryService.java` : 양력 계산 부분만 anniversary.resolveNextOccurrence()로 위임 (음력 분기는 유지)

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)

- 2024-02-29, isRepeated=true 기념일 생성 → 200 성공
<img width="824" height="1017" alt="스크린샷 2026-08-10 오후 4 38 13" src="https://github.com/user-attachments/assets/117951f8-615e-4596-be14-8b160db107b8" />

- 이후 기념일 목록 조회(GET) → 200, 500 발생 안 함
<img width="868" height="1061" alt="스크린샷 2026-08-10 오후 4 38 34" src="https://github.com/user-attachments/assets/396d944f-2d30-4610-b291-9097eaa67921" />

- 알림 설정 변경(PUT) → 200, 500 발생 안 함
<img width="824" height="1017" alt="스크린샷 2026-08-10 오후 4 42 18" src="https://github.com/user-attachments/assets/4edcf73d-1592-431c-bfe4-5db0e76e7ded" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #217
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.

- 같은 회귀를 막기 위해 중복 로직을 Anniversary 엔티티로 공통화함 (#178 때 MemberStorybook.resolveDisplayChapterOrder() 만든 패턴과 동일)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 반복 기념일의 다음 발생일을 보다 일관되게 계산합니다.
  * 오늘 이전의 비반복 기념일은 다음 발생일이 없는 것으로 처리합니다.
  * 윤년이 아닌 해의 2월 29일 기념일은 2월 28일로 자동 보정됩니다.
  * 양력·음력 기념일의 알림 및 일정 갱신에 동일한 계산 기준이 적용됩니다.
  * 음력 변환이 지원 범위를 벗어나거나 실패하는 경우 안전하게 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->