### PR TITLE
[FIX] 온보딩 이전 단계 재저장 시 진행 단계가 뒤로 밀리는 문제 수정

### DIFF
--- a/src/main/java/com/umc/halo/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/halo/domain/member/entity/Member.java
@@ -75,7 +75,12 @@ public class Member extends BaseEntity {
     }
 
     public void updateOnboardingStep(Integer step) {
-        this.onboardingStep = step;
+        if (step == null) {
+            return;
+        }
+        if (this.onboardingStep == null || step > this.onboardingStep) {
+            this.onboardingStep = step;
+        }
     }
 
     public void completeOnboarding() {


### PR DESCRIPTION
## 📝 작업 내용

이번 PR에서 구현한 내용을 간단히 설명해주세요.
 
- `Member.updateOnboardingStep()`이 조건 없이 값을 덮어써서, 뒤로가기로 이전 단계를 재저장하면 `onboardingStep`이 낮은 값으로 내려가던 문제를 수정했음.

기존 값보다 클 때만 갱신하도록 변경. 입력값 갱신은 기존과 동일하게 동작함.
---

## 🔧 변경 사항

수정되거나 추가된 주요 파일/기능을 작성해주세요.
 
- `Member.updateOnboardingStep()` : 전달받은 값이 기존 값보다 클 때만 갱신하도록 수정
---

## 🧪 테스트 결과

Swagger로 확인한 API 동작 결과를 첨부해주세요. (요청/응답 캡처 등)
 
- 
---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [ ] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인
---

## 🔗 관련 이슈

close #277 
 
---

## 📌 참고 사항

API 명세서, ERD, 관련 문서 등 참고할 내용을 작성해주세요.
 
- 


-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 온보딩 단계가 기존 단계보다 높을 때만 갱신되도록 변경했습니다.
  * `null` 값이 입력될 경우 온보딩 단계가 변경되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->