### PR TITLE
[Refactor] AI 호출 제한 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
 
     // Ai Rate Limit
     implementation "com.bucket4j:bucket4j-core:8.10.1"
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.2.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 
     // Firebase
     implementation 'com.google.firebase:firebase-admin:9.8.0'
+
+    // Ai Rate Limit
+    implementation "com.bucket4j:bucket4j-core:8.10.1"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/halo/domain/record/service/ChapterRecordWriter.java
+++ b/src/main/java/com/umc/halo/domain/record/service/ChapterRecordWriter.java
@@ -150,6 +150,7 @@ public class ChapterRecordWriter {
 
             // ai로 answer 3개 요약
             applicationEventPublisher.publishEvent(new ChapterCompletedEvent(
+                    memberId,
                     memberChapter.getId(),
                     chapter.getStorybook().getTitle(),
                     chapter.getTitle(),

--- a/src/main/java/com/umc/halo/global/ai/event/ChapterCompletedEvent.java
+++ b/src/main/java/com/umc/halo/global/ai/event/ChapterCompletedEvent.java
@@ -1,6 +1,7 @@
 package com.umc.halo.global.ai.event;
 
 public record ChapterCompletedEvent(
+        Long memberId,
         Long memberChapterId,
         String storybookTitle,
         String chapterTitle,

--- a/src/main/java/com/umc/halo/global/ai/exception/code/AiErrorCode.java
+++ b/src/main/java/com/umc/halo/global/ai/exception/code/AiErrorCode.java
@@ -12,7 +12,7 @@ public enum AiErrorCode implements BaseErrorCode {
     AI_RATE_LIMIT_EXCEEDED(
             HttpStatus.TOO_MANY_REQUESTS,
             "AI429_1",
-            "AI 요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."
+            "AI 요청 횟수를 초과했습니다. 한도 갱신 후 다시 시도해주세요."
     ),
 
     AI_RESPONSE_EMPTY(

--- a/src/main/java/com/umc/halo/global/ai/exception/code/AiErrorCode.java
+++ b/src/main/java/com/umc/halo/global/ai/exception/code/AiErrorCode.java
@@ -9,6 +9,12 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AiErrorCode implements BaseErrorCode {
 
+    AI_RATE_LIMIT_EXCEEDED(
+            HttpStatus.TOO_MANY_REQUESTS,
+            "AI429_1",
+            "AI 요청 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."
+    ),
+
     AI_RESPONSE_EMPTY(
             HttpStatus.BAD_GATEWAY,
             "AI502_1",

--- a/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
+++ b/src/main/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListener.java
@@ -60,8 +60,8 @@ public class AnniversaryNotificationListener {
 
         String d7Title = createNotificationTitle(anniversary, NotificationType.ANNIVERSARY_D7);
         String ddayTitle = createNotificationTitle(anniversary, NotificationType.ANNIVERSARY_DDAY);
-        String d7Message = createNotificationMessage(anniversary, NotificationType.ANNIVERSARY_D7);
-        String ddayMessage = createNotificationMessage(anniversary, NotificationType.ANNIVERSARY_DDAY);
+        String d7Message = createNotificationMessage(memberId, anniversary, NotificationType.ANNIVERSARY_D7);
+        String ddayMessage = createNotificationMessage(memberId, anniversary, NotificationType.ANNIVERSARY_DDAY);
 
         notificationTransactionService.saveOrUpdateBoth(anniversary, memberSetting, d7Title, d7Message, d7, ddayTitle, ddayMessage, dday, now);
     }
@@ -94,8 +94,8 @@ public class AnniversaryNotificationListener {
         String ddayMessage = null;
 
         if(event.titleChanged() || event.memoChanged()) {
-            d7Message = createNotificationMessage(anniversary, NotificationType.ANNIVERSARY_D7);
-            ddayMessage = createNotificationMessage(anniversary, NotificationType.ANNIVERSARY_DDAY);
+            d7Message = createNotificationMessage(memberId, anniversary, NotificationType.ANNIVERSARY_D7);
+            ddayMessage = createNotificationMessage(memberId, anniversary, NotificationType.ANNIVERSARY_DDAY);
         }
 
         notificationTransactionService.updateOrCancelBoth(anniversary, memberSetting,
@@ -135,10 +135,10 @@ public class AnniversaryNotificationListener {
         String ddayTitle = createNotificationTitle(anniversary, NotificationType.ANNIVERSARY_DDAY);
 
         String d7Message = (anniversary.getSevenDaysAlarmEnabled() && d7.isAfter(now))
-                ? createNotificationMessage(anniversary, NotificationType.ANNIVERSARY_D7)
+                ? createNotificationMessage(memberId, anniversary, NotificationType.ANNIVERSARY_D7)
                 : null;
         String ddayMessage = (anniversary.getDayAlarmEnabled() && dday.isAfter(now))
-                ? createNotificationMessage(anniversary, NotificationType.ANNIVERSARY_DDAY)
+                ? createNotificationMessage(memberId, anniversary, NotificationType.ANNIVERSARY_DDAY)
                 : null;
 
         notificationTransactionService.saveOrUpdateBoth(anniversary, memberSetting, d7Title, d7Message, d7, ddayTitle, ddayMessage, dday, now);
@@ -152,14 +152,14 @@ public class AnniversaryNotificationListener {
         return "오늘은 " + anniversary.getTitle() + "입니다.";
     }
 
-    private String createNotificationMessage(Anniversary anniversary, NotificationType notificationType) {
+    private String createNotificationMessage(Long memberId, Anniversary anniversary, NotificationType notificationType) {
 
         if (anniversary.getMemo() == null || anniversary.getMemo().isBlank()) {
             return createDefaultNotificationMessage(notificationType);
         }
 
         try {
-            return aiService.generateAnniversaryNotificationMessage(anniversary.getTitle(), anniversary.getMemo());
+            return aiService.generateAnniversaryNotificationMessage(memberId, anniversary.getTitle(), anniversary.getMemo());
         } catch (AiException e) {
             log.warn("AI 알림 문구 생성 실패. anniversaryId={}", anniversary.getId(), e);
             return createDefaultNotificationMessage(notificationType);

--- a/src/main/java/com/umc/halo/global/ai/listener/ChapterSummaryListener.java
+++ b/src/main/java/com/umc/halo/global/ai/listener/ChapterSummaryListener.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -48,6 +46,7 @@ public class ChapterSummaryListener {
         try {
             String summary =
                     aiService.generateChapterSummary(
+                            event.memberId(),
                             event.storybookTitle(),
                             event.chapterTitle(),
                             event.chapterDescription(),

--- a/src/main/java/com/umc/halo/global/ai/service/AiService.java
+++ b/src/main/java/com/umc/halo/global/ai/service/AiService.java
@@ -1,10 +1,13 @@
 package com.umc.halo.global.ai.service;
 
-import com.umc.halo.domain.notification.enums.NotificationType;
 import com.umc.halo.global.ai.AiClient;
 import com.umc.halo.global.ai.QuestionAnswer;
+import com.umc.halo.global.ai.exception.AiException;
+import com.umc.halo.global.ai.exception.code.AiErrorCode;
 import com.umc.halo.global.ai.factory.PromptFactory;
 import com.umc.halo.global.ai.filter.SensitiveDataFilter;
+import com.umc.halo.global.rateLimit.AiRateLimitType;
+import com.umc.halo.global.rateLimit.RateLimitService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,8 +19,13 @@ public class AiService {
 
     private final AiClient aiClient;
     private final SensitiveDataFilter sensitiveDataFilter;
+    private final RateLimitService rateLimitService;
 
-    public String generateChapterSummary(String themeName, String chapterTitle, String pageIntro, List<QuestionAnswer> questionAnswers, String emotionTag) {
+    public String generateChapterSummary(Long memberId, String themeName, String chapterTitle, String pageIntro, List<QuestionAnswer> questionAnswers, String emotionTag) {
+
+        if (!rateLimitService.tryConsume(memberId, AiRateLimitType.CHAPTER_SUMMARY)) {
+            throw new AiException(AiErrorCode.AI_RATE_LIMIT_EXCEEDED);
+        }
 
         List<QuestionAnswer> filteredAnswers =
                 questionAnswers.stream()
@@ -34,7 +42,11 @@ public class AiService {
         return aiClient.generate(prompt);
     }
 
-    public String generateAnniversaryNotificationMessage(String title, String memo) {
+    public String generateAnniversaryNotificationMessage(Long memberId, String title, String memo) {
+
+        if (!rateLimitService.tryConsume(memberId, AiRateLimitType.ANNIVERSARY_MESSAGE)) {
+            throw new AiException(AiErrorCode.AI_RATE_LIMIT_EXCEEDED);
+        }
 
         String filteredTitle = sensitiveDataFilter.mask(title);
         String filteredMemo = sensitiveDataFilter.mask(memo);

--- a/src/main/java/com/umc/halo/global/rateLimit/AiRateLimitType.java
+++ b/src/main/java/com/umc/halo/global/rateLimit/AiRateLimitType.java
@@ -1,0 +1,6 @@
+package com.umc.halo.global.rateLimit;
+
+public enum AiRateLimitType {
+    CHAPTER_SUMMARY,
+    ANNIVERSARY_MESSAGE
+}

--- a/src/main/java/com/umc/halo/global/rateLimit/RateLimitKey.java
+++ b/src/main/java/com/umc/halo/global/rateLimit/RateLimitKey.java
@@ -1,0 +1,6 @@
+package com.umc.halo.global.rateLimit;
+
+public record RateLimitKey(
+        Long memberId,
+        AiRateLimitType aiRateLimitType
+) {}

--- a/src/main/java/com/umc/halo/global/rateLimit/RateLimitService.java
+++ b/src/main/java/com/umc/halo/global/rateLimit/RateLimitService.java
@@ -1,0 +1,73 @@
+package com.umc.halo.global.rateLimit;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitService {
+
+    private final Map<RateLimitKey, Bucket> buckets = new ConcurrentHashMap<>();
+
+    public boolean tryConsume(Long memberId, AiRateLimitType aiRateLimitType) {
+
+        RateLimitKey rateLimitKey = new RateLimitKey(memberId, aiRateLimitType);
+
+        Bucket bucket = buckets.computeIfAbsent(rateLimitKey, k -> createBucket(aiRateLimitType));
+
+        boolean allowed = bucket.tryConsume(1);
+
+        if (!allowed) {
+            log.warn("AI Rate Limit 초과 memberId={}, remaining={}", memberId, bucket.getAvailableTokens());
+        }
+
+        return allowed;
+    }
+
+    private Bucket createBucket(AiRateLimitType aiRateLimitType) {
+
+        Bandwidth minuteLimit;
+        Bandwidth dayLimit;
+
+        switch (aiRateLimitType) {
+            case CHAPTER_SUMMARY -> {
+                    minuteLimit = Bandwidth.builder()
+                            .capacity(3)
+                            .refillIntervally(3, Duration.ofMinutes(1))
+                            .build();
+
+                    dayLimit = Bandwidth.builder()
+                            .capacity(10)
+                            .refillIntervally(10, Duration.ofDays(1))
+                            .build();
+            }
+
+            case ANNIVERSARY_MESSAGE -> {
+                    minuteLimit = Bandwidth.builder()
+                            .capacity(5)
+                            .refillIntervally(5, Duration.ofMinutes(1))
+                            .build();
+
+                    dayLimit = Bandwidth.builder()
+                        .capacity(30)
+                        .refillIntervally(30, Duration.ofDays(1))
+                        .build();
+            }
+
+            default -> throw new IllegalStateException();
+        };
+
+        return Bucket.builder()
+                .addLimit(minuteLimit)
+                .addLimit(dayLimit)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/halo/global/rateLimit/RateLimitService.java
+++ b/src/main/java/com/umc/halo/global/rateLimit/RateLimitService.java
@@ -1,5 +1,7 @@
 package com.umc.halo.global.rateLimit;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import lombok.RequiredArgsConstructor;
@@ -7,21 +9,28 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * AI API Rate Limit.
+ * 현재 EC2 단일 인스턴스 환경을 기준으로 메모리 기반 Bucket을 사용한다.
+ * 멀티 인스턴스 환경에서는 Redis 기반 Bucket4j 저장소로 교체해야 한다.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class RateLimitService {
 
-    private final Map<RateLimitKey, Bucket> buckets = new ConcurrentHashMap<>();
+    private final Cache<RateLimitKey, Bucket> buckets =
+            Caffeine.newBuilder()
+                    .expireAfterAccess(Duration.ofDays(1))
+                    .maximumSize(100_000)
+                    .build();
 
     public boolean tryConsume(Long memberId, AiRateLimitType aiRateLimitType) {
 
         RateLimitKey rateLimitKey = new RateLimitKey(memberId, aiRateLimitType);
 
-        Bucket bucket = buckets.computeIfAbsent(rateLimitKey, k -> createBucket(aiRateLimitType));
+        Bucket bucket = buckets.get(rateLimitKey, key -> createBucket(aiRateLimitType));
 
         boolean allowed = bucket.tryConsume(1);
 

--- a/src/main/java/com/umc/halo/global/rateLimit/RateLimitService.java
+++ b/src/main/java/com/umc/halo/global/rateLimit/RateLimitService.java
@@ -26,7 +26,7 @@ public class RateLimitService {
         boolean allowed = bucket.tryConsume(1);
 
         if (!allowed) {
-            log.warn("AI Rate Limit 초과 memberId={}, remaining={}", memberId, bucket.getAvailableTokens());
+            log.warn("AI Rate Limit 초과 memberId={}, api={}, remaining={}", memberId, aiRateLimitType, bucket.getAvailableTokens());
         }
 
         return allowed;
@@ -62,8 +62,8 @@ public class RateLimitService {
                         .build();
             }
 
-            default -> throw new IllegalStateException();
-        };
+            default -> throw new IllegalStateException("Unknown AI RateLimitType");
+        }
 
         return Bucket.builder()
                 .addLimit(minuteLimit)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,7 +59,7 @@ google:
 
 gemini:
   api-key: ${GEMINI_API_KEY}
-  model: gemini-2.5-flash-lite
+  model: gemini-3.5-flash-lite
 
 async:
   executor:

--- a/src/test/java/com/umc/halo/global/ai/listener/ChapterSummaryListenerTest.java
+++ b/src/test/java/com/umc/halo/global/ai/listener/ChapterSummaryListenerTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -43,7 +44,7 @@ class ChapterSummaryListenerTest {
     private ChapterSummaryListener chapterSummaryListener;
 
     private final ChapterCompletedEvent event =
-            new ChapterCompletedEvent(1L, 1L, "storybook", "chapter", "desc", Emotion.HAPPY.getDescription());
+            new ChapterCompletedEvent(11L, 1L, "storybook", "chapter", "desc", Emotion.HAPPY.getDescription());
 
     @Test
     void AI_요약_생성에_성공하면_memberChapter에_반영하고_명시적으로_저장한다() {
@@ -51,7 +52,7 @@ class ChapterSummaryListenerTest {
         given(memberChapterRepository.findById(1L)).willReturn(Optional.of(memberChapter));
         given(memberChapterAnswerRepository.findAllByMemberChapterOrderByQuestionOrder(memberChapter))
                 .willReturn(List.of());
-        given(aiService.generateChapterSummary(any(), any(), any(), any(), any(), any()))
+        given(aiService.generateChapterSummary(eq(11L), any(), any(), any(), any(), any()))
                 .willReturn("생성된 요약");
 
         chapterSummaryListener.generateSummary(event);
@@ -66,7 +67,7 @@ class ChapterSummaryListenerTest {
         given(memberChapterRepository.findById(1L)).willReturn(Optional.of(memberChapter));
         given(memberChapterAnswerRepository.findAllByMemberChapterOrderByQuestionOrder(memberChapter))
                 .willReturn(List.of());
-        given(aiService.generateChapterSummary(any(), any(), any(), any(), any(), any()))
+        given(aiService.generateChapterSummary(eq(11L), any(), any(), any(), any(), any()))
                 .willThrow(new AiException(AiErrorCode.AI_GENERATE_FAILED));
 
         assertThatCode(() -> chapterSummaryListener.generateSummary(event))

--- a/src/test/java/com/umc/halo/global/ai/listener/ChapterSummaryListenerTest.java
+++ b/src/test/java/com/umc/halo/global/ai/listener/ChapterSummaryListenerTest.java
@@ -43,7 +43,7 @@ class ChapterSummaryListenerTest {
     private ChapterSummaryListener chapterSummaryListener;
 
     private final ChapterCompletedEvent event =
-            new ChapterCompletedEvent(1L, "storybook", "chapter", "desc", Emotion.HAPPY.getDescription());
+            new ChapterCompletedEvent(1L, 1L, "storybook", "chapter", "desc", Emotion.HAPPY.getDescription());
 
     @Test
     void AI_요약_생성에_성공하면_memberChapter에_반영하고_명시적으로_저장한다() {
@@ -51,7 +51,7 @@ class ChapterSummaryListenerTest {
         given(memberChapterRepository.findById(1L)).willReturn(Optional.of(memberChapter));
         given(memberChapterAnswerRepository.findAllByMemberChapterOrderByQuestionOrder(memberChapter))
                 .willReturn(List.of());
-        given(aiService.generateChapterSummary(any(), any(), any(), any(), any()))
+        given(aiService.generateChapterSummary(any(), any(), any(), any(), any(), any()))
                 .willReturn("생성된 요약");
 
         chapterSummaryListener.generateSummary(event);
@@ -66,7 +66,7 @@ class ChapterSummaryListenerTest {
         given(memberChapterRepository.findById(1L)).willReturn(Optional.of(memberChapter));
         given(memberChapterAnswerRepository.findAllByMemberChapterOrderByQuestionOrder(memberChapter))
                 .willReturn(List.of());
-        given(aiService.generateChapterSummary(any(), any(), any(), any(), any()))
+        given(aiService.generateChapterSummary(any(), any(), any(), any(), any(), any()))
                 .willThrow(new AiException(AiErrorCode.AI_GENERATE_FAILED));
 
         assertThatCode(() -> chapterSummaryListener.generateSummary(event))


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 사용자/API 별 AI 호출 제한 설정
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- global/rateLimit 디렉토리 추가
- global/rateLimit/AiRateLimitType 추가 (API 종류를 구분하기 위한 Enum 타입)
- global/rateLimit/RateLimitKey 추가 (사용자/API 별 AI 호출을 제한하기 위한 키)
- gloval/rateLimit/RateLimitService 추가 (사용자.API 별 호출 제한 기능 구현)
- ChapterCompletedEvent 수정 (memberId 추가)
- AiErrorCode 수정 (AI 요청 횟수 초과 에러 코드 추가)
- AiService 수정 (각 메서드에서 memberId를 파라미터에 추가, RateLimitService로 호출 한도 조건 검사)
- AnniversaryNotificationListener 수정 (기념일 알림 문구 생성 메서드에서 memberId를 파라미터로 받도록 각 메서드 수정)
- ChapterSummaryListener 수정 (장 요약 메서드에서 memberId를 파라미터로 받도록 수정)
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #280
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- ERD: https://www.erdcloud.com/d/RoEN8CRQz3uSHCBGY
- API 메서드: https://app.notion.com/p/API-38cca1e217c080ee8ebffb8f025c8f61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * AI 장 요약 및 기념일 메시지 생성에 회원별 요청 횟수 제한을 적용했습니다.
  * 요청 한도 초과 시 안내 오류를 제공합니다.
  * AI 모델을 최신 설정으로 변경했습니다.
  * 장 완료 이벤트에 회원 식별 정보가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->