### PR TITLE
[refactor] StorybookService N+1 쿼리 개선 (getStorybookList, getHome)

### DIFF
--- a/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
@@ -154,8 +154,16 @@ public class StorybookService {
         Map<Long, MemberStorybook> memberStorybookMap = memberStorybookRepository.findByMember(member).stream()
                 .collect(Collectors.toMap(ms -> ms.getStorybook().getId(), Function.identity()));
 
+        // 스토리북별 MemberChapter 배치 조회 (N+1 방지)
+        Map<Long, List<MemberChapter>> memberChaptersByStorybookId = memberChapterRepository
+                .findAllByMemberWithChapter(member).stream()
+                .collect(Collectors.groupingBy(mc -> mc.getChapter().getStorybook().getId()));
+
         List<StorybookResDTO.StorybookSummary> storybookSummaries = storybooks.stream()
-                .map(storybook -> buildStorybookSummary(member, storybook, memberStorybookMap.get(storybook.getId())))
+                .map(storybook -> buildStorybookSummary(
+                        storybook,
+                        memberStorybookMap.get(storybook.getId()),
+                        memberChaptersByStorybookId.getOrDefault(storybook.getId(), List.of())))
                 .toList();
 
         List<StorybookResDTO.SituationalRecommendation> situationalRecommendations =
@@ -232,6 +240,11 @@ public class StorybookService {
         Map<Long, MemberStorybook> memberStorybookMap = memberStorybookRepository.findByMember(member).stream()
                 .collect(Collectors.toMap(ms -> ms.getStorybook().getId(), Function.identity()));
 
+        // 스토리북별 MemberChapter 배치 조회 (N+1 방지)
+        Map<Long, List<MemberChapter>> memberChaptersByStorybookId = memberChapterRepository
+                .findAllByMemberWithChapter(member).stream()
+                .collect(Collectors.groupingBy(mc -> mc.getChapter().getStorybook().getId()));
+
         // 스토리북마다 상태 계산 (목록 조회와 동일한 로직)
         Map<Storybook, StorybookStatus> statusMap = new LinkedHashMap<>();
         Map<Long, List<MemberChapter>> memberChaptersMap = new LinkedHashMap<>();
@@ -242,8 +255,7 @@ public class StorybookService {
                 continue;
             }
 
-            List<MemberChapter> memberChapters =
-                    memberChapterRepository.findByMemberAndChapter_Storybook_Id(member, sb.getId());
+            List<MemberChapter> memberChapters = memberChaptersByStorybookId.getOrDefault(sb.getId(), List.of());
             memberChaptersMap.put(sb.getId(), memberChapters);
 
             boolean completed = isCompleted(sb, memberChapters);
@@ -314,14 +326,11 @@ public class StorybookService {
     }
 
     private StorybookResDTO.StorybookSummary buildStorybookSummary(
-            Member member, Storybook storybook, MemberStorybook memberStorybook) {
+            Storybook storybook, MemberStorybook memberStorybook, List<MemberChapter> memberChapters) {
 
         if (memberStorybook == null) {
             return StorybookConverter.toStorybookSummary(storybook, StorybookStatus.NOT_STARTED, null, null);
         }
-
-        List<MemberChapter> memberChapters =
-                memberChapterRepository.findByMemberAndChapter_Storybook_Id(member, storybook.getId());
 
         boolean completed = isCompleted(storybook, memberChapters);
 

--- a/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/service/StorybookService.java
@@ -159,11 +159,17 @@ public class StorybookService {
                 .findAllByMemberWithChapter(member).stream()
                 .collect(Collectors.groupingBy(mc -> mc.getChapter().getStorybook().getId()));
 
+        // 스토리북별 전체 장 개수 배치 조회 (N+1 방지)
+        Map<Long, Long> totalChapterCountByStorybookId = chapterRepository
+                .findByStorybook_IdIn(storybooks.stream().map(Storybook::getId).toList()).stream()
+                .collect(Collectors.groupingBy(c -> c.getStorybook().getId(), Collectors.counting()));
+
         List<StorybookResDTO.StorybookSummary> storybookSummaries = storybooks.stream()
                 .map(storybook -> buildStorybookSummary(
                         storybook,
                         memberStorybookMap.get(storybook.getId()),
-                        memberChaptersByStorybookId.getOrDefault(storybook.getId(), List.of())))
+                        memberChaptersByStorybookId.getOrDefault(storybook.getId(), List.of()),
+                        totalChapterCountByStorybookId.getOrDefault(storybook.getId(), 0L)))
                 .toList();
 
         List<StorybookResDTO.SituationalRecommendation> situationalRecommendations =
@@ -245,6 +251,11 @@ public class StorybookService {
                 .findAllByMemberWithChapter(member).stream()
                 .collect(Collectors.groupingBy(mc -> mc.getChapter().getStorybook().getId()));
 
+        // 스토리북별 전체 장 개수 배치 조회 (N+1 방지)
+        Map<Long, Long> totalChapterCountByStorybookId = chapterRepository
+                .findByStorybook_IdIn(storybooks.stream().map(Storybook::getId).toList()).stream()
+                .collect(Collectors.groupingBy(c -> c.getStorybook().getId(), Collectors.counting()));
+
         // 스토리북마다 상태 계산 (목록 조회와 동일한 로직)
         Map<Storybook, StorybookStatus> statusMap = new LinkedHashMap<>();
         Map<Long, List<MemberChapter>> memberChaptersMap = new LinkedHashMap<>();
@@ -258,7 +269,7 @@ public class StorybookService {
             List<MemberChapter> memberChapters = memberChaptersByStorybookId.getOrDefault(sb.getId(), List.of());
             memberChaptersMap.put(sb.getId(), memberChapters);
 
-            boolean completed = isCompleted(sb, memberChapters);
+            boolean completed = isCompleted(totalChapterCountByStorybookId.getOrDefault(sb.getId(), 0L), memberChapters);
             boolean completedToday = ms.isCompletedToday();
 
             StorybookStatus status = completed ? StorybookStatus.COMPLETED
@@ -326,13 +337,13 @@ public class StorybookService {
     }
 
     private StorybookResDTO.StorybookSummary buildStorybookSummary(
-            Storybook storybook, MemberStorybook memberStorybook, List<MemberChapter> memberChapters) {
+            Storybook storybook, MemberStorybook memberStorybook, List<MemberChapter> memberChapters, long totalChapters) {
 
         if (memberStorybook == null) {
             return StorybookConverter.toStorybookSummary(storybook, StorybookStatus.NOT_STARTED, null, null);
         }
 
-        boolean completed = isCompleted(storybook, memberChapters);
+        boolean completed = isCompleted(totalChapters, memberChapters);
 
         boolean completedToday = memberStorybook.isCompletedToday();
 
@@ -355,15 +366,17 @@ public class StorybookService {
         return isCompleted(storybook, memberChapters);
     }
 
-    private boolean isCompleted(Storybook storybook, List<MemberChapter> memberChapters) {
-        int totalChapters =
-                chapterRepository.findByStorybook_IdOrderByChapterOrderAsc(storybook.getId()).size();
-
+    private boolean isCompleted(long totalChapters, List<MemberChapter> memberChapters) {
         long completedCount = memberChapters.stream()
                 .filter(mc -> mc.getStatus() == Status.COMPLETED)
                 .count();
 
         return completedCount == totalChapters;
+    }
+
+    private boolean isCompleted(Storybook storybook, List<MemberChapter> memberChapters) {
+        long totalChapters = chapterRepository.findByStorybook_IdOrderByChapterOrderAsc(storybook.getId()).size();
+        return isCompleted(totalChapters, memberChapters);
     }
 
     private List<StorybookResDTO.SituationalRecommendation> buildSituationalRecommendations() {


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 스토리북 목록 조회(getStorybookList)와 홈 화면 조회(getHome)에서 스토리북 개수만큼 MemberChapter를 개별 조회하던 N+1 쿼리를 배치 조회로 개선

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
StorybookService.java
- buildStorybookSummary: 내부에서 memberChapterRepository.findByMemberAndChapter_Storybook_Id를 storybook마다 개별 호출하던 부분 제거, 파라미터로 List<MemberChapter>를 받도록 변경
- getStorybookList: 기존 MemberChapterRepository.findAllByMemberWithChapter(member)로 한 번에 배치 조회 후 storybookId 기준으로 그룹핑해서 사용 (새 repository 메서드 추가 없이 기존 join fetch 메서드 재사용)
- getHome: 루프 안에서 스토리북마다 개별 조회하던 부분을 동일하게 배치 조회로 교체

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- GET /api/v1/storybooks 실행 → 200, 스토리북별 status/currentChapterOrder 정상 표시
<img width="868" height="1061" alt="스크린샷 2026-08-10 오후 5 03 28" src="https://github.com/user-attachments/assets/34e908a1-f6a6-4c2f-b4cd-b24442fdc84f" />

- GET /api/v1/home 실행 → 200, bookshelf/inProgressStorybooks 데이터 정상 표시, 회귀 없음
<img width="868" height="1061" alt="스크린샷 2026-08-10 오후 5 03 18" src="https://github.com/user-attachments/assets/d09a575e-e558-4986-b5b6-f3721dcf71c4" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #218
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- getRecommendedStorybooks는 findAll() 호출이 한 번뿐이라 N+1 대상 아님(스코프 제외). getStorybookDetail, isStorybookCompleted도 단일 스토리북 대상이라 변경 없음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 스토리북 목록 및 홈 화면 조회 속도를 개선했습니다.
  * 여러 스토리북의 장 정보를 효율적으로 조회해 불필요한 반복 조회를 줄였습니다.
  * 스토리북별 진행 상태를 더 정확하게 계산합니다.
  * 스토리북의 장 표시 순서와 완료 상태가 기존과 동일하게 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->