### PR TITLE
[fix] 인프라/CI-CD 보안 취약점 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -342,6 +342,11 @@ jobs:
             sleep 5
           done
           echo "보안그룹 규칙(rule-id: $RULE_ID) 제거 최종 실패 - SSH 인그레스가 열린 채로 남아있을 수 있음, 수동 확인 필요" >&2
+          if [ -n "${{ secrets.CD_ALERTS_DISCORD_WEBHOOK_URL }}" ]; then
+            PAYLOAD=$(jq -n --arg msg "🚨 [CD/prod] 보안그룹 규칙(rule-id: $RULE_ID) 제거 최종 실패 - SSH 인그레스가 열린 채로 남아있을 수 있음, 수동 확인 필요
+              https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $msg}')
+            curl -sf -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.CD_ALERTS_DISCORD_WEBHOOK_URL }}" || echo "Discord 알림 전송 실패" >&2
+          fi
           exit 1
 
   deploy-dev:
@@ -580,4 +585,9 @@ jobs:
             sleep 5
           done
           echo "보안그룹 규칙(rule-id: $RULE_ID) 제거 최종 실패 - SSH 인그레스가 열린 채로 남아있을 수 있음, 수동 확인 필요" >&2
+          if [ -n "${{ secrets.CD_ALERTS_DISCORD_WEBHOOK_URL }}" ]; then
+            PAYLOAD=$(jq -n --arg msg "🚨 [CD/dev] 보안그룹 규칙(rule-id: $RULE_ID) 제거 최종 실패 - SSH 인그레스가 열린 채로 남아있을 수 있음, 수동 확인 필요
+            https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" '{content: $msg}')
+            curl -sf -H "Content-Type: application/json" -d "$PAYLOAD" "${{ secrets.CD_ALERTS_DISCORD_WEBHOOK_URL }}" || echo "Discord 알림 전송 실패" >&2
+          fi
           exit 1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,11 +33,6 @@ jobs:
       - name: gradlew 실행 권한 부여
         run: chmod +x gradlew
 
-      - name: Firebase service account 생성
-        run: |
-          mkdir -p src/main/resources/firebase
-          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > src/main/resources/firebase/service-account.json
-
       - name: bootJar 빌드
         run: ./gradlew bootJar
 
@@ -171,6 +166,7 @@ jobs:
           S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}
           S3_BUCKET_ACCESS_KEY=${{ secrets.S3_BUCKET_ACCESS_KEY }}
           S3_BUCKET_SECRET_KEY=${{ secrets.S3_BUCKET_SECRET_KEY }}
+          FIREBASE_SERVICE_ACCOUNT_B64=${{secrets.FIREBASE_SERVICE_ACCOUNT_B64}}
           ENVEOF
 
             if [ -n "$HTPASSWD_USER_B64" ] && [ -n "$HTPASSWD_HASH_B64" ]; then
@@ -490,6 +486,7 @@ jobs:
           S3_BUCKET_NAME=${{ secrets.DEV_S3_BUCKET_NAME }}
           S3_BUCKET_ACCESS_KEY=${{ secrets.DEV_S3_BUCKET_ACCESS_KEY }}
           S3_BUCKET_SECRET_KEY=${{ secrets.DEV_S3_BUCKET_SECRET_KEY }}
+          FIREBASE_SERVICE_ACCOUNT_B64=${{ secrets.FIREBASE_SERVICE_ACCOUNT_B64 }}
           ENVEOF
 
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       S3_BUCKET_NAME: test
       S3_BUCKET_ACCESS_KEY: test
       S3_BUCKET_SECRET_KEY: test
+      FIREBASE_SERVICE_ACCOUNT_B64: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_B64 }}
 
     steps:
       - name: 소스 체크아웃
@@ -54,11 +55,6 @@ jobs:
 
       - name: gradlew 실행 권한 부여
         run: chmod +x gradlew
-
-      - name: Firebase service account 생성
-        run: |
-          mkdir -p src/main/resources/firebase
-          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > src/main/resources/firebase/service-account.json
 
       - name: 빌드 및 테스트
         run: ./gradlew build

