### PR TITLE
[test] 비동기 처리 테스트 작성

### DIFF
--- a/src/test/java/com/umc/halo/global/TransactionBoundaryTest.java
+++ b/src/test/java/com/umc/halo/global/TransactionBoundaryTest.java
@@ -17,6 +17,7 @@ import com.umc.halo.domain.record.service.ValidatedChapterRecord;
 import com.umc.halo.global.ai.event.AnniversaryCreatedEvent;
 import com.umc.halo.global.ai.event.AnniversaryUpdatedEvent;
 import com.umc.halo.global.ai.event.ChapterCompletedEvent;
+import com.umc.halo.global.ai.event.CreateNextYearNotificationEvent;
 import com.umc.halo.domain.notification.entity.Anniversary;
 import com.umc.halo.domain.notification.service.NotificationTransactionService;
 import com.umc.halo.domain.setting.entity.MemberSetting;
@@ -24,6 +25,7 @@ import com.umc.halo.global.ai.listener.AnniversaryNotificationListener;
 import com.umc.halo.global.ai.listener.ChapterSummaryListener;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,23 +43,52 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class TransactionBoundaryTest {
 
-    @TestFactory
-    Stream<DynamicTest> 외부_호출을_포함한_메서드는_트랜잭션이_없어야_한다() throws NoSuchMethodException {
-        List<Method> methods = List.of(
+    /**
+     * S3/JWKS/AI 등 느린 외부 호출을 담은 메서드들 — @Transactional이 없어야 한다.
+     * (이 중 이벤트 리스너들만 별도로 @Async 여부도 검증한다. MemberService.login,
+     * RecordService.writeChapterRecord/validate는 요청 흐름상 동기 호출이라 @Async 대상이 아님)
+     */
+    private static List<Method> externalCallMethods() throws NoSuchMethodException {
+        return List.of(
                 MemberService.class.getDeclaredMethod("login", MemberReqDTO.Login.class),
                 RecordService.class.getDeclaredMethod("writeChapterRecord", Long.class, RecordReqDTO.WriteChapterRecord.class),
                 RecordService.class.getDeclaredMethod("validate", Long.class, RecordReqDTO.WriteChapterRecord.class),
                 ImageFinalizeListener.class.getDeclaredMethod("handle", ImageFinalizeRequestedEvent.class),
                 ChapterSummaryListener.class.getDeclaredMethod("generateSummary", ChapterCompletedEvent.class),
                 AnniversaryNotificationListener.class.getDeclaredMethod("generateNotificationMessage", AnniversaryCreatedEvent.class),
-                AnniversaryNotificationListener.class.getDeclaredMethod("updateNotificationMessage", AnniversaryUpdatedEvent.class)
+                AnniversaryNotificationListener.class.getDeclaredMethod("updateNotificationMessage", AnniversaryUpdatedEvent.class),
+                AnniversaryNotificationListener.class.getDeclaredMethod("createNextNotification", CreateNextYearNotificationEvent.class)
         );
+    }
 
-        return methods.stream().map(method ->
+    @TestFactory
+    Stream<DynamicTest> 외부_호출을_포함한_메서드는_트랜잭션이_없어야_한다() throws NoSuchMethodException {
+        return externalCallMethods().stream().map(method ->
                 DynamicTest.dynamicTest(method.getDeclaringClass().getSimpleName() + "." + method.getName(), () ->
                         assertThat(method.isAnnotationPresent(Transactional.class))
                                 .as("%s는 외부 호출(S3/JWKS/AI)을 포함하므로 @Transactional이 없어야 함", method)
                                 .isFalse()
+                )
+        );
+    }
+
+    @TestFactory
+    Stream<DynamicTest> 외부_호출을_포함한_메서드는_Async여야_한다() throws NoSuchMethodException {
+        // MemberService.login, RecordService.writeChapterRecord/validate는 요청 흐름상 동기 호출이라 제외하고,
+        // 요청 스레드를 막지 않아야 하는 이벤트 리스너들만 검증한다.
+        List<Method> listenerMethods = List.of(
+                ImageFinalizeListener.class.getDeclaredMethod("handle", ImageFinalizeRequestedEvent.class),
+                ChapterSummaryListener.class.getDeclaredMethod("generateSummary", ChapterCompletedEvent.class),
+                AnniversaryNotificationListener.class.getDeclaredMethod("generateNotificationMessage", AnniversaryCreatedEvent.class),
+                AnniversaryNotificationListener.class.getDeclaredMethod("updateNotificationMessage", AnniversaryUpdatedEvent.class),
+                AnniversaryNotificationListener.class.getDeclaredMethod("createNextNotification", CreateNextYearNotificationEvent.class)
+        );
+
+        return listenerMethods.stream().map(method ->
+                DynamicTest.dynamicTest(method.getDeclaringClass().getSimpleName() + "." + method.getName(), () ->
+                        assertThat(method.isAnnotationPresent(Async.class))
+                                .as("%s는 이벤트 리스너이므로 요청 스레드를 막지 않도록 @Async가 있어야 함", method)
+                                .isTrue()
                 )
         );
     }

--- a/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
+++ b/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
@@ -9,6 +9,8 @@ import com.umc.halo.domain.setting.repository.MemberSettingRepository;
 import com.umc.halo.global.ai.event.AnniversaryCreatedEvent;
 import com.umc.halo.global.ai.event.AnniversaryUpdatedEvent;
 import com.umc.halo.global.ai.service.AiService;
+import com.umc.halo.global.ai.exception.AiException;
+import com.umc.halo.global.ai.exception.code.AiErrorCode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -84,6 +86,72 @@ class AnniversaryNotificationListenerTest {
 
         assertThat(d7TitleCaptor.getValue()).isEqualTo("결혼기념일까지 7일 남았어요.");
         assertThat(ddayTitleCaptor.getValue()).isEqualTo("오늘은 결혼기념일입니다.");
+        assertThat(d7MessageCaptor.getValue()).isEqualTo("오늘부터 조금씩 마음을 준비해 보세요.");
+        assertThat(ddayMessageCaptor.getValue()).isEqualTo("오늘의 따뜻한 안녕을 전해보세요.");
+    }
+
+    @Test
+    void generateNotificationMessage는_메모가_있으면_AI가_생성한_문구를_사용한다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .memo("우리가 처음 만난 날")
+                .anniversaryDate(LocalDate.now().plusDays(30))
+                .isRepeated(false)
+                .sevenDaysAlarmEnabled(true)
+                .dayAlarmEnabled(true)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+        given(anniversaryRepository.findMemberIdById(1L)).willReturn(Optional.of(5L));
+        given(memberSettingRepository.findByMemberId(any())).willReturn(Optional.of(memberSetting));
+        given(aiService.generateAnniversaryNotificationMessage(5L, "결혼기념일", "우리가 처음 만난 날"))
+                .willReturn("AI가 만든 문구");
+
+        listener.generateNotificationMessage(new AnniversaryCreatedEvent(1L));
+
+        ArgumentCaptor<String> d7MessageCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ddayMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(notificationTransactionService).saveOrUpdateBoth(
+                eq(anniversary), eq(memberSetting),
+                any(), d7MessageCaptor.capture(), any(),
+                any(), ddayMessageCaptor.capture(), any(),
+                any());
+
+        assertThat(d7MessageCaptor.getValue()).isEqualTo("AI가 만든 문구");
+        assertThat(ddayMessageCaptor.getValue()).isEqualTo("AI가 만든 문구");
+    }
+
+    @Test
+    void generateNotificationMessage는_AI_호출이_실패하면_기본_문구로_폴백한다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .memo("우리가 처음 만난 날")
+                .anniversaryDate(LocalDate.now().plusDays(30))
+                .isRepeated(false)
+                .sevenDaysAlarmEnabled(true)
+                .dayAlarmEnabled(true)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+        given(anniversaryRepository.findMemberIdById(1L)).willReturn(Optional.of(5L));
+        given(memberSettingRepository.findByMemberId(any())).willReturn(Optional.of(memberSetting));
+        given(aiService.generateAnniversaryNotificationMessage(5L, "결혼기념일", "우리가 처음 만난 날"))
+                .willThrow(new AiException(AiErrorCode.AI_GENERATE_FAILED));
+
+        listener.generateNotificationMessage(new AnniversaryCreatedEvent(1L));
+
+        ArgumentCaptor<String> d7MessageCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ddayMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(notificationTransactionService).saveOrUpdateBoth(
+                eq(anniversary), eq(memberSetting),
+                any(), d7MessageCaptor.capture(), any(),
+                any(), ddayMessageCaptor.capture(), any(),
+                any());
+
         assertThat(d7MessageCaptor.getValue()).isEqualTo("오늘부터 조금씩 마음을 준비해 보세요.");
         assertThat(ddayMessageCaptor.getValue()).isEqualTo("오늘의 따뜻한 안녕을 전해보세요.");
     }

--- a/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
+++ b/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
@@ -10,6 +10,7 @@ import com.umc.halo.global.ai.event.AnniversaryCreatedEvent;
 import com.umc.halo.global.ai.event.AnniversaryUpdatedEvent;
 import com.umc.halo.global.ai.event.CreateNextYearNotificationEvent;
 import com.umc.halo.global.ai.service.AiService;
+import com.umc.halo.global.util.AnniversaryOccurrenceResolver;
 import com.umc.halo.global.ai.exception.AiException;
 import com.umc.halo.global.ai.exception.code.AiErrorCode;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
@@ -30,6 +32,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -248,6 +251,30 @@ class AnniversaryNotificationListenerTest {
         given(memberSettingRepository.findByMemberId(5L)).willReturn(Optional.empty());
 
         listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+
+        verifyNoInteractions(notificationTransactionService);
+    }
+
+    @Test
+    void createNextNotification은_다음_발생일이_없으면_아무것도_하지_않는다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .anniversaryDate(LocalDate.now().plusDays(30))
+                .isRepeated(true)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+        given(anniversaryRepository.findMemberIdById(1L)).willReturn(Optional.of(5L));
+        given(memberSettingRepository.findByMemberId(5L)).willReturn(Optional.of(memberSetting));
+
+        try (MockedStatic<AnniversaryOccurrenceResolver> mockedResolver = mockStatic(AnniversaryOccurrenceResolver.class)) {
+            mockedResolver.when(() -> AnniversaryOccurrenceResolver.resolveNextOccurrence(eq(anniversary), any(LocalDate.class)))
+                    .thenReturn(null);
+
+            listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+        }
 
         verifyNoInteractions(notificationTransactionService);
     }

--- a/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
+++ b/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
@@ -8,6 +8,7 @@ import com.umc.halo.domain.setting.entity.MemberSetting;
 import com.umc.halo.domain.setting.repository.MemberSettingRepository;
 import com.umc.halo.global.ai.event.AnniversaryCreatedEvent;
 import com.umc.halo.global.ai.event.AnniversaryUpdatedEvent;
+import com.umc.halo.global.ai.event.CreateNextYearNotificationEvent;
 import com.umc.halo.global.ai.service.AiService;
 import com.umc.halo.global.ai.exception.AiException;
 import com.umc.halo.global.ai.exception.code.AiErrorCode;
@@ -30,6 +31,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * generateNotificationMessage/updateNotificationMessage는 AI 문구 생성
@@ -211,5 +213,106 @@ class AnniversaryNotificationListenerTest {
         assertThat(d7MessageCaptor.getValue()).isEqualTo("오늘부터 조금씩 마음을 준비해 보세요.");
         assertThat(ddayMessageCaptor.getValue()).isEqualTo("오늘의 따뜻한 안녕을 전해보세요.");
         verify(notificationTransactionService, never()).cancelBoth(any());
+    }
+
+    @Test
+    void createNextNotification은_반복_기념일이_아니면_아무것도_하지_않는다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .anniversaryDate(LocalDate.now().plusDays(30))
+                .isRepeated(false)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+
+        listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+
+        verify(anniversaryRepository, never()).findMemberIdById(any());
+        verifyNoInteractions(memberSettingRepository, notificationTransactionService);
+    }
+
+    @Test
+    void createNextNotification은_회원설정이_없으면_아무것도_하지_않는다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .anniversaryDate(LocalDate.now().plusDays(30))
+                .isRepeated(true)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+        given(anniversaryRepository.findMemberIdById(1L)).willReturn(Optional.of(5L));
+        given(memberSettingRepository.findByMemberId(5L)).willReturn(Optional.empty());
+
+        listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+
+        verifyNoInteractions(notificationTransactionService);
+    }
+
+    @Test
+    void createNextNotification은_알림이_비활성화되어_있으면_메시지_없이_저장한다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .anniversaryDate(LocalDate.now().plusDays(30))
+                .isRepeated(true)
+                .sevenDaysAlarmEnabled(false)
+                .dayAlarmEnabled(false)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+        given(anniversaryRepository.findMemberIdById(1L)).willReturn(Optional.of(5L));
+        given(memberSettingRepository.findByMemberId(5L)).willReturn(Optional.of(memberSetting));
+
+        listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+
+        ArgumentCaptor<String> d7MessageCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ddayMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(notificationTransactionService).saveOrUpdateBoth(
+                eq(anniversary), eq(memberSetting),
+                any(), d7MessageCaptor.capture(), any(),
+                any(), ddayMessageCaptor.capture(), any(),
+                any());
+
+        assertThat(d7MessageCaptor.getValue()).isNull();
+        assertThat(ddayMessageCaptor.getValue()).isNull();
+    }
+
+    @Test
+    void createNextNotification은_D7_DDay_메시지를_묶어서_한번에_넘긴다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .anniversaryDate(LocalDate.now().plusDays(30))
+                .isRepeated(true)
+                .sevenDaysAlarmEnabled(true)
+                .dayAlarmEnabled(true)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+        given(anniversaryRepository.findMemberIdById(1L)).willReturn(Optional.of(5L));
+        given(memberSettingRepository.findByMemberId(5L)).willReturn(Optional.of(memberSetting));
+
+        listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+
+        ArgumentCaptor<String> d7TitleCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> d7MessageCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ddayTitleCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ddayMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(notificationTransactionService).saveOrUpdateBoth(
+                eq(anniversary), eq(memberSetting),
+                d7TitleCaptor.capture(), d7MessageCaptor.capture(), any(),
+                ddayTitleCaptor.capture(), ddayMessageCaptor.capture(), any(),
+                any());
+
+        assertThat(d7TitleCaptor.getValue()).isEqualTo("결혼기념일까지 7일 남았어요.");
+        assertThat(ddayTitleCaptor.getValue()).isEqualTo("오늘은 결혼기념일입니다.");
+        assertThat(d7MessageCaptor.getValue()).isEqualTo("오늘부터 조금씩 마음을 준비해 보세요.");
+        assertThat(ddayMessageCaptor.getValue()).isEqualTo("오늘의 따뜻한 안녕을 전해보세요.");
     }
 }

