### PR TITLE
[FIX] 캘린더 월간 조회의 스토리북 완성 판정 기준 수정

### DIFF
--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -36,8 +36,8 @@ public interface CalendarControllerDocs {
                     1. 인증된 회원을 조회합니다.
                     2. 요청한 연/월(year, month)의 시작일~종료일 범위를 계산합니다.
                     3. 해당 기간에 완료(COMPLETED)된 장 기록을 조회하여 완료 페이지 수(completedPageCount)와 기록이 있는 날짜(recordedDays)를 계산합니다.
-                    4. 회원의 전체 스토리북 진행 정보 중 해당 기간 내 마지막 장 순서(lastChapterOrder)가 10(전체 장 수)인 스토리북을 완성 스토리북(completedStorybooks)으로 집계합니다.
-                    5. 해당 기간 내 lastChapterOrder가 10 미만인 스토리북 수를 진행 중 스토리북 수(inProgressStorybookCount)로 집계합니다.
+                    4. 회원의 전체 스토리북 진행 정보 중 완료(COMPLETED)한 장이 10개(전체 장 수)이고 해당 기간 내 완료된 스토리북을 완성 스토리북(completedStorybooks)으로 집계합니다.
+                    5. 완료한 장이 10개 미만이고 해당 기간 내 기록이 있는 스토리북 수를 진행 중 스토리북 수(inProgressStorybookCount)로 집계합니다.
                     6. 계산된 통계와 완성 스토리북 목록을 반환합니다.
                     """
     )

--- a/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/calendar/controller/docs/CalendarControllerDocs.java
@@ -36,8 +36,8 @@ public interface CalendarControllerDocs {
                     1. 인증된 회원을 조회합니다.
                     2. 요청한 연/월(year, month)의 시작일~종료일 범위를 계산합니다.
                     3. 해당 기간에 완료(COMPLETED)된 장 기록을 조회하여 완료 페이지 수(completedPageCount)와 기록이 있는 날짜(recordedDays)를 계산합니다.
-                    4. 회원의 전체 스토리북 진행 정보 중 완료(COMPLETED)한 장이 10개(전체 장 수)이고 해당 기간 내 완료된 스토리북을 완성 스토리북(completedStorybooks)으로 집계합니다.
-                    5. 완료한 장이 10개 미만이고 해당 기간 내 기록이 있는 스토리북 수를 진행 중 스토리북 수(inProgressStorybookCount)로 집계합니다.
+                    4. 스토리북별로 완료(COMPLETED)한 장의 총 개수를 집계하여, 10개(전체 장 수)를 모두 완료했고 완성일이 해당 기간 내인 스토리북을 완성 스토리북(completedStorybooks)으로 집계합니다.
+                    5. 스토리북별 완료 장 총 개수가 10개 미만이면서, 해당 기간 내에 완료한 장이 있는 스토리북 수를 진행 중 스토리북 수(inProgressStorybookCount)로 집계합니다.                    
                     6. 계산된 통계와 완성 스토리북 목록을 반환합니다.
                     """
     )

