### PR TITLE
[test] 인증/인가 테스트 작성

### DIFF
--- a/src/main/java/com/umc/halo/HaloServerApplication.java
+++ b/src/main/java/com/umc/halo/HaloServerApplication.java
@@ -2,10 +2,8 @@ package com.umc.halo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
 public class HaloServerApplication {

--- a/src/main/java/com/umc/halo/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/umc/halo/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.umc.halo.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/test/java/com/umc/halo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/umc/halo/domain/member/service/MemberServiceTest.java
@@ -2,28 +2,46 @@ package com.umc.halo.domain.member.service;
 
 import com.umc.halo.domain.member.dto.MemberReqDTO;
 import com.umc.halo.domain.member.dto.MemberResDTO;
+import com.umc.halo.domain.member.entity.Member;
 import com.umc.halo.domain.member.enums.Provider;
+import com.umc.halo.domain.member.event.MemberWithdrawnEvent;
 import com.umc.halo.domain.member.exception.code.AuthErrorCode;
+import com.umc.halo.domain.member.exception.code.MemberErrorCode;
 import com.umc.halo.domain.member.oauth.AbstractOidcProvider;
 import com.umc.halo.domain.member.oauth.OidcProviderFactory;
 import com.umc.halo.domain.member.oauth.OidcUserInfo;
+import com.umc.halo.domain.member.repository.MemberRepository;
+import com.umc.halo.domain.content.storybook.entity.StorybookCharacter;
+import com.umc.halo.domain.content.storybook.entity.StorybookCharacterVariant;
+import com.umc.halo.domain.content.storybook.enums.Variant;
+import com.umc.halo.domain.content.storybook.repository.StorybookCharacterVariantRepository;
+import com.umc.halo.domain.term.repository.MemberTermRepository;
 import com.umc.halo.global.apiPayload.exception.ProjectException;
+import com.umc.halo.global.security.JwtUtil;
+import com.umc.halo.global.util.HashUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * MemberService.login은 @Transactional이 없어야 함
  * OIDC 검증(외부 JWKS 호출)이 DB 쓰기보다 먼저 일어나는지 검증
+ * tokenReissue/logout/withdraw/getMyInfo의 정상·예외 흐름도 함께 검증
  */
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -34,6 +52,18 @@ class MemberServiceTest {
     private AbstractOidcProvider oidcProvider;
     @Mock
     private MemberWriter memberWriter;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private MemberTermRepository memberTermRepository;
+    @Mock
+    private JwtUtil jwtUtil;
+    @Mock
+    private HashUtil hashUtil;
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+    @Mock
+    private StorybookCharacterVariantRepository storybookCharacterVariantRepository;
 
     @InjectMocks
     private MemberService memberService;
@@ -73,5 +103,165 @@ class MemberServiceTest {
                 .satisfies(e -> assertThat(((ProjectException) e).getErrorCode()).isEqualTo(AuthErrorCode.UNSUPPORTED_PROVIDER));
 
         verifyNoInteractions(oidcProviderFactory, oidcProvider, memberWriter);
+    }
+
+    @Test
+    void tokenReissue_유효하지_않은_토큰이면_예외() {
+        MemberReqDTO.TokenReissue dto = new MemberReqDTO.TokenReissue("bad-token");
+        given(jwtUtil.isValid("bad-token")).willReturn(false);
+
+        assertThatThrownBy(() -> memberService.tokenReissue(dto))
+                .isInstanceOf(ProjectException.class)
+                .satisfies(e -> assertThat(((ProjectException) e).getErrorCode()).isEqualTo(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        verifyNoInteractions(memberRepository, hashUtil);
+    }
+
+    @Test
+    void tokenReissue_refreshToken_타입이_아니면_예외() {
+        MemberReqDTO.TokenReissue dto = new MemberReqDTO.TokenReissue("access-token-misused");
+        given(jwtUtil.isValid("access-token-misused")).willReturn(true);
+        given(jwtUtil.isRefreshToken("access-token-misused")).willReturn(false);
+
+        assertThatThrownBy(() -> memberService.tokenReissue(dto))
+                .isInstanceOf(ProjectException.class)
+                .satisfies(e -> assertThat(((ProjectException) e).getErrorCode()).isEqualTo(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        verifyNoInteractions(memberRepository, hashUtil);
+    }
+
+    @Test
+    void tokenReissue_저장된_해시와_불일치하면_예외() {
+        MemberReqDTO.TokenReissue dto = new MemberReqDTO.TokenReissue("old-refresh-token");
+        Member member = mock(Member.class);
+
+        given(jwtUtil.isValid("old-refresh-token")).willReturn(true);
+        given(jwtUtil.isRefreshToken("old-refresh-token")).willReturn(true);
+        given(jwtUtil.getMemberId("old-refresh-token")).willReturn(1L);
+        given(memberRepository.findByIdForUpdate(1L)).willReturn(Optional.of(member));
+        given(member.getRefreshTokenHash()).willReturn("stored-hash");
+        given(hashUtil.matches("old-refresh-token", "stored-hash")).willReturn(false);
+
+        assertThatThrownBy(() -> memberService.tokenReissue(dto))
+                .isInstanceOf(ProjectException.class)
+                .satisfies(e -> assertThat(((ProjectException) e).getErrorCode()).isEqualTo(AuthErrorCode.INVALID_REFRESH_TOKEN));
+    }
+
+    @Test
+    void tokenReissue_정상_흐름이면_새_토큰을_발급하고_해시를_갱신한다() {
+        MemberReqDTO.TokenReissue dto = new MemberReqDTO.TokenReissue("old-refresh-token");
+        Member member = mock(Member.class);
+
+        given(jwtUtil.isValid("old-refresh-token")).willReturn(true);
+        given(jwtUtil.isRefreshToken("old-refresh-token")).willReturn(true);
+        given(jwtUtil.getMemberId("old-refresh-token")).willReturn(1L);
+        given(memberRepository.findByIdForUpdate(1L)).willReturn(Optional.of(member));
+        given(member.getRefreshTokenHash()).willReturn("stored-hash");
+        given(hashUtil.matches("old-refresh-token", "stored-hash")).willReturn(true);
+        given(jwtUtil.createAccessToken(1L)).willReturn("new-access-token");
+        given(jwtUtil.createRefreshToken(1L)).willReturn("new-refresh-token");
+        given(hashUtil.hash("new-refresh-token")).willReturn("new-hash");
+        given(member.getId()).willReturn(1L);
+        given(member.getOnboardingCompleted()).willReturn(true);
+        given(memberTermRepository.areAllRequiredTermsAgreed(1L)).willReturn(true);
+
+        MemberResDTO.TokenReissue result = memberService.tokenReissue(dto);
+
+        assertThat(result.accessToken()).isEqualTo("new-access-token");
+        assertThat(result.refreshToken()).isEqualTo("new-refresh-token");
+        assertThat(result.onboardingCompleted()).isTrue();
+        assertThat(result.termsAgreed()).isTrue();
+        verify(member).updateRefreshTokenToHash("new-hash");
+    }
+
+    @Test
+    void logout_회원이_없으면_예외() {
+        given(memberRepository.findByIdForUpdate(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberService.logout(1L))
+                .isInstanceOf(ProjectException.class)
+                .satisfies(e -> assertThat(((ProjectException) e).getErrorCode()).isEqualTo(MemberErrorCode.NOT_FOUND));
+    }
+
+    @Test
+    void logout_정상_흐름이면_refreshToken을_삭제한다() {
+        Member member = mock(Member.class);
+        given(memberRepository.findByIdForUpdate(1L)).willReturn(Optional.of(member));
+
+        memberService.logout(1L);
+
+        verify(member).deleteRefreshToken();
+    }
+
+    @Test
+    void withdraw_회원이_없으면_예외() {
+        given(memberRepository.findByIdForUpdate(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberService.withdraw(1L))
+                .isInstanceOf(ProjectException.class)
+                .satisfies(e -> assertThat(((ProjectException) e).getErrorCode()).isEqualTo(MemberErrorCode.NOT_FOUND));
+    }
+
+    @Test
+    void withdraw_정상_흐름이면_이벤트를_발행한_후_회원을_삭제한다() {
+        Member member = mock(Member.class);
+        given(memberRepository.findByIdForUpdate(1L)).willReturn(Optional.of(member));
+
+        memberService.withdraw(1L);
+
+        InOrder inOrder = inOrder(applicationEventPublisher, memberRepository);
+        inOrder.verify(applicationEventPublisher).publishEvent(any(MemberWithdrawnEvent.class));
+        inOrder.verify(memberRepository).delete(member);
+    }
+
+    @Test
+    void getMyInfo_회원이_없으면_예외() {
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> memberService.getMyInfo(1L))
+                .isInstanceOf(ProjectException.class)
+                .satisfies(e -> assertThat(((ProjectException) e).getErrorCode()).isEqualTo(MemberErrorCode.NOT_FOUND));
+    }
+
+    @Test
+    void getMyInfo_storybookCharacter가_없으면_characterImageUrl은_null이다() {
+        Member member = mock(Member.class);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(member.getStorybookCharacter()).willReturn(null);
+
+        MemberResDTO.MyInfo result = memberService.getMyInfo(1L);
+
+        assertThat(result.characterImageUrl()).isNull();
+        verifyNoInteractions(storybookCharacterVariantRepository);
+    }
+
+    @Test
+    void getMyInfo_캐릭터는_있지만_PROFILE_variant가_없으면_null을_반환한다() {
+        Member member = mock(Member.class);
+        StorybookCharacter character = mock(StorybookCharacter.class);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(member.getStorybookCharacter()).willReturn(character);
+        given(storybookCharacterVariantRepository.findByStorybookCharacterAndVariant(character, Variant.PROFILE))
+                .willReturn(Optional.empty());
+
+        MemberResDTO.MyInfo result = memberService.getMyInfo(1L);
+
+        assertThat(result.characterImageUrl()).isNull();
+    }
+
+    @Test
+    void getMyInfo_캐릭터와_PROFILE_variant가_있으면_이미지_URL을_반환한다() {
+        Member member = mock(Member.class);
+        StorybookCharacter character = mock(StorybookCharacter.class);
+        StorybookCharacterVariant variant = mock(StorybookCharacterVariant.class);
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(member.getStorybookCharacter()).willReturn(character);
+        given(storybookCharacterVariantRepository.findByStorybookCharacterAndVariant(character, Variant.PROFILE))
+                .willReturn(Optional.of(variant));
+        given(variant.getImageUrl()).willReturn("https://example.com/character.png");
+
+        MemberResDTO.MyInfo result = memberService.getMyInfo(1L);
+
+        assertThat(result.characterImageUrl()).isEqualTo("https://example.com/character.png");
     }
 }

--- a/src/test/java/com/umc/halo/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/umc/halo/global/config/SecurityConfigTest.java
@@ -1,4 +1,109 @@
 package com.umc.halo.global.config;
 
-public class SecurityConfigTest {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.halo.domain.member.controller.MemberController;
+import com.umc.halo.domain.member.dto.MemberReqDTO;
+import com.umc.halo.domain.member.dto.MemberResDTO;
+import com.umc.halo.domain.member.service.MemberService;
+import com.umc.halo.domain.term.controller.TermController;
+import com.umc.halo.domain.term.service.TermService;
+import com.umc.halo.global.security.JwtAccessDeniedHandler;
+import com.umc.halo.global.security.JwtAuthenticationEntryPoint;
+import com.umc.halo.global.security.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SecurityConfig의 경로별 인증 규칙(PUBLIC_URIS, GET /api/v1/terms만 Public, 나머지 Private)이
+ * 실제 필터 체인(JwtAuthFilter 포함)에서 의도대로 동작하는지 검증.
+ * 웹 계층만 띄우는 슬라이스 테스트라 DataSource/Flyway/Firebase/S3는 로딩되지 않는다.
+ * JwtAuthFilter는 @WebMvcTest가 Filter 타입 빈으로 자동 스캔하므로 별도 @Import 불필요.
+ */
+@WebMvcTest(controllers = {MemberController.class, TermController.class})
+@Import({SecurityConfig.class, JwtAuthenticationEntryPoint.class, JwtAccessDeniedHandler.class})
+@EnableWebSecurity
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private MemberService memberService;
+    @MockitoBean
+    private TermService termService;
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    void 로그인은_토큰_없이도_통과한다() throws Exception {
+        given(memberService.login(any())).willReturn(
+                MemberResDTO.Login.builder()
+                        .accessToken("a").refreshToken("r")
+                        .isNewUser(false).onboardingCompleted(true).termsAgreed(true)
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new MemberReqDTO.Login("KAKAO", "token"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 토큰_재발급은_토큰_없이도_통과한다() throws Exception {
+        given(memberService.tokenReissue(any())).willReturn(
+                MemberResDTO.TokenReissue.builder()
+                        .accessToken("a").refreshToken("r")
+                        .onboardingCompleted(true).termsAgreed(true)
+                        .build()
+        );
+
+        mockMvc.perform(post("/api/v1/auth/reissue")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new MemberReqDTO.TokenReissue("refresh-token"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 약관_목록_조회는_GET만_토큰_없이도_통과한다() throws Exception {
+        given(termService.getTerms()).willReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/terms"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 약관_동의는_POST라서_토큰_없으면_401이다() throws Exception {
+        mockMvc.perform(post("/api/v1/terms/agreements")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 로그아웃은_Private이라_토큰_없으면_401이다() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/logout"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 내정보_조회는_Private이라_토큰_없으면_401이다() throws Exception {
+        mockMvc.perform(get("/api/v1/members/me"))
+                .andExpect(status().isUnauthorized());
+    }
 }

--- a/src/test/java/com/umc/halo/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/umc/halo/global/config/SecurityConfigTest.java
@@ -88,6 +88,12 @@ class SecurityConfigTest {
     }
 
     @Test
+    void 약관_목록_POST_요청은_토큰_없으면_401이다() throws Exception {
+        mockMvc.perform(post("/api/v1/terms"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     void 약관_동의는_POST라서_토큰_없으면_401이다() throws Exception {
         mockMvc.perform(post("/api/v1/terms/agreements")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/umc/halo/global/config/SecurityConfigTest.java
+++ b/src/test/java/com/umc/halo/global/config/SecurityConfigTest.java
@@ -1,0 +1,4 @@
+package com.umc.halo.global.config;
+
+public class SecurityConfigTest {
+}

--- a/src/test/java/com/umc/halo/global/security/JwtAuthFilterTest.java
+++ b/src/test/java/com/umc/halo/global/security/JwtAuthFilterTest.java
@@ -1,0 +1,114 @@
+package com.umc.halo.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * JwtAuthFilter는 토큰이 없거나 유효하지 않아도 에러 응답을 만들지 않고
+ * 인증 세팅 없이 다음 필터로 넘긴다 (Public/Private 판단은 SecurityConfig가 담당).
+ * 유효한 accessToken일 때만 SecurityContext에 memberId로 인증 객체를 저장하는지 검증.
+ */
+@ExtendWith(MockitoExtension.class)
+class JwtAuthFilterTest {
+
+    @Mock
+    private JwtUtil jwtUtil;
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private JwtAuthFilter jwtAuthFilter;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void Authorization_헤더가_없으면_인증없이_다음_필터로_넘긴다() throws Exception {
+        given(request.getHeader("Authorization")).willReturn(null);
+
+        jwtAuthFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void Bearer_형식이_아니면_인증없이_다음_필터로_넘긴다() throws Exception {
+        given(request.getHeader("Authorization")).willReturn("Basic abcdef");
+
+        jwtAuthFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void 유효하지_않은_토큰이면_인증없이_다음_필터로_넘긴다() throws Exception {
+        given(request.getHeader("Authorization")).willReturn("Bearer invalid-token");
+        given(jwtUtil.isValid("invalid-token")).willReturn(false);
+        given(jwtUtil.isExpired("invalid-token")).willReturn(false);
+
+        jwtAuthFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void 만료된_토큰이면_인증없이_다음_필터로_넘긴다() throws Exception {
+        given(request.getHeader("Authorization")).willReturn("Bearer expired-token");
+        given(jwtUtil.isValid("expired-token")).willReturn(false);
+        given(jwtUtil.isExpired("expired-token")).willReturn(true);
+
+        jwtAuthFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void accessToken_자리에_refreshToken을_쓰면_인증없이_다음_필터로_넘긴다() throws Exception {
+        given(request.getHeader("Authorization")).willReturn("Bearer refresh-token");
+        given(jwtUtil.isValid("refresh-token")).willReturn(true);
+        given(jwtUtil.isRefreshToken("refresh-token")).willReturn(true);
+
+        jwtAuthFilter.doFilterInternal(request, response, filterChain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void 유효한_accessToken이면_SecurityContext에_memberId로_인증객체를_저장한다() throws Exception {
+        given(request.getHeader("Authorization")).willReturn("Bearer valid-token");
+        given(jwtUtil.isValid("valid-token")).willReturn(true);
+        given(jwtUtil.isRefreshToken("valid-token")).willReturn(false);
+        given(jwtUtil.getMemberId("valid-token")).willReturn(99L);
+
+        jwtAuthFilter.doFilterInternal(request, response, filterChain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.getPrincipal()).isEqualTo(99L);
+        verify(filterChain).doFilter(request, response);
+    }
+}

--- a/src/test/java/com/umc/halo/global/security/JwtUtilTest.java
+++ b/src/test/java/com/umc/halo/global/security/JwtUtilTest.java
@@ -1,0 +1,65 @@
+package com.umc.halo.global.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * JwtUtil의 토큰 생성/검증 로직 자체를 검증한다.
+ * accessToken/refreshToken 생성 후 memberId 왕복이 정확한지,
+ * 만료·서명오류·형식오류 토큰에 대해 isValid/isExpired가 올바르게 판별하는지 확인.
+ */
+class JwtUtilTest {
+
+    private static final String SECRET = "test-secret-key-for-jwt-util-test-1234567890";
+
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        // access 1시간, refresh 14일
+        jwtUtil = new JwtUtil(SECRET, 1000L * 60 * 60, 1000L * 60 * 60 * 24 * 14);
+    }
+
+    @Test
+    void accessToken_생성후_memberId를_정확히_추출한다() {
+        String token = jwtUtil.createAccessToken(42L);
+
+        assertThat(jwtUtil.getMemberId(token)).isEqualTo(42L);
+        assertThat(jwtUtil.isValid(token)).isTrue();
+        assertThat(jwtUtil.isRefreshToken(token)).isFalse();
+    }
+
+    @Test
+    void refreshToken_생성후_memberId와_타입이_정확하다() {
+        String token = jwtUtil.createRefreshToken(7L);
+
+        assertThat(jwtUtil.getMemberId(token)).isEqualTo(7L);
+        assertThat(jwtUtil.isValid(token)).isTrue();
+        assertThat(jwtUtil.isRefreshToken(token)).isTrue();
+    }
+
+    @Test
+    void 만료된_토큰은_isValid가_false이고_isExpired가_true다() {
+        JwtUtil expiredJwtUtil = new JwtUtil(SECRET, -1000L, 1000L * 60);
+        String token = expiredJwtUtil.createAccessToken(1L);
+
+        assertThat(expiredJwtUtil.isValid(token)).isFalse();
+        assertThat(expiredJwtUtil.isExpired(token)).isTrue();
+    }
+
+    @Test
+    void 서명이_다른_토큰은_isValid가_false이고_isExpired는_false다() {
+        JwtUtil otherJwtUtil = new JwtUtil("different-secret-key-should-fail-verify-000", 1000L * 60 * 60, 1000L * 60 * 60);
+        String token = otherJwtUtil.createAccessToken(1L);
+
+        assertThat(jwtUtil.isValid(token)).isFalse();
+        assertThat(jwtUtil.isExpired(token)).isFalse();
+    }
+
+    @Test
+    void 형식이_잘못된_토큰_문자열은_isValid가_false다() {
+        assertThat(jwtUtil.isValid("not-a-jwt-token")).isFalse();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- 인증/인가(JWT, SecurityConfig) 관련 테스트 코드 작성

---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- JwtUtilTest 추가 (토큰 생성/검증)
- JwtAuthFilterTest 추가 (인증 필터 6가지 분기)
- MemberServiceTest 보강 (tokenReissue/logout/withdraw/getMyInfo)
- SecurityConfigTest 추가 (경로별 인증 규칙)
- HaloServerApplication.java: @EnableJpaAuditing을 JpaAuditingConfig로 분리 (@WebMvcTest 슬라이스에서 JPA metamodel 에러 방지 목적, auditing 동작 자체는 변경 없음)

---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 이번 PR은 테스트 코드 작성 건이라 별도 Swagger 캡처 없음
- ./gradlew test --tests "*.JwtUtilTest" --tests "*.JwtAuthFilterTest" --tests "*.MemberServiceTest" --tests "*.SecurityConfigTest" 전체 통과 확인
- MemberWriterIntegrationTest로 @EnableJpaAuditing 분리에 따른 회귀 없음 확인

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [x] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #282
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- HaloServerApplication.java는 공용 파일이라 리뷰 시 참고 부탁드립니다. @EnableJpaAuditing 위치만 옮긴 거라 런타임 동작 변화는 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - JPA 감사 기능 설정을 별도 구성으로 분리해 애플리케이션 설정 구조를 정리했습니다.
  - 기존 스케줄링 및 애플리케이션 실행 동작은 유지됩니다.

- **테스트**
  - 회원 정보 조회, 로그아웃, 탈퇴, 토큰 재발급 등 회원 기능의 정상 및 예외 상황 검증을 추가했습니다.
  - 인증이 필요한 API의 접근 제어와 토큰 유효성 검증 범위를 확대했습니다.
  - 유효하지 않거나 만료된 토큰 처리에 대한 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->