### PR TITLE
[fix] mem_limit을 호스트 실제 용량 기준으로 조정, JVM_OPTS 개별 지정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,9 @@ services:
     restart: unless-stopped
     init: true
     stop_grace_period: 40s
-    mem_limit: 1536m
+    mem_limit: 480m
+    environment:
+      - JVM_OPTS=-Xms128m -Xmx320m -XX:+UseG1GC -XX:MaxMetaspaceSize=128m -Duser.timezone=Asia/Seoul
     logging:
       driver: json-file
       options:
@@ -38,7 +40,9 @@ services:
     restart: unless-stopped
     init: true
     stop_grace_period: 40s
-    mem_limit: 1024m
+    mem_limit: 288m
+    environment:
+      - JVM_OPTS=-Xms64m -Xmx144m -XX:+UseG1GC -XX:MaxMetaspaceSize=112m -Duser.timezone=Asia/Seoul
     logging:
       driver: json-file
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,9 @@ services:
     init: true
     stop_grace_period: 40s
     mem_limit: 480m
+    memswap_limit: 480m
     environment:
-      - JVM_OPTS=-Xms128m -Xmx320m -XX:+UseG1GC -XX:MaxMetaspaceSize=128m -Duser.timezone=Asia/Seoul
+      - JVM_OPTS=-Xms128m -Xmx280m -XX:+UseG1GC -XX:MaxMetaspaceSize=100m -Duser.timezone=Asia/Seoul
     logging:
       driver: json-file
       options:
@@ -41,8 +42,9 @@ services:
     init: true
     stop_grace_period: 40s
     mem_limit: 288m
+    memswap_limit: 288m
     environment:
-      - JVM_OPTS=-Xms64m -Xmx144m -XX:+UseG1GC -XX:MaxMetaspaceSize=112m -Duser.timezone=Asia/Seoul
+      - JVM_OPTS=-Xms64m -Xmx144m -XX:+UseG1GC -XX:MaxMetaspaceSize=64m -Duser.timezone=Asia/Seoul
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- EC2(t3.micro)에서 prod/dev 컨테이너가 메모리 제한 없이 동시 실행되어 스왑을 과도하게 사용하던 문제 해결
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `docker-compose.yml`: prod, dev 서비스별 mem_limit을 호스트 실제 용량 기준으로 조정, 서비스별 environment에 JVM_OPTS 개별 지정하여 Dockerfile 공통 기본값을 prod/dev 각각 다른 힙 크기로 덮어쓰기
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #255
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 애플리케이션 실행 환경의 메모리 및 스왑 사용량을 조정했습니다.
  * 실행 안정성을 높이기 위해 JVM 힙, 메타스페이스, 가비지 컬렉션 및 서울 시간대 설정을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->