### PR TITLE
[fix] 실제 동작과 명세 불일치 수정 (CHAPTER400_3, SettingControllerDocs @Tag)

### DIFF
--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -36,7 +36,7 @@ public interface RecordControllerDocs {
                     4. 진행 중인 장 순서를 기준으로 요청한 장에 접근 가능한지 검증합니다. 아직 열리지 않은 장이면 403(CHAPTER403_1), 이미 완료한 장이면 403(CHAPTER403_2)을 반환합니다.
                     5. coverType과 imageKey/sceneCardId 조합이 일치하는지 검증합니다. (CHAPTER400_1)
                     6. coverType이 IMAGE이고 새로 업로드한 imageKey(기존 기록과 다른 값)이면, 소유권 및 S3 실재 여부를 확인합니다. 본인이 업로드한 이미지가 아니거나 S3에 존재하지 않으면 404(IMAGE404_1), 용량 제한을 초과했으면 400(IMAGE400_2)을 반환합니다.
-                    7. 각 답변의 chapterQuestionId가 실재하는 질문인지(CHAPTER404_2), 해당 장의 질문이 맞는지(CHAPTER400_3) 검증합니다.
+                    7. 같은 chapterQuestionId에 대한 답변이 중복되지 않았는지(CHAPTER400_7), 각 답변의 chapterQuestionId가 실재하는 질문인지(CHAPTER404_2), 해당 장의 질문이 맞는지(CHAPTER400_3) 검증합니다.
                     8. status가 COMPLETED이면 coverType, emotion이 모두 입력되었는지, 장의 모든 질문에 답변했는지 검증합니다. (CHAPTER400_4~6)
                     9. sceneCardId가 있으면 해당 장의 장면 카드가 맞는지 확인합니다. (CHAPTER400_2)
                     10. 장 기록(MemberChapter)을 생성하거나 갱신합니다. 동시 요청으로 중복 저장이 발생하면 409(CHAPTER409_2)를 반환합니다.
@@ -150,6 +150,17 @@ public interface RecordControllerDocs {
                                                                 "isSuccess": false,
                                                                 "code": "CHAPTER400_6",
                                                                 "message": "감정 선택이 필요합니다.",
+                                                                "result": null
+                                                            }
+                                                            """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "같은 질문(answers[].chapterQuestionId)에 대한 답변 중복",
+                                                    value = """
+                                                            {
+                                                                "isSuccess": false,
+                                                                "code": "CHAPTER400_7",
+                                                                "message": "같은 질문에 대한 답변이 중복되었습니다.",
                                                                 "result": null
                                                             }
                                                             """

--- a/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/record/controller/docs/RecordControllerDocs.java
@@ -36,11 +36,12 @@ public interface RecordControllerDocs {
                     4. 진행 중인 장 순서를 기준으로 요청한 장에 접근 가능한지 검증합니다. 아직 열리지 않은 장이면 403(CHAPTER403_1), 이미 완료한 장이면 403(CHAPTER403_2)을 반환합니다.
                     5. coverType과 imageKey/sceneCardId 조합이 일치하는지 검증합니다. (CHAPTER400_1)
                     6. coverType이 IMAGE이고 새로 업로드한 imageKey(기존 기록과 다른 값)이면, 소유권 및 S3 실재 여부를 확인합니다. 본인이 업로드한 이미지가 아니거나 S3에 존재하지 않으면 404(IMAGE404_1), 용량 제한을 초과했으면 400(IMAGE400_2)을 반환합니다.
-                    7. status가 COMPLETED이면 coverType, emotion이 모두 입력되었는지, 장의 모든 질문에 답변했는지 검증합니다. (CHAPTER400_4~6)
-                    8. sceneCardId가 있으면 해당 장의 장면 카드가 맞는지 확인합니다. (CHAPTER400_2)
-                    9. 장 기록(MemberChapter)을 생성하거나 갱신합니다. 동시 요청으로 중복 저장이 발생하면 409(CHAPTER409_2)를 반환합니다.
-                    10. 기존 답변을 삭제하고 요청받은 답변을 새로 저장합니다. 각 답변의 chapterQuestionId가 해당 장의 질문인지 검증합니다. (CHAPTER400_3)
-                    11. status가 COMPLETED면 스토리북 진행 상태를 갱신하고 AI 요약 생성 이벤트를 발행합니다. 마지막 장(10번째)이면 isStorybookCompleted를 true로 반환합니다. status가 DRAFT면 임시저장 상태로 진행 정보를 갱신합니다.
+                    7. 각 답변의 chapterQuestionId가 실재하는 질문인지(CHAPTER404_2), 해당 장의 질문이 맞는지(CHAPTER400_3) 검증합니다.
+                    8. status가 COMPLETED이면 coverType, emotion이 모두 입력되었는지, 장의 모든 질문에 답변했는지 검증합니다. (CHAPTER400_4~6)
+                    9. sceneCardId가 있으면 해당 장의 장면 카드가 맞는지 확인합니다. (CHAPTER400_2)
+                    10. 장 기록(MemberChapter)을 생성하거나 갱신합니다. 동시 요청으로 중복 저장이 발생하면 409(CHAPTER409_2)를 반환합니다.
+                    11. 기존 답변을 삭제하고 요청받은 답변을 새로 저장합니다.
+                    12. status가 COMPLETED면 스토리북 진행 상태를 갱신하고 AI 요약 생성 이벤트를 발행합니다. 마지막 장(10번째)이면 isStorybookCompleted를 true로 반환합니다. status가 DRAFT면 임시저장 상태로 진행 정보를 갱신합니다.
 
                     ## 참고
                     - 6번에서 새 이미지의 소유권·실재 여부만 확인하고 응답을 반환하며, 실제 최종 위치로의 이동(S3 copy/delete)은 응답 반환 이후 비동기로 처리됩니다. 그 사이에도 imageKey는 항상 실제 조회 가능한 파일을 가리킵니다.

--- a/src/main/java/com/umc/halo/domain/record/exception/code/RecordErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/record/exception/code/RecordErrorCode.java
@@ -12,6 +12,7 @@ public enum RecordErrorCode implements BaseErrorCode {
     INCOMPLETE_ANSWERS(HttpStatus.BAD_REQUEST, "CHAPTER400_4", "모든 장 질문에 대한 답변이 필요합니다."),
     MISSING_COVER_TYPE(HttpStatus.BAD_REQUEST, "CHAPTER400_5", "커버 타입 선택이 필요합니다."),
     MISSING_EMOTION(HttpStatus.BAD_REQUEST, "CHAPTER400_6", "감정 선택이 필요합니다."),
+    DUPLICATE_ANSWER(HttpStatus.BAD_REQUEST, "CHAPTER400_7", "같은 질문에 대한 답변이 중복되었습니다."),
 
     NOT_COMPLETED_MEMBER_CHAPTER(HttpStatus.FORBIDDEN, "CHAPTER403_4", "아직 완료되지 않은 장 기록입니다."),
 

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -97,6 +97,27 @@ public class RecordService {
             }
         }
 
+        // 답변한 질문이 실재하는지, 해당 장의 질문이 맞는지 검증
+        Set<Long> answeredQuestionIds = recordReqDTO.answers() == null ? Set.of()
+                : recordReqDTO.answers().stream()
+                .map(RecordReqDTO.WriteChapterRecord.Answer::chapterQuestionId)
+                .collect(Collectors.toSet());
+
+        if (!answeredQuestionIds.isEmpty()) {
+            Map<Long, ChapterQuestion> chapterQuestionById = chapterQuestionRepository.findAllById(answeredQuestionIds)
+                    .stream().collect(Collectors.toMap(ChapterQuestion::getId, cq -> cq));
+
+            for (Long chapterQuestionId : answeredQuestionIds) {
+                ChapterQuestion chapterQuestion = chapterQuestionById.get(chapterQuestionId);
+                if (chapterQuestion == null) {
+                    throw new ChapterException(ChapterErrorCode.NOT_FOUND_CHAPTER_QUESTION);
+                }
+                if (!chapterQuestion.getChapter().getId().equals(chapter.getId())) {
+                    throw new ChapterException(ChapterErrorCode.UNMATCHED_CHAPTER_QUESTION);
+                }
+            }
+        }
+
         // COMPLETED 상태일 경우 필수값 검증
         if (recordReqDTO.status() == Status.COMPLETED) {
             if (recordReqDTO.coverType() == null) {
@@ -109,10 +130,6 @@ public class RecordService {
             // 장 질문 답변이 모두 채워졌는지 검증
             Set<Long> requiredQuestionIds = chapterQuestionRepository.findByChapter(chapter).stream()
                     .map(ChapterQuestion::getId)
-                    .collect(Collectors.toSet());
-            Set<Long> answeredQuestionIds = recordReqDTO.answers() == null ? Set.of()
-                    : recordReqDTO.answers().stream()
-                    .map(RecordReqDTO.WriteChapterRecord.Answer::chapterQuestionId)
                     .collect(Collectors.toSet());
             if (!answeredQuestionIds.containsAll(requiredQuestionIds)) {
                 throw new RecordException(RecordErrorCode.INCOMPLETE_ANSWERS);

--- a/src/main/java/com/umc/halo/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/halo/domain/record/service/RecordService.java
@@ -97,25 +97,34 @@ public class RecordService {
             }
         }
 
-        // 답변한 질문이 실재하는지, 해당 장의 질문이 맞는지 검증
-        Set<Long> answeredQuestionIds = recordReqDTO.answers() == null ? Set.of()
+        // 같은 질문에 답변이 중복 전송되었는지 검증
+        List<Long> answeredQuestionIdList = recordReqDTO.answers() == null ? List.of()
                 : recordReqDTO.answers().stream()
                 .map(RecordReqDTO.WriteChapterRecord.Answer::chapterQuestionId)
-                .collect(Collectors.toSet());
+                .toList();
+        Set<Long> answeredQuestionIds = new HashSet<>(answeredQuestionIdList);
+        if (answeredQuestionIds.size() != answeredQuestionIdList.size()) {
+            throw new RecordException(RecordErrorCode.DUPLICATE_ANSWER);
+        }
 
-        if (!answeredQuestionIds.isEmpty()) {
-            Map<Long, ChapterQuestion> chapterQuestionById = chapterQuestionRepository.findAllById(answeredQuestionIds)
-                    .stream().collect(Collectors.toMap(ChapterQuestion::getId, cq -> cq));
+        // 해당 장의 질문 ID (소속 검증과 완료 검증에 공통 사용, 둘 다 필요 없으면 조회 생략)
+        boolean needsChapterQuestions = !answeredQuestionIds.isEmpty() || recordReqDTO.status() == Status.COMPLETED;
+        Set<Long> chapterQuestionIds = needsChapterQuestions
+                ? chapterQuestionRepository.findByChapter(chapter).stream()
+                .map(ChapterQuestion::getId)
+                .collect(Collectors.toSet())
+                : Set.of();
 
-            for (Long chapterQuestionId : answeredQuestionIds) {
-                ChapterQuestion chapterQuestion = chapterQuestionById.get(chapterQuestionId);
-                if (chapterQuestion == null) {
-                    throw new ChapterException(ChapterErrorCode.NOT_FOUND_CHAPTER_QUESTION);
-                }
-                if (!chapterQuestion.getChapter().getId().equals(chapter.getId())) {
-                    throw new ChapterException(ChapterErrorCode.UNMATCHED_CHAPTER_QUESTION);
-                }
+        // 답변한 질문이 해당 장의 질문이 맞는지 검증
+        if (!chapterQuestionIds.containsAll(answeredQuestionIds)) {
+            Set<Long> unknownQuestionIds = answeredQuestionIds.stream()
+                    .filter(id -> !chapterQuestionIds.contains(id))
+                    .collect(Collectors.toSet());
+            // 실재하지 않는 질문인지 검증
+            if (chapterQuestionRepository.findAllById(unknownQuestionIds).size() < unknownQuestionIds.size()) {
+                throw new ChapterException(ChapterErrorCode.NOT_FOUND_CHAPTER_QUESTION);
             }
+            throw new ChapterException(ChapterErrorCode.UNMATCHED_CHAPTER_QUESTION);
         }
 
         // COMPLETED 상태일 경우 필수값 검증
@@ -128,10 +137,7 @@ public class RecordService {
             }
 
             // 장 질문 답변이 모두 채워졌는지 검증
-            Set<Long> requiredQuestionIds = chapterQuestionRepository.findByChapter(chapter).stream()
-                    .map(ChapterQuestion::getId)
-                    .collect(Collectors.toSet());
-            if (!answeredQuestionIds.containsAll(requiredQuestionIds)) {
+            if (!answeredQuestionIds.containsAll(chapterQuestionIds)) {
                 throw new RecordException(RecordErrorCode.INCOMPLETE_ANSWERS);
             }
         }

--- a/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/setting/controller/docs/SettingControllerDocs.java
@@ -13,7 +13,7 @@ import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "알림 API")
+@Tag(name = "설정 API")
 public interface SettingControllerDocs {
 
     // 알림 설정 조회


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 장 기록 작성 API(POST /api/v1/member-chapters)에서 다른 장의 chapterQuestionId를 보냈을 때, 의도한 CHAPTER400_3(해당 장의 질문이 아닙니다)이 아니라 CHAPTER400_4(모든 장 질문에 대한 답변이 필요합니다)가 반환되던 문제를 수정
- 같은 질문에 대한 답변이 중복 전송되어도 검증 없이 통과하여, DRAFT 저장 시 같은 질문의 답변이 여러 행으로 저장되던 문제를 수정
- SettingControllerDocs의 @Tag가 실제 문서화 범위와 맞지 않던 부분을 수정
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `RecordService.validate()`
  - 답변 질문 검증을 status와 무관하게 수행하고, 완료 검증(INCOMPLETE_ANSWERS)보다 앞에 배치
  - 같은 chapterQuestionId가 중복 전송되면 DUPLICATE_ANSWER(CHAPTER400_7) 반환
  - 해당 장의 질문 목록(findByChapter)을 소속 검증과 완료 검증에 공통 사용하고, 둘 다 불필요하면 조회 생략
  - 소속 검증에서 걸러진 ID에 대해서만 실재 여부를 재조회: 없는 ID면 `NOT_FOUND_CHAPTER_QUESTION(CHAPTER404_2)`, 장이 다르면 `UNMATCHED_CHAPTER_QUESTION(CHAPTER400_3)`
- `RecordErrorCode`
  - `DUPLICATE_ANSWER(CHAPTER400_7, "같은 질문에 대한 답변이 중복되었습니다.")` 추가
- `RecordControllerDocs`: 동작 방식 순서를 실제 검증 순서에 맞게 갱신, CHAPTER400_7 응답 예시 추가
- `SettingControllerDocs`: `@Tag`(name = "알림 API") → `@Tag`(name = "설정 API")
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- COMPLETED CHAPTER400_3 확인
<img width="1079" height="1279" alt="image" src="https://github.com/user-attachments/assets/97f5877b-6eff-476b-9f81-240c1e13040e" />
- DRAFT CHAPTER400_4 확인
<img width="1079" height="1306" alt="image" src="https://github.com/user-attachments/assets/bf0115bc-aefd-4e8c-bca7-b63a64992cfe" />


---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #259
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-
