### PR TITLE
[fix] 접근 제한 해제 설정 복구

### DIFF
--- a/nginx/fragments/20-dev-app.conf.template
+++ b/nginx/fragments/20-dev-app.conf.template
@@ -28,9 +28,8 @@ server {
     ssl_protocols TLSv1.2 TLSv1.3;
 
     # 개발 환경은 팀 외 접근 차단
-    # TODO: 과제 제출 기간 임시 해제 (issue #110)
-    # auth_basic "Restricted";
-    # auth_basic_user_file /etc/nginx/.htpasswd;
+    auth_basic "Restricted";
+    auth_basic_user_file /etc/nginx/.htpasswd;
 
     location /actuator {
         return 404;

--- a/nginx/fragments/20-dev-app.conf.template
+++ b/nginx/fragments/20-dev-app.conf.template
@@ -35,7 +35,16 @@ server {
         return 404;
     }
 
+    location /api/ {
+        auth_basic off;
+
+        proxy_pass http://dev_app_upstream;
+        include /etc/nginx/fragments/proxy-common.conf;
+    }
+
     location = /api/v1/auth/login {
+        auth_basic off;
+
         # 브루트포스/트래픽 폭주 방지용 rate limit
         limit_req zone=auth_limit burst=10 nodelay;
         limit_req_status 429;
@@ -45,6 +54,8 @@ server {
     }
 
     location = /api/v1/auth/reissue {
+        auth_basic off;
+
         # 브루트포스/트래픽 폭주 방지용 rate limit
         limit_req zone=auth_limit burst=10 nodelay;
         limit_req_status 429;

--- a/nginx/fragments/20-dev-app.conf.template
+++ b/nginx/fragments/20-dev-app.conf.template
@@ -65,6 +65,7 @@ server {
     }
 
     location / {
+        proxy_set_header Authorization "";
         proxy_pass http://dev_app_upstream;
         include /etc/nginx/fragments/proxy-common.conf;
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,12 +11,11 @@ logging:
   level:
     org.hibernate.SQL: !!str info
 
-# TODO: 과제 채점 기한 임시 해제
 springdoc:
   api-docs:
-    enabled: true
+    enabled: false
   swagger-ui:
-    enabled: true
+    enabled: false
 
 management:
   endpoints:


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 과제 채점 기한 동안 임시로 열어뒀던 접근 제한 해제 설정 복구
  - dev 환경 nginx Basic Auth 재적용
  - 운영(prod) 환경 Swagger UI / API docs 재차단
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- 20-dev-app.conf.template: auth_basic / auth_basic_user_file 주석 해제 (개발 서버 접근시 팀 인증 필요)
- application-prod.yml: springdoc.api-docs.enabled, springdoc.swagger-ui.enabled (운영 서버의 스웨거 열람 불가능)
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [ ] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #272
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **보안 강화**
  * 개발 환경의 HTTPS 접속에 Basic 인증을 적용했습니다.
  * 인증된 사용자만 보호된 개발 서버에 접근할 수 있습니다.
  * 로그인 및 인증 토큰 갱신 API는 Basic 인증 없이 이용할 수 있습니다.

* **설정 변경**
  * 프로덕션 환경에서 API 문서와 Swagger UI를 비활성화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->