--- a/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -55,8 +56,16 @@ public class CalendarService {
         List<MemberStorybook> memberStorybooks = memberStorybookRepository
                 .findAllByMemberWithStorybook(member);
 
+        Map<Long, Long> completedChapterCountByStorybook = memberChapterRepository
+                .findAllByMemberWithChapter(member).stream()
+                .filter(mc -> mc.getStatus() == Status.COMPLETED)
+                .collect(Collectors.groupingBy(
+                        mc -> mc.getChapter().getStorybook().getId(),
+                        Collectors.counting()));
+
         List<MemberStorybook> completedThisMonth = memberStorybooks.stream()
-                .filter(ms -> ms.getLastChapterOrder() == TOTAL_CHAPTER_COUNT)
+                .filter(ms -> completedChapterCountByStorybook
+                        .getOrDefault(ms.getStorybook().getId(), 0L) == TOTAL_CHAPTER_COUNT)
                 .filter(ms -> ms.getLastCompletedDate() != null
                         && !ms.getLastCompletedDate().isBefore(startDate)
                         && !ms.getLastCompletedDate().isAfter(endDate))
@@ -68,7 +77,8 @@ public class CalendarService {
         int completedStorybookCount = completedStorybooks.size();
 
         int inProgressStorybookCount = (int) memberStorybooks.stream()
-                .filter(ms -> ms.getLastChapterOrder() < TOTAL_CHAPTER_COUNT)
+                .filter(ms -> completedChapterCountByStorybook
+                        .getOrDefault(ms.getStorybook().getId(), 0L) < TOTAL_CHAPTER_COUNT)
                 .filter(ms -> ms.getLastCompletedDate() != null
                         && !ms.getLastCompletedDate().isBefore(startDate)
                         && !ms.getLastCompletedDate().isAfter(endDate))

--- a/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
+++ b/src/main/java/com/umc/halo/domain/calendar/service/CalendarService.java
@@ -56,12 +56,22 @@ public class CalendarService {
         List<MemberStorybook> memberStorybooks = memberStorybookRepository
                 .findAllByMemberWithStorybook(member);
 
-        Map<Long, Long> completedChapterCountByStorybook = memberChapterRepository
-                .findAllByMemberWithChapter(member).stream()
+        List<MemberChapter> allMemberChapters = memberChapterRepository
+                .findAllByMemberWithChapter(member);
+
+        Map<Long, Long> completedChapterCountByStorybook = allMemberChapters.stream()
                 .filter(mc -> mc.getStatus() == Status.COMPLETED)
                 .collect(Collectors.groupingBy(
                         mc -> mc.getChapter().getStorybook().getId(),
                         Collectors.counting()));
+
+        Set<Long> recordedStorybookIds = allMemberChapters.stream()
+                .filter(mc -> mc.getStatus() == Status.COMPLETED)
+                .filter(mc -> mc.getCompletedDate() != null
+                        && !mc.getCompletedDate().isBefore(startDate)
+                        && !mc.getCompletedDate().isAfter(endDate))
+                .map(mc -> mc.getChapter().getStorybook().getId())
+                .collect(Collectors.toSet());
 
         List<MemberStorybook> completedThisMonth = memberStorybooks.stream()
                 .filter(ms -> completedChapterCountByStorybook
@@ -79,9 +89,7 @@ public class CalendarService {
         int inProgressStorybookCount = (int) memberStorybooks.stream()
                 .filter(ms -> completedChapterCountByStorybook
                         .getOrDefault(ms.getStorybook().getId(), 0L) < TOTAL_CHAPTER_COUNT)
-                .filter(ms -> ms.getLastCompletedDate() != null
-                        && !ms.getLastCompletedDate().isBefore(startDate)
-                        && !ms.getLastCompletedDate().isAfter(endDate))
+                .filter(ms -> recordedStorybookIds.contains(ms.getStorybook().getId()))
                 .count();
 
 


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 캘린더 월간 조회의 스토리북 완성 판정 기준을 `last_chapter_order` → `COMPLETED 장 개수`로 변경했습니다.
- 기존에는 장을 임시저장(DRAFT)만 해도 `last_chapter_order`가 증가해, 10장을 임시저장한 스토리북이 캘린더에서 "완성"으로 집계되는 문제가 있었습니다. (테마함은 COMPLETED 장 개수 기준이라 "진행중"으로 나와 두 화면의 결과가 달랐습니다) 
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `CalendarService.getMonthly()` — 스토리북별 COMPLETED 장 개수 집계 추가, 완성/진행중 판정 기준 교체
  - `MemberChapterRepository.findAllByMemberWithChapter` 재사용 (테마함이 이미 사용 중인 메서드)
- `CalendarControllerDocs` — Swagger 동작 설명의 판정 기준 문구 수정
***
- `CalendarService.getMonthly()` — `inProgressStorybookCount` 집계 기준 변경
  - `member_storybook.last_completed_date` 월 범위 → 해당 월에 완료한 장이 있는 스토리북 기준
  - `last_completed_date`는 장 완료 시마다 최신 날짜로 덮어써져, 과거 월 조회 시 그 달에 진행 중이던 스토리북이 누락되는 문제가 있었습니다.
  - CodeRabbit 리뷰 지적 사항을 같은 PR에서 반영했습니다.
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- **① 10장 전부 완료 (회원 1)— 기존 동작 유지 확인**
<img width="1154" height="488" alt="스크린샷 2026-08-12 오후 9 10 04" src="https://github.com/user-attachments/assets/7f4312b1-7830-42c4-883d-29cc301c74bb" />
 


- **② 9장 완료 + 10장 임시저장 (회원 2) — 버그 수정 확인**
<img width="1105" height="422" alt="스크린샷 2026-08-12 오후 9 12 56" src="https://github.com/user-attachments/assets/9349e413-5d17-40bd-9ceb-75379b48659a" />


- **③ 동일 계정 테마함 조회 — 판정 일치 확인**
<img width="1143" height="451" alt="스크린샷 2026-08-12 오후 9 12 39" src="https://github.com/user-attachments/assets/c2408b74-7efb-4901-b17d-8423e4d826b2" />

---
## ✅ 확인 사항

- [X] 서버 정상 기동 확인
- [X] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [X] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #245 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- DB 스키마 변경 없음 (마이그레이션 없음), 조회 로직만 수정했습니다.
- API 응답 구조(필드명·타입·Nullable) 변경 없음 → 안드로이드 영향 없음


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 월간 캘린더에서 동화책 완료 여부를 마지막 장 순서가 아닌 전체 챕터 완료 수를 기준으로 정확히 집계합니다.
  * 완료 챕터가 10개인 동화책은 완료로, 10개 미만이며 해당 기간 내 기록이 있는 동화책은 진행 중으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->