--- a/nginx/fragments/00-redirect.conf.template
+++ b/nginx/fragments/00-redirect.conf.template
@@ -1,3 +1,5 @@
+limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=30r/m;
+
 # 명시적 default_server: 없으면 첫 server 블록이 암묵적 default가 되어
 # 위조된 Host 헤더로 open redirect가 생길 수 있음 -> 알 수 없는 Host는 바로 끊음
 server {

--- a/nginx/fragments/10-app.conf.template
+++ b/nginx/fragments/10-app.conf.template
@@ -31,16 +31,26 @@ server {
         return 404;
     }
 
+    location = /api/v1/auth/login {
+        # 브루트포스/트래픽 폭주 방지용 rate limit
+        limit_req zone=auth_limit burst=10 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://app_upstream;
+        include /etc/nginx/fragments/proxy-common.conf;
+    }
+
+    location = /api/v1/auth/reissue {
+        # 브루트포스/트래픽 폭주 방지용 rate limit
+        limit_req zone=auth_limit burst=10 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://app_upstream;
+        include /etc/nginx/fragments/proxy-common.conf;
+    }
+
     location / {
         proxy_pass http://app_upstream;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        # 배포 중 app 컨테이너가 잠깐 교체되는 구간의 502를 흡수하기 위한 재시도
-        proxy_connect_timeout 2s;
-        proxy_next_upstream error timeout http_502 http_503 http_504;
-        proxy_next_upstream_tries 3;
+        include /etc/nginx/fragments/proxy-common.conf;
     }
 }

--- a/nginx/fragments/20-dev-app.conf.template
+++ b/nginx/fragments/20-dev-app.conf.template
@@ -36,15 +36,26 @@ server {
         return 404;
     }
 
+    location = /api/v1/auth/login {
+        # 브루트포스/트래픽 폭주 방지용 rate limit
+        limit_req zone=auth_limit burst=10 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://dev_app_upstream;
+        include /etc/nginx/fragments/proxy-common.conf;
+    }
+
+    location = /api/v1/auth/reissue {
+        # 브루트포스/트래픽 폭주 방지용 rate limit
+        limit_req zone=auth_limit burst=10 nodelay;
+        limit_req_status 429;
+
+        proxy_pass http://dev_app_upstream;
+        include /etc/nginx/fragments/proxy-common.conf;
+    }
+
     location / {
         proxy_pass http://dev_app_upstream;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-
-        proxy_connect_timeout 2s;
-        proxy_next_upstream error timeout http_502 http_503 http_504;
-        proxy_next_upstream_tries 3;
+        include /etc/nginx/fragments/proxy-common.conf;
     }
 }

--- a/nginx/fragments/proxy-common.conf
+++ b/nginx/fragments/proxy-common.conf
@@ -1,0 +1,8 @@
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+
+proxy_connect_timeout 2s;
+proxy_next_upstream error timeout http_502 http_503 http_504;
+proxy_next_upstream_tries 3;

--- a/src/main/java/com/umc/halo/global/config/FirebaseConfig.java
+++ b/src/main/java/com/umc/halo/global/config/FirebaseConfig.java
@@ -4,31 +4,35 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Base64;
 
 @Configuration
 public class FirebaseConfig {
 
+    @Value("${FIREBASE_SERVICE_ACCOUNT_B64:}")
+    private String serviceAccountB64;
+
     @PostConstruct
     public void initialize() throws IOException {
 
-        InputStream inputStream = getClass()
-                .getClassLoader()
-                .getResourceAsStream("firebase/service-account.json");
-
-        if (inputStream == null) {
-            throw new IllegalStateException("service-account.json을 찾을 수 없습니다.");
+        if (serviceAccountB64 == null || serviceAccountB64.isBlank()) {
+            throw new IllegalStateException("FIREBASE_SERVICE_ACCOUNT_B64 환경변수가 설정되지 않았습니다.");
         }
 
-        FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(inputStream))
-                .build();
+        try (InputStream inputStream = new ByteArrayInputStream(Base64.getDecoder().decode(serviceAccountB64))) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(inputStream))
+                    .build();
 
-        if (FirebaseApp.getApps().isEmpty()) {
-            FirebaseApp.initializeApp(options);
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+            }
         }
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- FirebaseConfig가 클래스패스 파일 대신 런타임 환경변수(FIREBASE_SERVICE_ACCOUNT_B64)로 키를 주입받도록 변경, CI/CD의 파일 생성 스텝 제거
- SG revoke 실패 시 Discord webhook으로 알림 추가 (DISCORD_WEBHOOK_URL 시크릿 등록 + cd.yml의 최종 실패 분기에 curl 알림 추가)
- nginx에 공개 엔드포인트(로그인/소셜 인증) 대상 limit_req 설정 추가
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 추후 수정
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #216
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Firebase 인증 정보가 환경 변수 기반으로 관리되어 배포 보안성이 향상되었습니다.
  * 인증 로그인 및 토큰 재발급 요청에 속도 제한이 적용되어 과도한 요청을 방지합니다.
  * 제한 초과 시 명확한 429 응답이 제공됩니다.
  * 공통 프록시 설정을 통해 요청 헤더 전달, 연결 시간 초과 및 재시도 동작이 일관되게 적용됩니다.
  * 클라이언트별 일반 요청 제한이 분당 30회로 조정되었습니다.
  * 배포 중 보안 규칙 정리 실패 시 선택적으로 Discord 알림을 받을 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->