--- a/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
+++ b/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -159,6 +160,7 @@ class AnniversaryNotificationListenerTest {
 
         assertThat(d7MessageCaptor.getValue()).isEqualTo("오늘부터 조금씩 마음을 준비해 보세요.");
         assertThat(ddayMessageCaptor.getValue()).isEqualTo("오늘의 따뜻한 안녕을 전해보세요.");
+        verify(aiService, times(2)).generateAnniversaryNotificationMessage(5L, "결혼기념일", "우리가 처음 만난 날");
     }
 
     @Test
@@ -274,6 +276,8 @@ class AnniversaryNotificationListenerTest {
                     .thenReturn(null);
 
             listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+
+            mockedResolver.verify(() -> AnniversaryOccurrenceResolver.resolveNextOccurrence(eq(anniversary), any(LocalDate.class)));
         }
 
         verifyNoInteractions(notificationTransactionService);

--- a/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
+++ b/src/test/java/com/umc/halo/global/ai/listener/AnniversaryNotificationListenerTest.java
@@ -254,6 +254,8 @@ class AnniversaryNotificationListenerTest {
 
         listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
 
+        verify(anniversaryRepository).findMemberIdById(1L);
+        verify(memberSettingRepository).findByMemberId(5L);
         verifyNoInteractions(notificationTransactionService);
     }
 
