### PR TITLE
[FIX] 온보딩 저장 시 단계 순서 검증 추가

### DIFF
--- a/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/controller/docs/OnboardingControllerDocs.java
@@ -117,12 +117,13 @@ public interface OnboardingControllerDocs {
 
                     ## 동작 방식
                     1. 요청받은 step(1~5)에 따라 필요한 필드를 검증합니다. 필수값이 없으면 400(ONBOARDING400_3)을 반환합니다.
-                    2. step 1은 이름/닉네임 형식을, step 2는 성별과 생년월일(미래 날짜 불가)을 검증합니다.
-                    3. step 3(부모님 성향 태그, 최대 3개)/step 4(현재 관계 상태 태그, 1개)/step 5(목표 관계 태그, 1~2개)는 각각 해당 카테고리의 태그인지 확인하고, 존재하지 않는 태그면 404(ONBOARDING404_1)를 반환합니다.
-                    4. 태그가 포함된 step은 기존 태그를 삭제하고 새로 저장합니다.
-                    5. 회원의 온보딩 단계(onboardingStep)를 갱신합니다.
-                    6. step이 5(마지막 단계)이면 온보딩을 완료 처리하고, 등록된 캐릭터 중 하나를 무작위로 배정합니다.
-                    7. 저장된 단계와 완료 여부를 반환합니다.
+                    2. 이전 단계를 완료하지 않고 건너뛴 경우 400(ONBOARDING400_7)을 반환합니다. 저장된 단계 + 1 이하만 허용하며, 이전 단계 재저장(수정)은 가능합니다.
+                    3. step 1은 이름/닉네임 형식을, step 2는 성별과 생년월일(미래 날짜 불가)을 검증합니다.
+                    4. step 3(부모님 성향 태그, 최대 3개)/step 4(현재 관계 상태 태그, 1개)/step 5(목표 관계 태그, 1~2개)는 각각 해당 카테고리의 태그인지 확인하고, 존재하지 않는 태그면 404(ONBOARDING404_1)를 반환합니다.
+                    5. 태그가 포함된 step은 기존 태그를 삭제하고 새로 저장합니다.
+                    6. 회원의 온보딩 단계(onboardingStep)를 갱신합니다.
+                    7. step이 5(마지막 단계)이면 온보딩을 완료 처리하고, 등록된 캐릭터 중 하나를 무작위로 배정합니다.
+                    8. 저장된 단계와 완료 여부를 반환합니다.
                     """
     )
     @ApiResponses(value = {
@@ -143,17 +144,31 @@ public interface OnboardingControllerDocs {
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(
                     responseCode = "400",
-                    description = "필수값 누락 / 태그 개수 초과",
+                    description = "필수값 누락 / 태그 개수 초과 / 단계 순서 위반",
                     content = @Content(
                             mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "isSuccess": false,
-                                      "code": "ONBOARDING400_3",
-                                      "message": "필수 입력값이 누락되었습니다.",
-                                      "result": null
-                                    }
-                                    """)
+                            examples = {
+                                    @ExampleObject(
+                                            name = "필수값 누락",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "ONBOARDING400_3",
+                                                      "message": "필수 입력값이 누락되었습니다.",
+                                                      "result": null
+                                                    }
+                                                    """),
+                                    @ExampleObject(
+                                            name = "단계 순서 위반",
+                                            value = """
+                                                    {
+                                                      "isSuccess": false,
+                                                      "code": "ONBOARDING400_7",
+                                                      "message": "이전 단계를 먼저 완료해주세요.",
+                                                      "result": null
+                                                    }
+                                                    """)
+                            }
                     )
             ),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(

--- a/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingErrorCode.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/exception/code/OnboardingErrorCode.java
@@ -28,6 +28,9 @@ public enum OnboardingErrorCode implements BaseErrorCode {
     INVALID_TAG_CATEGORY(HttpStatus.BAD_REQUEST,
             "ONBOARDING400_6",
             "해당 단계에 맞지 않는 태그입니다."),
+    INVALID_STEP_SEQUENCE(HttpStatus.BAD_REQUEST,
+            "ONBOARDING400_7",
+            "이전 단계를 먼저 완료해주세요."),
 
     // 404
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND,

--- a/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/umc/halo/domain/onboarding/service/OnboardingService.java
@@ -77,6 +77,11 @@ public class OnboardingService {
             throw new OnboardingException(OnboardingErrorCode.MISSING_REQUIRED_FIELD);
         }
 
+        int savedStep = (member.getOnboardingStep() == null) ? 0 : member.getOnboardingStep();
+        if (step > savedStep + 1) {
+            throw new OnboardingException(OnboardingErrorCode.INVALID_STEP_SEQUENCE);
+        }
+
         switch (step) {
             case 1 -> {
                 if (request.name() == null) {


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 온보딩 저장 API가 `step` 범위(1~5)만 검증하고 순서를 검증하지 않아, 온보딩을 시작하지 않은 회원이 `step: 5`를 바로 보내도 완료 처리되던 문제를 수정했음.
- 저장된 단계 + 1 이하만 허용하도록 검증 추가. 이전 단계 재저장(뒤로가기 수정)은 기존과 동일하게 허용됨.
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `OnboardingErrorCode` : `INVALID_STEP_SEQUENCE(ONBOARDING400_7)` 추가
- `OnboardingService.saveOnboarding()` : 태그 저장 등 부수효과 발생 전에 순서 검증 추가
- `OnboardingControllerDocs` : 동작 방식 및 400 응답 예시 갱신
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
<img width="521" height="219" alt="스크린샷 2026-09-05 오전 2 23 20" src="https://github.com/user-attachments/assets/275c54d0-f13c-4e60-a35e-6ba833537c36" />

<img width="820" height="273" alt="스크린샷 2026-09-05 오전 2 26 19" src="https://github.com/user-attachments/assets/189dfd48-937f-4d3d-b538-978ad11b2adf" />

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #275 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 온보딩 단계 저장 시 이전 단계를 건너뛰는 요청을 제한합니다.
  * 허용되지 않는 단계 순서로 요청하면 `ONBOARDING400_7` 오류가 반환됩니다.

* **문서**
  * 온보딩 단계 저장 규칙과 단계 순서 위반 오류 응답 예시를 업데이트했습니다.
  * 필수값 누락 및 단계 순서 위반 사례를 구분해 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->