### PR TITLE
[FIX] 온보딩 API 회원 조회 실패 시 에러 코드 통일

### DIFF
--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -158,18 +158,31 @@ public interface OnboardingControllerDocs {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "404",
-                    description = "존재하지 않는 태그",
+                    description = "존재하지 않는 태그 / 존재하지 않는 회원",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "code": "ONBOARDING404_1",
-                                      "message": "존재하지 않는 태그입니다.",
-                                      "result": null
-                                    }
-                                    """)
-
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하지 않는 태그",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "ONBOARDING404_1",
+                                                      "message": "존재하지 않는 태그입니다.",
+                                                      "result": null
+                                                    }
+                                                    """),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 회원 (탈퇴 등)",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "MEMBER404_1",
+                                                      "message": "존재하지 않는 회원입니다.",
+                                                      "result": null
+                                                    }
+                                                    """)
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -197,21 +210,6 @@ public interface OnboardingControllerDocs {
                                       "isSuccess": false,
                                       "code": "ONBOARDING500_1",
                                       "message": "배정 가능한 캐릭터가 존재하지 않습니다.",
-                                      "result": null
-                                    }
-                                    """)
-                    )
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "존재하지 않는 회원 (탈퇴 등)",
-                    content = @Content(
-                            mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "code": "MEMBER404_1",
-                                      "message": "존재하지 않는 회원입니다.",
                                       "result": null
                                     }
                                     """)

--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -77,6 +77,21 @@ public interface OnboardingControllerDocs {
                                     }
                                     """)
                     )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원 (탈퇴 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
             )
     })
     ApiResponse<OnboardingResDTO.NicknameCheck> checkNickname(
@@ -186,6 +201,21 @@ public interface OnboardingControllerDocs {
                                     }
                                     """)
                     )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원 (탈퇴 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
             )
     })
     ApiResponse<OnboardingResDTO.Save> saveOnboarding(
@@ -249,6 +279,21 @@ public interface OnboardingControllerDocs {
                                       "isSuccess": false,
                                       "code": "AUTH401_1",
                                       "message": "토큰이 만료되었습니다.",
+                                      "result": null
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 회원 (탈퇴 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": "MEMBER404_1",
+                                      "message": "존재하지 않는 회원입니다.",
                                       "result": null
                                     }
                                     """)

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -2,6 +2,8 @@ package com.umc.halo.domain.onboarding.service;
 
 import com.umc.halo.domain.content.storybook.entity.StorybookCharacter;
 import com.umc.halo.domain.content.storybook.repository.StorybookCharacterRepository;
+import com.umc.halo.domain.member.exception.MemberException;
+import com.umc.halo.domain.member.exception.code.MemberErrorCode;
 import com.umc.halo.domain.member.repository.MemberRepository;
 import com.umc.halo.domain.onboarding.dto.OnboardingResDTO;
 import com.umc.halo.domain.onboarding.exception.OnboardingException;
@@ -47,7 +49,7 @@ public class OnboardingService {
 
         validateNicknameFormat(nickname);
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
         if (nickname.equals(member.getName())) {
             return OnboardingConverter.toNicknameCheck(true);
@@ -68,7 +70,7 @@ public class OnboardingService {
     public OnboardingResDTO.Save saveOnboarding(Long memberId, OnboardingReqDTO.Save request) {
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
         Integer step = request.step();
         if (step == null || step < 1 || step > 5) {
@@ -160,7 +162,7 @@ public class OnboardingService {
     public OnboardingResDTO.Status getStatus(Long memberId) {
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
         // 아직 온보딩 시작 전
         if (member.getOnboardingStep() == null) {


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 온보딩 API 3종에서 토큰의 회원이 DB에 없을 때(탈퇴 등) `400 ONBOARDING400_3`("필수 입력값이 누락되었습니다.")을 반환하던 것을 `404 MEMBER404_1`로 변경
- `JwtAuthFilter`가 토큰의 서명·만료만 검증하기 때문에, 탈퇴 후 만료되지 않은 accessToken으로 요청하면 실제로 발생하는 응답이었음
- 다른 도메인(관계 정보 / 캘린더 / 약관 / 테마함)은 같은 상황에서 이미 `MEMBER404_1`을 반환하고 있어 온보딩만 달랐음
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
- `OnboardingService` — 회원 조회 3곳(`checkNickname` / `saveOnboarding` / `getStatus`)의 `orElseThrow`를 `MemberException(NOT_FOUND)`으로 변경
- `OnboardingControllerDocs` — 위 3개 API에 404 `MEMBER404_1` 응답 예시 추가

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- Swagger 문서에서 온보딩 3개 API의 Responses에 404 `MEMBER404_1`이 정상 노출되는 것을 확인했음
<img width="1147" height="277" alt="스크린샷 2026-08-12 오후 9 41 39" src="https://github.com/user-attachments/assets/b6604ea5-9c05-49cc-97fa-3718d458a37c" />
<img width="1162" height="276" alt="스크린샷 2026-08-12 오후 9 41 58" src="https://github.com/user-attachments/assets/5c471bf9-4a17-4b50-b93f-3043963a8f3a" />
<img width="1138" height="260" alt="스크린샷 2026-08-12 오후 9 42 19" src="https://github.com/user-attachments/assets/5a4e2e61-44a6-49f1-86bd-48cf60c86bbe" />

---

## ✅ 확인 사항

- [X] 서버 정상 기동 확인
- [X] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [X] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #247 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- `ONBOARDING400_3`은 삭제하지 않았습니다. step 범위 검증 및 step별 필수 입력값 누락 상황에서는 그대로 사용됩니다.
- 신규 에러 코드 추가 없이 기존 `MEMBER404_1`을 재사용했습니다.
- DB 스키마 변경 없음 (마이그레이션 없음)

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 탈퇴 등으로 존재하지 않는 회원이 닉네임 중복 확인, 온보딩 정보 저장, 온보딩 상태 조회를 요청할 경우 일관되게 회원 없음 오류(404)로 처리됩니다.
  * 잘못된 회원 정보로 인한 예외 응답이 명확해져 API 이용 시 오류 상황을 쉽게 파악할 수 있습니다.

* **문서**
  * 관련 온보딩 API 문서에 회원 없음(404) 응답 예시가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->