@@ -311,6 +313,96 @@ class AnniversaryNotificationListenerTest {
 
         assertThat(d7MessageCaptor.getValue()).isNull();
         assertThat(ddayMessageCaptor.getValue()).isNull();
+    }
+
+    @Test
+    void createNextNotification은_D7만_활성화되어_있으면_D7_메시지만_채운다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .anniversaryDate(LocalDate.now().plusDays(30))
+                .isRepeated(true)
+                .sevenDaysAlarmEnabled(true)
+                .dayAlarmEnabled(false)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+        given(anniversaryRepository.findMemberIdById(1L)).willReturn(Optional.of(5L));
+        given(memberSettingRepository.findByMemberId(5L)).willReturn(Optional.of(memberSetting));
+
+        listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+
+        ArgumentCaptor<String> d7MessageCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ddayMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(notificationTransactionService).saveOrUpdateBoth(
+                eq(anniversary), eq(memberSetting),
+                any(), d7MessageCaptor.capture(), any(),
+                any(), ddayMessageCaptor.capture(), any(),
+                any());
+
+        assertThat(d7MessageCaptor.getValue()).isEqualTo("오늘부터 조금씩 마음을 준비해 보세요.");
+        assertThat(ddayMessageCaptor.getValue()).isNull();
+    }
+
+    @Test
+    void createNextNotification은_DDay만_활성화되어_있으면_DDay_메시지만_채운다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .anniversaryDate(LocalDate.now().plusDays(30))
+                .isRepeated(true)
+                .sevenDaysAlarmEnabled(false)
+                .dayAlarmEnabled(true)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+        given(anniversaryRepository.findMemberIdById(1L)).willReturn(Optional.of(5L));
+        given(memberSettingRepository.findByMemberId(5L)).willReturn(Optional.of(memberSetting));
+
+        listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+
+        ArgumentCaptor<String> d7MessageCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ddayMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(notificationTransactionService).saveOrUpdateBoth(
+                eq(anniversary), eq(memberSetting),
+                any(), d7MessageCaptor.capture(), any(),
+                any(), ddayMessageCaptor.capture(), any(),
+                any());
+
+        assertThat(d7MessageCaptor.getValue()).isNull();
+        assertThat(ddayMessageCaptor.getValue()).isEqualTo("오늘의 따뜻한 안녕을 전해보세요.");
+    }
+
+    @Test
+    void createNextNotification은_D7_발생일이_이미_지났으면_DDay_메시지만_채운다() {
+        Anniversary anniversary = Anniversary.builder()
+                .id(1L)
+                .member(member)
+                .title("결혼기념일")
+                .anniversaryDate(LocalDate.now().plusDays(3))
+                .isRepeated(true)
+                .sevenDaysAlarmEnabled(true)
+                .dayAlarmEnabled(true)
+                .build();
+
+        given(anniversaryRepository.findById(1L)).willReturn(Optional.of(anniversary));
+        given(anniversaryRepository.findMemberIdById(1L)).willReturn(Optional.of(5L));
+        given(memberSettingRepository.findByMemberId(5L)).willReturn(Optional.of(memberSetting));
+
+        listener.createNextNotification(new CreateNextYearNotificationEvent(1L));
+
+        ArgumentCaptor<String> d7MessageCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ddayMessageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(notificationTransactionService).saveOrUpdateBoth(
+                eq(anniversary), eq(memberSetting),
+                any(), d7MessageCaptor.capture(), any(),
+                any(), ddayMessageCaptor.capture(), any(),
+                any());
+
+        assertThat(d7MessageCaptor.getValue()).isNull();
+        assertThat(ddayMessageCaptor.getValue()).isEqualTo("오늘의 따뜻한 안녕을 전해보세요.");
     }
 
     @Test

