### PR TITLE
[refactor] RESTful 설계 원칙에 맞춰 API 수정

### DIFF
--- a/src/main/java/com/umc/halo/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/CalendarController.java
@@ -26,6 +26,7 @@ public class CalendarController implements CalendarControllerDocs {
     private final CalendarService calendarService;
 
     // 월간
+    @Override
     @GetMapping
     public ApiResponse<CalendarMonthlyResDTO.MonthlyInfo> getMonthly(
             @AuthenticationPrincipal Long memberId, @RequestParam int year, @RequestParam int month
@@ -35,6 +36,7 @@ public class CalendarController implements CalendarControllerDocs {
     }
 
     // 일별
+    @Override
     @GetMapping("/{date}")
     public ApiResponse<CalendarDailyResDTO.DailyInfo> getDaily(
             @AuthenticationPrincipal Long memberId, @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date

--- a/src/main/java/com/umc/halo/domain/content/storybook/controller/StorybookController.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/controller/StorybookController.java
@@ -62,7 +62,7 @@ public class StorybookController implements StorybookControllerDocs {
         );
     }
 
-    @PostMapping("/storybooks/{storybookId}/start")
+    @PostMapping("/storybooks/{storybookId}/member-storybooks")
     @Override
     public ApiResponse<StorybookResDTO.StartStorybook> startStorybook(
             @PathVariable Long storybookId,

--- a/src/main/java/com/umc/halo/domain/content/storybook/controller/StorybookController.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/controller/StorybookController.java
@@ -7,6 +7,7 @@ import com.umc.halo.domain.content.storybook.exception.code.StorybookSuccessCode
 import com.umc.halo.domain.content.storybook.service.StorybookService;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -64,13 +65,12 @@ public class StorybookController implements StorybookControllerDocs {
 
     @PostMapping("/storybooks/{storybookId}/member-storybooks")
     @Override
-    public ApiResponse<StorybookResDTO.StartStorybook> startStorybook(
+    public ResponseEntity<ApiResponse<StorybookResDTO.StartStorybook>> startStorybook(
             @PathVariable Long storybookId,
             @AuthenticationPrincipal Long memberId
     ) {
-        return ApiResponse.onSuccess(
-                StorybookSuccessCode.START_STORYBOOK,
-                storybookService.startStorybook(storybookId, memberId)
-        );
+        StorybookResDTO.StartStorybook result = storybookService.startStorybook(storybookId, memberId);
+        return ResponseEntity.status(StorybookSuccessCode.START_STORYBOOK.getStatus())
+                .body(ApiResponse.onSuccess(StorybookSuccessCode.START_STORYBOOK, result));
     }
 }

--- a/src/main/java/com/umc/halo/domain/content/storybook/controller/docs/StorybookControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/controller/docs/StorybookControllerDocs.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.*;
 import io.swagger.v3.oas.annotations.media.*;
 import io.swagger.v3.oas.annotations.responses.*;
 import io.swagger.v3.oas.annotations.tags.*;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.*;
 
 @Tag(name = "스토리북 API")
@@ -41,90 +42,90 @@ public interface StorybookControllerDocs {
                                     @ExampleObject(
                                             name = "진행중인 스토리북이 있는 경우",
                                             value = """
-                                        {
-                                          "isSuccess": true,
-                                          "code": "HOME200_1",
-                                          "message": "홈 화면을 성공적으로 조회했습니다.",
-                                          "result": {
-                                            "homeStatus": "MULTIPLE_IN_PROGRESS",
-                                            "memberName": "김하로님",
-                                            "bookshelf": [
-                                              { "storybookId": 1, "title": "오래전 당신", "shortDescription": "가족과의 만남", "imageUrl": "https://example.com/storybook1.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님의 지난 시간을 알고 싶다면" },
-                                              { "storybookId": 2, "title": "당신 사용설명서", "shortDescription": "따뜻했던 순간들", "imageUrl": "https://example.com/storybook2.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님을 더 잘 이해하고 싶다면" },
-                                              { "storybookId": 3, "title": "가족의 온도", "shortDescription": "가족이 서로에게 건네는 마음", "imageUrl": "https://example.com/storybook3.png", "currentChapterOrder": 1, "todayAvailable": true, "recommendationReasonText": null },
-                                              { "storybookId": 4, "title": "취향이 닿는 날", "shortDescription": "서로의 취향을 알아가는 시간", "imageUrl": "https://example.com/storybook4.png", "currentChapterOrder": 3, "todayAvailable": true, "recommendationReasonText": null },
-                                              { "storybookId": 5, "title": "나란히 걷는 날", "shortDescription": "함께 걸어온 시간을 돌아보는 이야기", "imageUrl": "https://example.com/storybook5.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "함께하는 시간을 늘리고 싶다면" },
-                                              { "storybookId": 6, "title": "오늘은 내가 먼저", "shortDescription": "먼저 다가서는 용기에 대한 이야기", "imageUrl": "https://example.com/storybook6.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "먼저 마음을 표현하고 싶다면" },
-                                              { "storybookId": 7, "title": "생신까지 열 장", "shortDescription": "열 번의 준비", "imageUrl": "https://example.com/storybook7.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "특별한 생신을 준비하고 싶다면" },
-                                              { "storybookId": 8, "title": "한 장의 가족사진", "shortDescription": "한 장의 추억", "imageUrl": "https://example.com/storybook8.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "가족의 순간을 남기고 싶다면" },
-                                              { "storybookId": 9, "title": "손을 내미는 연습", "shortDescription": "용기의 시작", "imageUrl": "https://example.com/storybook9.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "어색한 관계에 다가가고 싶다면" },
-                                              { "storybookId": 10, "title": "당신의 1호 팬", "shortDescription": "가장 큰 응원", "imageUrl": "https://example.com/storybook10.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님을 응원하고 싶다면" }
-                                            ],
-                                            "inProgressStorybooks": [
-                                              {
-                                                "storybookId": 3,
-                                                "title": "가족의 온도",
-                                                "imageUrl": "https://example.com/storybook3.png",
-                                                "currentChapterOrder": 1,
-                                                "totalChapterCount": 10,
-                                                "todayAvailable": true
-                                              },
-                                              {
-                                                "storybookId": 4,
-                                                "title": "취향이 닿는 날",
-                                                "imageUrl": "https://example.com/storybook4.png",
-                                                "currentChapterOrder": 3,
-                                                "totalChapterCount": 10,
-                                                "todayAvailable": true
-                                              }
-                                            ],
-                                            "recommendedStorybooks": []
-                                          }
-                                        }
-                                        """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "HOME200_1",
+                                                      "message": "홈 화면을 성공적으로 조회했습니다.",
+                                                      "result": {
+                                                        "homeStatus": "MULTIPLE_IN_PROGRESS",
+                                                        "memberName": "김하로님",
+                                                        "bookshelf": [
+                                                          { "storybookId": 1, "title": "오래전 당신", "shortDescription": "가족과의 만남", "imageUrl": "https://example.com/storybook1.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님의 지난 시간을 알고 싶다면" },
+                                                          { "storybookId": 2, "title": "당신 사용설명서", "shortDescription": "따뜻했던 순간들", "imageUrl": "https://example.com/storybook2.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님을 더 잘 이해하고 싶다면" },
+                                                          { "storybookId": 3, "title": "가족의 온도", "shortDescription": "가족이 서로에게 건네는 마음", "imageUrl": "https://example.com/storybook3.png", "currentChapterOrder": 1, "todayAvailable": true, "recommendationReasonText": null },
+                                                          { "storybookId": 4, "title": "취향이 닿는 날", "shortDescription": "서로의 취향을 알아가는 시간", "imageUrl": "https://example.com/storybook4.png", "currentChapterOrder": 3, "todayAvailable": true, "recommendationReasonText": null },
+                                                          { "storybookId": 5, "title": "나란히 걷는 날", "shortDescription": "함께 걸어온 시간을 돌아보는 이야기", "imageUrl": "https://example.com/storybook5.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "함께하는 시간을 늘리고 싶다면" },
+                                                          { "storybookId": 6, "title": "오늘은 내가 먼저", "shortDescription": "먼저 다가서는 용기에 대한 이야기", "imageUrl": "https://example.com/storybook6.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "먼저 마음을 표현하고 싶다면" },
+                                                          { "storybookId": 7, "title": "생신까지 열 장", "shortDescription": "열 번의 준비", "imageUrl": "https://example.com/storybook7.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "특별한 생신을 준비하고 싶다면" },
+                                                          { "storybookId": 8, "title": "한 장의 가족사진", "shortDescription": "한 장의 추억", "imageUrl": "https://example.com/storybook8.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "가족의 순간을 남기고 싶다면" },
+                                                          { "storybookId": 9, "title": "손을 내미는 연습", "shortDescription": "용기의 시작", "imageUrl": "https://example.com/storybook9.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "어색한 관계에 다가가고 싶다면" },
+                                                          { "storybookId": 10, "title": "당신의 1호 팬", "shortDescription": "가장 큰 응원", "imageUrl": "https://example.com/storybook10.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님을 응원하고 싶다면" }
+                                                        ],
+                                                        "inProgressStorybooks": [
+                                                          {
+                                                            "storybookId": 3,
+                                                            "title": "가족의 온도",
+                                                            "imageUrl": "https://example.com/storybook3.png",
+                                                            "currentChapterOrder": 1,
+                                                            "totalChapterCount": 10,
+                                                            "todayAvailable": true
+                                                          },
+                                                          {
+                                                            "storybookId": 4,
+                                                            "title": "취향이 닿는 날",
+                                                            "imageUrl": "https://example.com/storybook4.png",
+                                                            "currentChapterOrder": 3,
+                                                            "totalChapterCount": 10,
+                                                            "todayAvailable": true
+                                                          }
+                                                        ],
+                                                        "recommendedStorybooks": []
+                                                      }
+                                                    }
+                                                    """
                                     ),
                                     @ExampleObject(
                                             name = "진행중인 스토리북이 없는 경우(추천)",
                                             value = """
-                                        {
-                                          "isSuccess": true,
-                                          "code": "HOME200_1",
-                                          "message": "홈 화면을 성공적으로 조회했습니다.",
-                                          "result": {
-                                            "homeStatus": "NO_STORYBOOK",
-                                            "memberName": "김하로님",
-                                            "bookshelf": [
-                                              { "storybookId": 1, "title": "오래전 당신", "shortDescription": "가족과의 만남", "imageUrl": "https://example.com/storybook1.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님의 지난 시간을 알고 싶다면" },
-                                              { "storybookId": 2, "title": "당신 사용설명서", "shortDescription": "따뜻했던 순간들", "imageUrl": "https://example.com/storybook2.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님을 더 잘 이해하고 싶다면" },
-                                              { "storybookId": 3, "title": "가족의 온도", "shortDescription": "가족이 서로에게 건네는 마음", "imageUrl": "https://example.com/storybook3.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "가족의 마음을 다시 느끼고 싶다면" },
-                                              { "storybookId": 4, "title": "취향이 닿는 날", "shortDescription": "서로의 취향을 알아가는 시간", "imageUrl": "https://example.com/storybook4.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "함께할 취향을 찾고 싶다면" },
-                                              { "storybookId": 5, "title": "나란히 걷는 날", "shortDescription": "함께 걸어온 시간을 돌아보는 이야기", "imageUrl": "https://example.com/storybook5.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "함께하는 시간을 늘리고 싶다면" },
-                                              { "storybookId": 6, "title": "오늘은 내가 먼저", "shortDescription": "먼저 다가서는 용기에 대한 이야기", "imageUrl": "https://example.com/storybook6.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "먼저 마음을 표현하고 싶다면" },
-                                              { "storybookId": 7, "title": "생신까지 열 장", "shortDescription": "열 번의 준비", "imageUrl": "https://example.com/storybook7.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "특별한 생신을 준비하고 싶다면" },
-                                              { "storybookId": 8, "title": "한 장의 가족사진", "shortDescription": "한 장의 추억", "imageUrl": "https://example.com/storybook8.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "가족의 순간을 남기고 싶다면" },
-                                              { "storybookId": 9, "title": "손을 내미는 연습", "shortDescription": "용기의 시작", "imageUrl": "https://example.com/storybook9.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "어색한 관계에 다가가고 싶다면" },
-                                              { "storybookId": 10, "title": "당신의 1호 팬", "shortDescription": "가장 큰 응원", "imageUrl": "https://example.com/storybook10.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님을 응원하고 싶다면" }
-                                            ],
-                                            "inProgressStorybooks": [],
-                                            "recommendedStorybooks": [
-                                              {
-                                                "storybookId": 1,
-                                                "title": "오래전 당신",
-                                                "shortDescription": "가족과의 만남",
-                                                "imageUrl": "https://example.com/storybook1.png",
-                                                "recommendationReasonText": "부모님의 지난 시간을 알고 싶다면"
-                                              },
-                                              {
-                                                "storybookId": 2,
-                                                "title": "당신 사용설명서",
-                                                "shortDescription": "따뜻했던 순간들",
-                                                "imageUrl": "https://example.com/storybook2.png",
-                                                "recommendationReasonText": "부모님을 더 잘 이해하고 싶다면"
-                                              }
-                                            ]
-                                          }
-                                        }
-                                        """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "HOME200_1",
+                                                      "message": "홈 화면을 성공적으로 조회했습니다.",
+                                                      "result": {
+                                                        "homeStatus": "NO_STORYBOOK",
+                                                        "memberName": "김하로님",
+                                                        "bookshelf": [
+                                                          { "storybookId": 1, "title": "오래전 당신", "shortDescription": "가족과의 만남", "imageUrl": "https://example.com/storybook1.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님의 지난 시간을 알고 싶다면" },
+                                                          { "storybookId": 2, "title": "당신 사용설명서", "shortDescription": "따뜻했던 순간들", "imageUrl": "https://example.com/storybook2.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님을 더 잘 이해하고 싶다면" },
+                                                          { "storybookId": 3, "title": "가족의 온도", "shortDescription": "가족이 서로에게 건네는 마음", "imageUrl": "https://example.com/storybook3.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "가족의 마음을 다시 느끼고 싶다면" },
+                                                          { "storybookId": 4, "title": "취향이 닿는 날", "shortDescription": "서로의 취향을 알아가는 시간", "imageUrl": "https://example.com/storybook4.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "함께할 취향을 찾고 싶다면" },
+                                                          { "storybookId": 5, "title": "나란히 걷는 날", "shortDescription": "함께 걸어온 시간을 돌아보는 이야기", "imageUrl": "https://example.com/storybook5.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "함께하는 시간을 늘리고 싶다면" },
+                                                          { "storybookId": 6, "title": "오늘은 내가 먼저", "shortDescription": "먼저 다가서는 용기에 대한 이야기", "imageUrl": "https://example.com/storybook6.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "먼저 마음을 표현하고 싶다면" },
+                                                          { "storybookId": 7, "title": "생신까지 열 장", "shortDescription": "열 번의 준비", "imageUrl": "https://example.com/storybook7.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "특별한 생신을 준비하고 싶다면" },
+                                                          { "storybookId": 8, "title": "한 장의 가족사진", "shortDescription": "한 장의 추억", "imageUrl": "https://example.com/storybook8.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "가족의 순간을 남기고 싶다면" },
+                                                          { "storybookId": 9, "title": "손을 내미는 연습", "shortDescription": "용기의 시작", "imageUrl": "https://example.com/storybook9.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "어색한 관계에 다가가고 싶다면" },
+                                                          { "storybookId": 10, "title": "당신의 1호 팬", "shortDescription": "가장 큰 응원", "imageUrl": "https://example.com/storybook10.png", "currentChapterOrder": null, "todayAvailable": true, "recommendationReasonText": "부모님을 응원하고 싶다면" }
+                                                        ],
+                                                        "inProgressStorybooks": [],
+                                                        "recommendedStorybooks": [
+                                                          {
+                                                            "storybookId": 1,
+                                                            "title": "오래전 당신",
+                                                            "shortDescription": "가족과의 만남",
+                                                            "imageUrl": "https://example.com/storybook1.png",
+                                                            "recommendationReasonText": "부모님의 지난 시간을 알고 싶다면"
+                                                          },
+                                                          {
+                                                            "storybookId": 2,
+                                                            "title": "당신 사용설명서",
+                                                            "shortDescription": "따뜻했던 순간들",
+                                                            "imageUrl": "https://example.com/storybook2.png",
+                                                            "recommendationReasonText": "부모님을 더 잘 이해하고 싶다면"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
                                     )
                             }
                     )
@@ -325,62 +326,62 @@ public interface StorybookControllerDocs {
                                     @ExampleObject(
                                             name = "전체 완료된 스토리북",
                                             value = """
-                        {
-                          "isSuccess": true,
-                          "code": "STORYBOOK200_2",
-                          "message": "스토리북 상세를 성공적으로 조회했습니다.",
-                          "result": {
-                            "storybookId": 1,
-                            "title": "오래전 당신",
-                            "description": "부모님에게도 지금의 나와 같은 시절이 있었습니다. 어린 날의 꿈과 청춘의 순간을 따라가며, 부모가 아닌 한 사람으로서의 당신을 만나봅니다.",
-                            "imageUrl": "https://example.com/storybook1.png",
-                            "completedChapterCount": 10,
-                            "progressPercentage": 100,
-                            "chapters": [
-                              { "chapterOrder": 1, "memberChapterId": 1, "title": "나와 같은 나이였던 시절", "shortImageUrl": "https://example.com/chapter1.png", "shortDescription": "부모님이 지금의 내 나이였을 때의 하루", "description": "부모님을 한 사람으로 바라보는 첫 장입니다. 지금의 내 나이였을 때 부모님은 어떤 하루를 살고 있었는지 돌아봅니다.", "status": "COMPLETED" },
-                              { "chapterOrder": 2, "memberChapterId": 2, "title": "소년과 소녀의 꿈", "shortImageUrl": "https://example.com/chapter2.png", "shortDescription": "어린 시절 마음속에 품었던 작은 꿈들", "description": "부모님에게도 작고 선명했던 어린 시절의 꿈이 있었습니다. 무엇을 좋아하고 어떤 사람이 되고 싶었는지 들어봅니다.", "status": "COMPLETED" },
-                              { "chapterOrder": 3, "memberChapterId": 3, "title": "빛나던 청춘의 한 페이지", "shortImageUrl": "https://example.com/chapter3.png", "shortDescription": "설렘과 도전으로 반짝이던 젊은 날", "description": "부모님의 젊은 날이 담긴 사진 속으로 들어가보는 장입니다. 사진 속 장소와 사람들을 통해 내가 몰랐던 부모님의 표정을 발견합니다.", "status": "COMPLETED" },
-                              { "chapterOrder": 4, "memberChapterId": 4, "title": "첫 출근과 첫 월급", "shortImageUrl": "https://example.com/chapter4.png", "shortDescription": "처음 세상에 내디딘 사회인의 발걸음", "description": "부모님이 처음 사회에 나섰던 순간을 돌아봅니다. 첫 출근의 마음과 첫 월급의 기억을 통해 부모님의 시작점을 기록합니다.", "status": "COMPLETED" },
-                              { "chapterOrder": 5, "memberChapterId": 5, "title": "두 사람의 서막", "shortImageUrl": "https://example.com/chapter5.png", "shortDescription": "두 사람이 만나 가족이 시작된 순간", "description": "부모님이 서로를 만나 가족이 시작되기 전의 이야기를 들어봅니다. 첫 만남과 첫인상을 통해 우리 가족의 첫 장면을 떠올립니다.", "status": "COMPLETED" },
-                              { "chapterOrder": 6, "memberChapterId": 6, "title": "가장 용기 냈던 순간", "shortImageUrl": "https://example.com/chapter6.png", "shortDescription": "삶의 방향을 바꾸었던 가장 큰 선택", "description": "부모님이 삶에서 큰 결정을 내렸던 순간을 돌아봅니다. 그때의 고민과 선택을 들으며 부모님의 용기를 이해해봅니다.", "status": "COMPLETED" },
-                              { "chapterOrder": 7, "memberChapterId": 7, "title": "잊지 못할 사람들", "shortImageUrl": "https://example.com/chapter7.png", "shortDescription": "오랜 시간이 지나도 남아 있는 인연들", "description": "부모님 마음속에 오래 남아 있는 사람을 만나보는 장입니다. 그 사람이 어떤 의미였는지 들으며 부모님의 관계와 시간을 알아갑니다.", "status": "COMPLETED" },
-                              { "chapterOrder": 8, "memberChapterId": 8, "title": "부모가 되기 전의 밤", "shortImageUrl": "https://example.com/chapter8.png", "shortDescription": "부모라는 이름을 만나기 직전의 마음", "description": "내가 태어나기 전 부모님의 마음을 조심스럽게 들어봅니다. 기다림과 걱정, 설렘이 섞여 있던 시간을 기록합니다.", "status": "COMPLETED" },
-                              { "chapterOrder": 9, "memberChapterId": 9, "title": "잠시 접어두었던 것들", "shortImageUrl": "https://example.com/chapter9.png", "shortDescription": "가족을 위해 잠시 미뤄두었던 꿈과 시간", "description": "부모님이 가족을 위해 잠시 미뤄두었던 것들을 떠올려봅니다. 내려놓았던 꿈이나 취미를 통해 부모님의 또 다른 모습을 발견합니다.", "status": "COMPLETED" },
-                              { "chapterOrder": 10, "memberChapterId": 10, "title": "다시 쓰는 당신의 프로필", "shortImageUrl": "https://example.com/chapter10.png", "shortDescription": "부모가 아닌 한 사람으로 다시 만난 당신", "description": "앞의 기록을 바탕으로 부모님을 다시 소개하는 마지막 장입니다. 누구의 부모가 아닌 한 사람으로서의 부모님을 정리합니다.", "status": "COMPLETED" }
-                            ]
-                          }
-                        }
-                        """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "STORYBOOK200_2",
+                                                      "message": "스토리북 상세를 성공적으로 조회했습니다.",
+                                                      "result": {
+                                                        "storybookId": 1,
+                                                        "title": "오래전 당신",
+                                                        "description": "부모님에게도 지금의 나와 같은 시절이 있었습니다. 어린 날의 꿈과 청춘의 순간을 따라가며, 부모가 아닌 한 사람으로서의 당신을 만나봅니다.",
+                                                        "imageUrl": "https://example.com/storybook1.png",
+                                                        "completedChapterCount": 10,
+                                                        "progressPercentage": 100,
+                                                        "chapters": [
+                                                          { "chapterOrder": 1, "memberChapterId": 1, "title": "나와 같은 나이였던 시절", "shortImageUrl": "https://example.com/chapter1.png", "shortDescription": "부모님이 지금의 내 나이였을 때의 하루", "description": "부모님을 한 사람으로 바라보는 첫 장입니다. 지금의 내 나이였을 때 부모님은 어떤 하루를 살고 있었는지 돌아봅니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 2, "memberChapterId": 2, "title": "소년과 소녀의 꿈", "shortImageUrl": "https://example.com/chapter2.png", "shortDescription": "어린 시절 마음속에 품었던 작은 꿈들", "description": "부모님에게도 작고 선명했던 어린 시절의 꿈이 있었습니다. 무엇을 좋아하고 어떤 사람이 되고 싶었는지 들어봅니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 3, "memberChapterId": 3, "title": "빛나던 청춘의 한 페이지", "shortImageUrl": "https://example.com/chapter3.png", "shortDescription": "설렘과 도전으로 반짝이던 젊은 날", "description": "부모님의 젊은 날이 담긴 사진 속으로 들어가보는 장입니다. 사진 속 장소와 사람들을 통해 내가 몰랐던 부모님의 표정을 발견합니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 4, "memberChapterId": 4, "title": "첫 출근과 첫 월급", "shortImageUrl": "https://example.com/chapter4.png", "shortDescription": "처음 세상에 내디딘 사회인의 발걸음", "description": "부모님이 처음 사회에 나섰던 순간을 돌아봅니다. 첫 출근의 마음과 첫 월급의 기억을 통해 부모님의 시작점을 기록합니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 5, "memberChapterId": 5, "title": "두 사람의 서막", "shortImageUrl": "https://example.com/chapter5.png", "shortDescription": "두 사람이 만나 가족이 시작된 순간", "description": "부모님이 서로를 만나 가족이 시작되기 전의 이야기를 들어봅니다. 첫 만남과 첫인상을 통해 우리 가족의 첫 장면을 떠올립니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 6, "memberChapterId": 6, "title": "가장 용기 냈던 순간", "shortImageUrl": "https://example.com/chapter6.png", "shortDescription": "삶의 방향을 바꾸었던 가장 큰 선택", "description": "부모님이 삶에서 큰 결정을 내렸던 순간을 돌아봅니다. 그때의 고민과 선택을 들으며 부모님의 용기를 이해해봅니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 7, "memberChapterId": 7, "title": "잊지 못할 사람들", "shortImageUrl": "https://example.com/chapter7.png", "shortDescription": "오랜 시간이 지나도 남아 있는 인연들", "description": "부모님 마음속에 오래 남아 있는 사람을 만나보는 장입니다. 그 사람이 어떤 의미였는지 들으며 부모님의 관계와 시간을 알아갑니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 8, "memberChapterId": 8, "title": "부모가 되기 전의 밤", "shortImageUrl": "https://example.com/chapter8.png", "shortDescription": "부모라는 이름을 만나기 직전의 마음", "description": "내가 태어나기 전 부모님의 마음을 조심스럽게 들어봅니다. 기다림과 걱정, 설렘이 섞여 있던 시간을 기록합니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 9, "memberChapterId": 9, "title": "잠시 접어두었던 것들", "shortImageUrl": "https://example.com/chapter9.png", "shortDescription": "가족을 위해 잠시 미뤄두었던 꿈과 시간", "description": "부모님이 가족을 위해 잠시 미뤄두었던 것들을 떠올려봅니다. 내려놓았던 꿈이나 취미를 통해 부모님의 또 다른 모습을 발견합니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 10, "memberChapterId": 10, "title": "다시 쓰는 당신의 프로필", "shortImageUrl": "https://example.com/chapter10.png", "shortDescription": "부모가 아닌 한 사람으로 다시 만난 당신", "description": "앞의 기록을 바탕으로 부모님을 다시 소개하는 마지막 장입니다. 누구의 부모가 아닌 한 사람으로서의 부모님을 정리합니다.", "status": "COMPLETED" }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
                                     ),
                                     @ExampleObject(
                                             name = "진행 중인 스토리북",
                                             value = """
-                {
-                  "isSuccess": true,
-                  "code": "STORYBOOK200_2",
-                  "message": "스토리북 상세를 성공적으로 조회했습니다.",
-                  "result": {
-                    "storybookId": 4,
-                    "title": "취향이 닿는 날",
-                    "description": "서로 좋아하는 것을 나누면 대화를 시작할 이유가 하나 더 생깁니다. 음식과 노래, 장소와 취미를 함께 경험하며 우리 둘의 취향이 닿는 순간을 만들어봅니다.",
-                    "imageUrl": "https://example.com/storybook4.png",
-                    "completedChapterCount": 1,
-                    "progressPercentage": 10,
-                    "chapters": [
-                      { "chapterOrder": 1, "memberChapterId": 1, "title": "같이 먹어본맛", "shortImageUrl": "https://example.com/chapter1-short.png", "shortDescription": "한 끼를 나누며 발견한 닮은 입맛", "description": "부모님이 좋아하는 음식을 함께 먹어보는 장입니다. 맛보다 그 음식을 좋아하는 이유를 들으며 취향을 알아갑니다.", "status": "COMPLETED" },
-                      { "chapterOrder": 2, "memberChapterId": null, "title": "부모님의 플레이리스트", "shortImageUrl": "https://example.com/chapter2-short.png", "shortDescription": "노래 한 곡에 담긴 부모님의 시간", "description": "부모님이 좋아하는 노래를 함께 들어봅니다. 노래에 담긴 시절과 분위기를 통해 부모님의 기억을 만납니다.", "status": "TODAY" },
-                      { "chapterOrder": 3, "memberChapterId": null, "title": "같이 본 장면", "shortImageUrl": "https://example.com/chapter3-short.png", "shortDescription": "같은 장면을 보며 나눈 서로 다른 감상", "description": "부모님과 영상 콘텐츠를 함께 보는 장입니다. 어떤 장면을 좋아하셨는지 들으며 취향의 방향을 발견합니다.", "status": "LOCKED" },
-                      { "chapterOrder": 4, "memberChapterId": null, "title": "취미의 입구", "shortImageUrl": "https://example.com/chapter4-short.png", "shortDescription": "부모님이 좋아하는 세계에 들어선 첫걸음", "description": "부모님의 취미를 아주 짧게 따라 해봅니다. 잘하려고 하기보다 왜 즐거운지 느껴보는 것이 중심입니다.", "status": "LOCKED" },
-                      { "chapterOrder": 5, "memberChapterId": null, "title": "단골의 이유", "shortImageUrl": "https://example.com/chapter5-short.png", "shortDescription": "오래 찾게 되는 익숙한 장소의 이유", "description": "부모님이 자주 가는 장소에 함께 가봅니다. 그곳이 편한 이유와 부모님의 일상적인 시간을 알아갑니다.", "status": "LOCKED" },
-                      { "chapterOrder": 6, "memberChapterId": null, "title": "고르는 기준", "shortImageUrl": "https://example.com/chapter6-short.png", "shortDescription": "물건 하나에도 드러나는 부모님의 기준", "description": "부모님이 물건을 고를 때 중요하게 보는 기준을 관찰합니다. 가격, 편함, 오래 씀 같은 선택의 이유를 기록합니다.", "status": "LOCKED" },
-                      { "chapterOrder": 7, "memberChapterId": null, "title": "쉬는 날의 선택", "shortImageUrl": "https://example.com/chapter7-short.png", "shortDescription": "쉬는 날 자연스럽게 향하는 곳과 시간", "description": "부모님이 쉬는 날 하고 싶은 일을 함께 해봅니다. 거창하지 않아도 부모님의 리듬을 따라가보는 장입니다.", "status": "LOCKED" },
-                      { "chapterOrder": 8, "memberChapterId": null, "title": "내 취향 소개하기", "shortImageUrl": "https://example.com/chapter8-short.png", "shortDescription": "내가 좋아하는 것을 부모님께 건넨 날", "description": "이번에는 내가 좋아하는 것을 부모님께 소개합니다. 부모님의 반응을 보며 의외로 닿는 취향을 찾아봅니다.", "status": "LOCKED" },
-                      { "chapterOrder": 9, "memberChapterId": null, "title": "우리 둘의 공통점", "shortImageUrl": "https://example.com/chapter9-short.png", "shortDescription": "사소하지만 반가운 우리 둘의 닮은 점", "description": "부모님과 나 사이의 비슷한 취향을 발견합니다. 사소한 공통점도 다음 경험으로 이어질 수 있습니다.", "status": "LOCKED" },
-                      { "chapterOrder": 10, "memberChapterId": null, "title": "같이좋아하게 된 것", "shortImageUrl": "https://example.com/chapter10-short.png", "shortDescription": "함께 경험하며 새로 생겨난 공통 취향", "description": "함께 경험한 취향들을 돌아보는 마지막 장입니다. 앞으로도 이어가고 싶은 작은 취향 루틴을 정리합니다.", "status": "LOCKED" }
-                    ]
-                  }
-                }
-                """
+                                                    {
+                                                      "isSuccess": true,
+                                                      "code": "STORYBOOK200_2",
+                                                      "message": "스토리북 상세를 성공적으로 조회했습니다.",
+                                                      "result": {
+                                                        "storybookId": 4,
+                                                        "title": "취향이 닿는 날",
+                                                        "description": "서로 좋아하는 것을 나누면 대화를 시작할 이유가 하나 더 생깁니다. 음식과 노래, 장소와 취미를 함께 경험하며 우리 둘의 취향이 닿는 순간을 만들어봅니다.",
+                                                        "imageUrl": "https://example.com/storybook4.png",
+                                                        "completedChapterCount": 1,
+                                                        "progressPercentage": 10,
+                                                        "chapters": [
+                                                          { "chapterOrder": 1, "memberChapterId": 1, "title": "같이 먹어본맛", "shortImageUrl": "https://example.com/chapter1-short.png", "shortDescription": "한 끼를 나누며 발견한 닮은 입맛", "description": "부모님이 좋아하는 음식을 함께 먹어보는 장입니다. 맛보다 그 음식을 좋아하는 이유를 들으며 취향을 알아갑니다.", "status": "COMPLETED" },
+                                                          { "chapterOrder": 2, "memberChapterId": null, "title": "부모님의 플레이리스트", "shortImageUrl": "https://example.com/chapter2-short.png", "shortDescription": "노래 한 곡에 담긴 부모님의 시간", "description": "부모님이 좋아하는 노래를 함께 들어봅니다. 노래에 담긴 시절과 분위기를 통해 부모님의 기억을 만납니다.", "status": "TODAY" },
+                                                          { "chapterOrder": 3, "memberChapterId": null, "title": "같이 본 장면", "shortImageUrl": "https://example.com/chapter3-short.png", "shortDescription": "같은 장면을 보며 나눈 서로 다른 감상", "description": "부모님과 영상 콘텐츠를 함께 보는 장입니다. 어떤 장면을 좋아하셨는지 들으며 취향의 방향을 발견합니다.", "status": "LOCKED" },
+                                                          { "chapterOrder": 4, "memberChapterId": null, "title": "취미의 입구", "shortImageUrl": "https://example.com/chapter4-short.png", "shortDescription": "부모님이 좋아하는 세계에 들어선 첫걸음", "description": "부모님의 취미를 아주 짧게 따라 해봅니다. 잘하려고 하기보다 왜 즐거운지 느껴보는 것이 중심입니다.", "status": "LOCKED" },
+                                                          { "chapterOrder": 5, "memberChapterId": null, "title": "단골의 이유", "shortImageUrl": "https://example.com/chapter5-short.png", "shortDescription": "오래 찾게 되는 익숙한 장소의 이유", "description": "부모님이 자주 가는 장소에 함께 가봅니다. 그곳이 편한 이유와 부모님의 일상적인 시간을 알아갑니다.", "status": "LOCKED" },
+                                                          { "chapterOrder": 6, "memberChapterId": null, "title": "고르는 기준", "shortImageUrl": "https://example.com/chapter6-short.png", "shortDescription": "물건 하나에도 드러나는 부모님의 기준", "description": "부모님이 물건을 고를 때 중요하게 보는 기준을 관찰합니다. 가격, 편함, 오래 씀 같은 선택의 이유를 기록합니다.", "status": "LOCKED" },
+                                                          { "chapterOrder": 7, "memberChapterId": null, "title": "쉬는 날의 선택", "shortImageUrl": "https://example.com/chapter7-short.png", "shortDescription": "쉬는 날 자연스럽게 향하는 곳과 시간", "description": "부모님이 쉬는 날 하고 싶은 일을 함께 해봅니다. 거창하지 않아도 부모님의 리듬을 따라가보는 장입니다.", "status": "LOCKED" },
+                                                          { "chapterOrder": 8, "memberChapterId": null, "title": "내 취향 소개하기", "shortImageUrl": "https://example.com/chapter8-short.png", "shortDescription": "내가 좋아하는 것을 부모님께 건넨 날", "description": "이번에는 내가 좋아하는 것을 부모님께 소개합니다. 부모님의 반응을 보며 의외로 닿는 취향을 찾아봅니다.", "status": "LOCKED" },
+                                                          { "chapterOrder": 9, "memberChapterId": null, "title": "우리 둘의 공통점", "shortImageUrl": "https://example.com/chapter9-short.png", "shortDescription": "사소하지만 반가운 우리 둘의 닮은 점", "description": "부모님과 나 사이의 비슷한 취향을 발견합니다. 사소한 공통점도 다음 경험으로 이어질 수 있습니다.", "status": "LOCKED" },
+                                                          { "chapterOrder": 10, "memberChapterId": null, "title": "같이좋아하게 된 것", "shortImageUrl": "https://example.com/chapter10-short.png", "shortDescription": "함께 경험하며 새로 생겨난 공통 취향", "description": "함께 경험한 취향들을 돌아보는 마지막 장입니다. 앞으로도 이어가고 싶은 작은 취향 루틴을 정리합니다.", "status": "LOCKED" }
+                                                        ]
+                                                      }
+                                                    }
+                                                    """
                                     )
                             }
                     )
@@ -460,7 +461,7 @@ public interface StorybookControllerDocs {
     )
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
+                    responseCode = "201",
                     description = "성공 예시",
                     content = @Content(
                             mediaType = "application/json",
@@ -468,7 +469,7 @@ public interface StorybookControllerDocs {
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": true,
-                                      "code": "STORYBOOK200_3",
+                                      "code": "STORYBOOK201_1",
                                       "message": "스토리북을 시작했습니다.",
                                       "result": {
                                         "memberStorybookId": 4,
@@ -557,7 +558,7 @@ public interface StorybookControllerDocs {
                     )
             )
     })
-    ApiResponse<StorybookResDTO.StartStorybook> startStorybook(
+    ResponseEntity<ApiResponse<StorybookResDTO.StartStorybook>> startStorybook(
             @Parameter(description = "스토리북 ID", required = true) Long storybookId,
             @AuthenticationPrincipal Long memberId
     );
@@ -591,7 +592,7 @@ public interface StorybookControllerDocs {
                             examples = @ExampleObject(value = """
                                     {
                                       "isSuccess": true,
-                                      "code": "STORYBOOK200_4",
+                                      "code": "STORYBOOK200_3",
                                       "message": "추천 스토리북을 성공적으로 조회했습니다.",
                                       "result": {
                                         "storybooks": [

--- a/src/main/java/com/umc/halo/domain/content/storybook/exception/code/StorybookSuccessCode.java
+++ b/src/main/java/com/umc/halo/domain/content/storybook/exception/code/StorybookSuccessCode.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum StorybookSuccessCode implements BaseSuccessCode {
     GET_STORYBOOK_LIST(HttpStatus.OK, "STORYBOOK200_1", "스토리북 목록을 성공적으로 조회했습니다."),
     GET_STORYBOOK_DETAIL(HttpStatus.OK, "STORYBOOK200_2", "스토리북 상세를 성공적으로 조회했습니다."),
-    START_STORYBOOK(HttpStatus.OK, "STORYBOOK200_3", "스토리북을 시작했습니다."),
-    GET_RECOMMENDED_STORYBOOKS(HttpStatus.OK, "STORYBOOK200_4", "추천 스토리북을 성공적으로 조회했습니다.");
+    START_STORYBOOK(HttpStatus.CREATED, "STORYBOOK201_1", "스토리북을 시작했습니다."),
+    GET_RECOMMENDED_STORYBOOKS(HttpStatus.OK, "STORYBOOK200_3", "추천 스토리북을 성공적으로 조회했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/halo/domain/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/umc/halo/domain/exhibition/controller/ExhibitionController.java
@@ -18,6 +18,7 @@ public class ExhibitionController implements ExhibitionControllerDocs {
 
     private final ExhibitionService exhibitionService;
 
+    @Override
     @GetMapping
     public ApiResponse<ExhibitionResDTO.MainInfo> getExhibition(
             @AuthenticationPrincipal Long memberId
@@ -26,6 +27,7 @@ public class ExhibitionController implements ExhibitionControllerDocs {
         return ApiResponse.onSuccess(code, exhibitionService.getExhibition(memberId));
     }
 
+    @Override
     @GetMapping("/{storybookId}/chapters")
     public ApiResponse<ExhibitionChapterResDTO.ChaptersInfo> getChapters(
             @AuthenticationPrincipal Long memberId,

--- a/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberController.java
@@ -21,6 +21,7 @@ public class MemberController implements MemberControllerDocs {
 
     private final MemberService memberService;
 
+    @Override
     @PostMapping("/v1/auth/login")
     public ApiResponse<MemberResDTO.Login> login(
             @RequestBody @Valid MemberReqDTO.Login dto
@@ -29,6 +30,7 @@ public class MemberController implements MemberControllerDocs {
         return ApiResponse.onSuccess(code, memberService.login(dto));
     }
 
+    @Override
     @PostMapping("/v1/auth/reissue")
     public ApiResponse<MemberResDTO.TokenReissue> tokenReissue(
             @RequestBody @Valid MemberReqDTO.TokenReissue dto
@@ -37,6 +39,7 @@ public class MemberController implements MemberControllerDocs {
         return ApiResponse.onSuccess(code, memberService.tokenReissue(dto));
     }
 
+    @Override
     @PostMapping("/v1/auth/logout")
     public ApiResponse<Void> logout(
             @Parameter(hidden = true)
@@ -47,6 +50,7 @@ public class MemberController implements MemberControllerDocs {
         return ApiResponse.onSuccess(code);
     }
 
+    @Override
     @DeleteMapping("/v1/members/me")
     public ApiResponse<Void> withdraw(
             @Parameter(hidden = true)
@@ -57,6 +61,7 @@ public class MemberController implements MemberControllerDocs {
         return ApiResponse.onSuccess(code);
     }
 
+    @Override
     @GetMapping("/v1/members/me")
     public ApiResponse<MemberResDTO.MyInfo> getMyInfo(
             @Parameter(hidden = true)
@@ -66,6 +71,7 @@ public class MemberController implements MemberControllerDocs {
         return ApiResponse.onSuccess(code, memberService.getMyInfo(memberId));
     }
 
+    @Override
     @PatchMapping("/v1/members/last-access-at")
     public ApiResponse<Void> updateAccess(
             @Parameter(hidden = true) @AuthenticationPrincipal Long memberId

--- a/src/main/java/com/umc/halo/domain/member/controller/MemberDeviceController.java
+++ b/src/main/java/com/umc/halo/domain/member/controller/MemberDeviceController.java
@@ -21,6 +21,7 @@ public class MemberDeviceController implements MemberDeviceControllerDocs {
     private final MemberDeviceRepository memberDeviceRepository;
     private final MemberDeviceService memberDeviceService;
 
+    @Override
     @PostMapping
     public ApiResponse<Void> registerDevice(
             @Parameter(hidden = true) @AuthenticationPrincipal Long memberId,
@@ -31,6 +32,7 @@ public class MemberDeviceController implements MemberDeviceControllerDocs {
         return ApiResponse.onSuccess(code);
     }
 
+    @Override
     @DeleteMapping
     public ApiResponse<Void> deleteDevice(
             @Parameter(hidden = true) @AuthenticationPrincipal Long memberId,

--- a/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
@@ -22,6 +22,7 @@ public class AnniversaryController implements AnniversaryControllerDocs {
 
     private final AnniversaryService anniversaryService;
 
+    @Override
     @GetMapping
     public ApiResponse<AnniversaryResDTO.GetAnniversaries> getAnniversaries(
             @AuthenticationPrincipal Long memberId
@@ -32,6 +33,7 @@ public class AnniversaryController implements AnniversaryControllerDocs {
         );
     }
 
+    @Override
     @PostMapping
     public ResponseEntity<ApiResponse<AnniversaryResDTO.CreateAnniversary>> createAnniversary(
             @AuthenticationPrincipal Long memberId,
@@ -42,6 +44,7 @@ public class AnniversaryController implements AnniversaryControllerDocs {
                 .body(ApiResponse.onSuccess(AnniversarySuccessCode.ANNIVERSARY_CREATE_SUCCESS, result));
     }
 
+    @Override
     @PatchMapping("/{anniversaryId}")
     public ApiResponse<AnniversaryResDTO.UpdateAnniversary> updateAnniversary(
             @AuthenticationPrincipal Long memberId,
@@ -54,6 +57,7 @@ public class AnniversaryController implements AnniversaryControllerDocs {
         );
     }
 
+    @Override
     @DeleteMapping
     public ApiResponse<Void> deleteAnniversaries(
             @AuthenticationPrincipal Long memberId,

--- a/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
@@ -7,9 +7,13 @@ import com.umc.halo.domain.notification.exception.code.AnniversarySuccessCode;
 import com.umc.halo.domain.notification.service.AnniversaryService;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/anniversary")
@@ -54,9 +58,9 @@ public class AnniversaryController implements AnniversaryControllerDocs {
     @DeleteMapping
     public ApiResponse<Void> deleteAnniversaries(
             @AuthenticationPrincipal Long memberId,
-            @Valid @RequestBody AnniversaryReqDTO.Delete request
+            @RequestParam @NotEmpty(message = "삭제할 기념일 ID 목록은 필수입니다.") List<Long> anniversaryIds
     ) {
-        anniversaryService.deleteAnniversaries(memberId, request.anniversaryIds());
+        anniversaryService.deleteAnniversaries(memberId, anniversaryIds);
         return ApiResponse.onSuccess(AnniversarySuccessCode.ANNIVERSARY_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/AnniversaryController.java
@@ -33,14 +33,13 @@ public class AnniversaryController implements AnniversaryControllerDocs {
     }
 
     @PostMapping
-    public ApiResponse<AnniversaryResDTO.CreateAnniversary> createAnniversary(
+    public ResponseEntity<ApiResponse<AnniversaryResDTO.CreateAnniversary>> createAnniversary(
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody AnniversaryReqDTO.Create request
     ) {
-        return ApiResponse.onSuccess(
-                AnniversarySuccessCode.ANNIVERSARY_CREATE_SUCCESS,
-                anniversaryService.createAnniversary(memberId, request)
-        );
+        AnniversaryResDTO.CreateAnniversary result = anniversaryService.createAnniversary(memberId, request);
+        return ResponseEntity.status(AnniversarySuccessCode.ANNIVERSARY_CREATE_SUCCESS.getStatus())
+                .body(ApiResponse.onSuccess(AnniversarySuccessCode.ANNIVERSARY_CREATE_SUCCESS, result));
     }
 
     @PatchMapping("/{anniversaryId}")

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -583,22 +583,35 @@ public interface AnniversaryControllerDocs {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "요청 값 누락",
+                    description = "anniversaryIds 누락 또는 빈 목록",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(
-                                    name = "anniversaryIds 누락",
-                                    value = """
-                                            {
-                                              "isSuccess": false,
-                                              "code": "COMMON400_1",
-                                              "message": "잘못된 요청입니다.",
-                                              "result": {
-                                                "anniversaryIds": "삭제할 기념일 ID 목록은 필수입니다."
-                                              }
-                                            }
-                                            """
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "anniversaryIds 파라미터 자체가 없음",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": null
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "anniversaryIds가 빈 목록으로 전달됨",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "COMMON400_1",
+                                                      "message": "잘못된 요청입니다.",
+                                                      "result": {
+                                                        "anniversaryIds": "삭제할 기념일 ID 목록은 필수입니다."
+                                                      }
+                                                    }
+                                                    """
+                                    )
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -10,9 +10,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @Tag(name = "기념일 API")
 public interface AnniversaryControllerDocs {
@@ -550,10 +554,9 @@ public interface AnniversaryControllerDocs {
                     
                     ## 요청 형식
                     - **Header**
-                        - Content-Type: application/json
                         - Authorization: Bearer {accessToken}
-                    - **Body**
-                        - anniversaryIds : 삭제할 기념일 ID 목록 (필수, 예: [1, 2, 5])
+                    - **Query Parameter**
+                        - anniversaryIds : 삭제할 기념일 ID 목록 (필수, 예: ?anniversaryIds=1&anniversaryIds=2)
                     
                     ## 동작 방식
                     1. 요청한 ID 목록이 모두 존재하는지 확인하고, 하나라도 존재하지 않으면 404 예외를 반환합니다.
@@ -646,6 +649,6 @@ public interface AnniversaryControllerDocs {
     })
     ApiResponse<Void> deleteAnniversaries(
             @AuthenticationPrincipal Long memberId,
-            @Valid @RequestBody AnniversaryReqDTO.Delete request
+            @RequestParam @NotEmpty(message = "삭제할 기념일 ID 목록은 필수입니다.") List<Long> anniversaryIds
     );
 }

--- a/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/notification/controller/docs/AnniversaryControllerDocs.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -309,7 +310,7 @@ public interface AnniversaryControllerDocs {
                     )
             )
     })
-    ApiResponse<AnniversaryResDTO.CreateAnniversary> createAnniversary(
+    ResponseEntity<ApiResponse<AnniversaryResDTO.CreateAnniversary>> createAnniversary(
             @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody AnniversaryReqDTO.Create request
     );

--- a/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryReqDTO.java
+++ b/src/main/java/com/umc/halo/domain/notification/dto/AnniversaryReqDTO.java
@@ -1,12 +1,10 @@
 package com.umc.halo.domain.notification.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
-import java.util.List;
 
 public class AnniversaryReqDTO {
 
@@ -57,12 +55,6 @@ public class AnniversaryReqDTO {
 
             @Size(max = 50, message = "메모는 50자 이하로 입력해주세요.")
             String memo
-    ) {
-    }
-
-    public record Delete(
-            @NotEmpty(message = "삭제할 기념일 ID 목록은 필수입니다.")
-            List<Long> anniversaryIds
     ) {
     }
 }

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/OnboardingController.java
@@ -23,6 +23,7 @@ public class OnboardingController implements OnboardingControllerDocs {
 
     private final OnboardingService onboardingService;
     // 닉네임 중복 확인
+    @Override
     @GetMapping("/nickname/check")
     public ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
             @AuthenticationPrincipal Long memberId,
@@ -33,6 +34,7 @@ public class OnboardingController implements OnboardingControllerDocs {
     }
 
     // 온보딩 정보 저장
+    @Override
     @PostMapping
     public ApiResponse<OnboardingResDTO.Save> saveOnboarding(
             @AuthenticationPrincipal Long memberId,
@@ -43,6 +45,7 @@ public class OnboardingController implements OnboardingControllerDocs {
     }
 
     // 온보딩 진행 상태 조회
+    @Override
     @GetMapping("/status")
     public ApiResponse<OnboardingResDTO.Status> getStatus(
             @AuthenticationPrincipal Long memberId
@@ -52,6 +55,7 @@ public class OnboardingController implements OnboardingControllerDocs {
     }
 
     // 온보딩 태그 목록 조회
+    @Override
     @GetMapping("/tags")
     public ApiResponse<OnboardingResDTO.TagList> getTags() {
         BaseSuccessCode code = OnboardingSuccessCode.TAG_LIST_SUCCESS;

--- a/src/main/java/com/umc/halo/domain/relationship/controller/RelationshipController.java
+++ b/src/main/java/com/umc/halo/domain/relationship/controller/RelationshipController.java
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/relationships")
 public class RelationshipController implements RelationshipControllerDocs {
     private final RelationshipService relationshipService;
+
+    @Override
     @GetMapping
     public ApiResponse<RelationshipResDTO.Info> getRelationshipInfo(
             @AuthenticationPrincipal Long memberId

--- a/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/SettingController.java
@@ -20,6 +20,7 @@ public class SettingController implements SettingControllerDocs {
 
     private final SettingService settingService;
 
+    @Override
     @GetMapping("/v1/settings/notifications")
     public ApiResponse<SettingResDTO.NotificationSettings> getNotificationSettings(
             @Parameter(hidden = true)
@@ -29,6 +30,7 @@ public class SettingController implements SettingControllerDocs {
         return ApiResponse.onSuccess(code, settingService.getNotificationSettings(memberId));
     }
 
+    @Override
     @GetMapping("/v1/settings/bgm")
     public ApiResponse<SettingResDTO.BgmSettings> getBgmSettings(
             @Parameter(hidden = true)
@@ -38,12 +40,14 @@ public class SettingController implements SettingControllerDocs {
         return ApiResponse.onSuccess(code, settingService.getBgmSettings(memberId));
     }
 
+    @Override
     @GetMapping("/v1/bgms")
     public ApiResponse<SettingResDTO.Bgms> getBgms() {
         BaseSuccessCode code = SettingSuccessCode.BGM_LIST_GET_SUCCESS;
         return ApiResponse.onSuccess(code, settingService.getBgms());
     }
 
+    @Override
     @PutMapping("/v1/settings/notifications")
     public ApiResponse<SettingResDTO.NotificationSettings> updateNotificationSettings(
             @Parameter(hidden = true)
@@ -54,6 +58,7 @@ public class SettingController implements SettingControllerDocs {
         return ApiResponse.onSuccess(code, settingService.updateNotificationSettings(memberId, dto));
     }
 
+    @Override
     @PutMapping("/v1/settings/bgm")
     public ApiResponse<SettingResDTO.BgmSettings> updateBgmSettings(
             @Parameter(hidden = true)

--- a/src/main/java/com/umc/halo/domain/term/controller/TermController.java
+++ b/src/main/java/com/umc/halo/domain/term/controller/TermController.java
@@ -26,6 +26,7 @@ public class TermController implements TermControllerDocs {
     private final TermService termService;
 
     // 약관 목록 조회
+    @Override
     @GetMapping
     public ApiResponse<List<TermResDTO.Info>> getTerms() {
         BaseSuccessCode code = TermSuccessCode.LIST_SUCCESS;
@@ -33,6 +34,7 @@ public class TermController implements TermControllerDocs {
     }
 
     // 약관 동의 처리
+    @Override
     @PostMapping("/agreements")
     public ApiResponse<Void> agree(
             @AuthenticationPrincipal Long memberId,
@@ -44,6 +46,7 @@ public class TermController implements TermControllerDocs {
     }
 
     // 약관 동의 여부 조회
+    @Override
     @GetMapping("/agreements")
     public ApiResponse<TermResDTO.AgreementStatus> getAgreementStatus(
             @AuthenticationPrincipal Long memberId


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- RESTful 설계 원칙에 맞춰 정리


- 기념일 삭제 API가 요청 body로 ID 목록을 받던 것을 쿼리 파라미터로 변경
- 스토리북 시작 API 경로에서 동사(`start`)를 제거하고 리소스 명으로 변경
- 리소스를 새로 생성하는 API(기념일 생성, 스토리북 시작)가 실제로 201을 반환하도록 수정
- 전체 컨트롤러에 `@Override` 어노테이션을 일관되게 적용
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 기념일(Anniversary)
  - `AnniversaryController.java`: 삭제 API가 `@RequestBody` 대신 `@RequestParam List<Long> anniversaryIds`(쿼리 파라미터)로 ID 목록을 받도록 변경 / 생성 API가 201을 반환하도록 수정 / 전체 메서드에 `@Override` 추가
  - `AnniversaryControllerDocs.java`: 위 시그니처 변경에 맞춰 인터페이스 동기화, Swagger 문서 쿼리 파라미터 형식으로 수정
  - `AnniversaryReqDTO.java`: 더 이상 쓰이지 않는 `Delete` record 제거

- 스토리북(Storybook)
  - `StorybookController.java`: 시작 API 경로를 `/storybooks/{storybookId}/start` 에서 `/storybooks/{storybookId}/member-storybooks`로 변경 / `ResponseEntity`로 감싸 201을 반환하도록 수정 / 전체 메서드에 `@Override` 추가
  - `StorybookControllerDocs.java`: 위 시그니처 변경에 맞춰 인터페이스 동기화, Swagger 응답 예시 상태코드/코드 문자열 수정
  - `StorybookSuccessCode.java`: `START_STORYBOOK`의 `HttpStatus`를 ` `CREATED`로 수정

- 나머지 컨트롤러 (`@Override` 통일)
  - `CalendarController.java`, `ExhibitionController.java`, `MemberController.java`, `MemberDeviceController.java`, `OnboardingController.java`, `RelationshipController.java`, `SettingController.java`, `TermController.java`
  - Docs 인터페이스를 구현하는 모든 메서드에 `@Override` 추가

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 기념일 생성
<img width="1075" height="1684" alt="image" src="https://github.com/user-attachments/assets/3a1732f1-951e-4f0c-9b10-7977552c209b" />

- 기념일 삭제
<img width="1079" height="1480" alt="image" src="https://github.com/user-attachments/assets/6fc258a1-8054-4cfd-bc19-d5c45bacfccd" />

- 스토리북 시작하기
<img width="1079" height="1335" alt="image" src="https://github.com/user-attachments/assets/22a845f8-bbde-485f-83f0-d508cad89862" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #238
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - 동화 시작 API 경로가 변경되었으며, 성공 시 HTTP 201 응답을 반환합니다.
  - 기념일 삭제 API가 요청 본문 대신 쿼리 파라미터로 여러 기념일 ID를 받도록 변경되었습니다.
  - 기념일 생성 API가 HTTP 상태 코드와 응답 본문을 함께 반환합니다.
  - 기념일 삭제 시 ID 목록이 비어 있으면 요청이 거부됩니다.

- **문서**
  - 관련 API 명세와 성공 응답 코드가 최신 동작에 맞게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->