--- a/src/test/java/com/umc/halo/global/config/AsyncConfigTest.java
+++ b/src/test/java/com/umc/halo/global/config/AsyncConfigTest.java
@@ -1,0 +1,43 @@
+package com.umc.halo.global.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * AsyncConfig.asyncExecutor()가 application.yml의 async.executor.* 설정값대로
+ * ThreadPoolTaskExecutor를 만드는지, 거부 정책이 CallerRunsPolicy인지 검증.
+ * @Value로 주입되는 파라미터는 메서드를 직접 호출하면서 리터럴 값으로 대체한다
+ * (Spring 컨테이너 없이도 순수 자바 메서드 호출로 테스트 가능).
+ */
+class AsyncConfigTest {
+
+    private final AsyncConfig asyncConfig = new AsyncConfig();
+
+    @Test
+    void asyncExecutor는_설정값대로_스레드풀_속성을_구성한다() {
+        ThreadPoolTaskExecutor executor = asyncConfig.asyncExecutor(4, 8, 50, 60, 20);
+
+        assertThat(executor.getCorePoolSize()).isEqualTo(4);
+        assertThat(executor.getMaxPoolSize()).isEqualTo(8);
+        assertThat(executor.getQueueCapacity()).isEqualTo(50);
+        assertThat(executor.getKeepAliveSeconds()).isEqualTo(60);
+        assertThat(executor.getThreadNamePrefix()).isEqualTo("halo-async-");
+    }
+
+    @Test
+    void asyncExecutor는_큐가_가득_차면_호출_스레드가_직접_실행하는_CallerRunsPolicy를_쓴다() {
+        ThreadPoolTaskExecutor executor = asyncConfig.asyncExecutor(4, 8, 50, 60, 20);
+        executor.initialize();
+
+        try {
+            assertThat(executor.getThreadPoolExecutor().getRejectedExecutionHandler())
+                    .isInstanceOf(ThreadPoolExecutor.CallerRunsPolicy.class);
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/src/test/java/com/umc/halo/global/config/AsyncConfigTest.java
+++ b/src/test/java/com/umc/halo/global/config/AsyncConfigTest.java
@@ -2,6 +2,7 @@ package com.umc.halo.global.config;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -25,6 +26,7 @@ class AsyncConfigTest {
         assertThat(executor.getMaxPoolSize()).isEqualTo(8);
         assertThat(executor.getQueueCapacity()).isEqualTo(50);
         assertThat(executor.getKeepAliveSeconds()).isEqualTo(60);
+        assertThat((Long) ReflectionTestUtils.getField(executor, "awaitTerminationMillis")).isEqualTo(20_000L);
         assertThat(executor.getThreadNamePrefix()).isEqualTo("halo-async-");
     }
 


### PR DESCRIPTION
## 📝 작업 내용

AI 응답을 비동기로 처리하는 리스너와 실행기(Executor) 설정에 대한 테스트를 보강했습니다.

- AsyncConfig의 asyncExecutor 빈이 설정값대로 스레드풀을 구성하는지 검증
- AnniversaryNotificationListener의 createNotificationMessage가 AI 호출/예외 처리를 올바르게 하는지 검증
- AnniversaryNotificationListener.createNextNotification의 각 분기(반복 아님/회원설정 없음/알림 비활성화/정상 케이스)를 검증
- 리플렉션으로 리스너 메서드들에 @Async가 실제로 붙어있는지 구조적으로 고정

---

## 🔧 변경 사항

- `AsyncConfigTest` 신규 작성 — asyncExecutor 빈의 corePoolSize/maxPoolSize/keepAlive/큐 용량/거부 정책(CallerRunsPolicy) 검증
- `AnniversaryNotificationListenerTest` 보강
  - 메모가 있을 때 AI가 생성한 문구를 사용하는지
  - AI 호출이 실패하면 기본 문구로 폴백하는지
  - `createNextNotification`의 4가지 분기 조건 검증
- `TransactionBoundaryTest`에 `외부_호출을_포함한_메서드는_Async여야_한다` 팩토리 테스트 추가 — 이벤트 리스너 5개(ImageFinalizeListener.handle, ChapterSummaryListener.generateSummary, AnniversaryNotificationListener의 3개 메서드)에 @Async 존재 여부 검증
  - 기존 `외부_호출을_포함한_메서드는_트랜잭션이_없어야_한다`가 쓰던 메서드 목록에 `createNextNotification`이 빠져있어 같이 추가

---

## 🧪 테스트 결과

```
./gradlew test --tests "*.AsyncConfigTest" --tests "*.AnniversaryNotificationListenerTest" --tests "*.TransactionBoundaryTest"
BUILD SUCCESSFUL
```

기존 테스트 회귀 없음 확인.

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [x] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #297

---

## 📌 참고 사항

- `TransactionBoundaryTest`는 여러 도메인의 트랜잭션 경계를 한 파일에서 구조적으로 고정하는 공용 테스트라, 리뷰 시 이 파일의 다른 테스트에 영향 없는지 같이 봐주시면 좋을 것 같습니다.
- TransactionBoundaryTest의 @Async 검증에 ImageFinalizeListener.handle도 포함했습니다. 이슈 #297에 명시된 범위는 아니지만, 같은 파일에서 이미 검증 중인 "외부 호출 포함 메서드는 @Async여야 한다" 구조 검증을 이벤트 리스너 전체에 일관되게 적용하기 위함입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **테스트**
  * 이벤트 리스너 메서드의 비동기 실행 여부를 검증하는 테스트를 추가했습니다.
  * 기념일 알림의 생성·수정·후속 알림 처리와 AI 문구 적용 및 실패 시 기본 문구 전환을 검증합니다.
  * 반복 여부, 회원 설정, 다음 발생일, 알림 활성화 상태에 따른 알림 처리 동작을 검증합니다.
  * 다음 기념일 발생일이 없을 때 후속 알림을 생성하지 않는 동작을 검증합니다.
  * 비동기 실행기의 스레드 풀 속성, 스레드 이름, 작업 거부 정책 및 대기 시간을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->