### PR TITLE
[test] 전역 예외 처리 테스트 작성

### DIFF
--- a/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
+++ b/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
@@ -15,13 +15,19 @@ import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.validation.method.ParameterValidationResult;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -157,5 +163,84 @@ class GeneralExceptionAdviceTest {
         @SuppressWarnings("unchecked")
         Map<String, String> errors = (Map<String, String>) body.getResult();
         assertThat(errors).containsEntry("size", "size는 양수여야 합니다.");
+    }
+
+    @Test
+    void handleHttpMessageNotReadable는_BAD_REQUEST와_고정_메시지로_응답한다() {
+        HttpMessageNotReadableException ex = mock(HttpMessageNotReadableException.class);
+        when(ex.getCause()).thenReturn(new RuntimeException("Unexpected character"));
+
+        ResponseEntity<Object> response = advice.handleHttpMessageNotReadable(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getResult()).isEqualTo("요청 Body 형식이 잘못되었습니다.");
+    }
+
+    @Test
+    void handleMissingServletRequestParameter는_BAD_REQUEST로_응답한다() {
+        MissingServletRequestParameterException ex = mock(MissingServletRequestParameterException.class);
+        when(ex.getMessage()).thenReturn("Required request parameter 'page' is not present");
+
+        ResponseEntity<Object> response = advice.handleMissingServletRequestParameter(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo(GeneralErrorCode.BAD_REQUEST.getCode());
+    }
+
+    @Test
+    void handleHttpMediaTypeNotSupported는_UNSUPPORTED_MEDIA_TYPE으로_응답한다() {
+        HttpMediaTypeNotSupportedException ex = mock(HttpMediaTypeNotSupportedException.class);
+        when(ex.getMessage()).thenReturn("Content-Type 'text/plain' is not supported");
+
+        ResponseEntity<Object> response = advice.handleHttpMediaTypeNotSupported(
+                ex, HttpHeaders.EMPTY, HttpStatus.UNSUPPORTED_MEDIA_TYPE, mock(WebRequest.class));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo(GeneralErrorCode.UNSUPPORTED_MEDIA_TYPE.getCode());
+    }
+
+    @Test
+    void handleHttpRequestMethodNotSupported는_METHOD_NOT_ALLOWED로_응답한다() {
+        HttpRequestMethodNotSupportedException ex = mock(HttpRequestMethodNotSupportedException.class);
+        when(ex.getMessage()).thenReturn("Request method 'DELETE' is not supported");
+
+        ResponseEntity<Object> response = advice.handleHttpRequestMethodNotSupported(
+                ex, HttpHeaders.EMPTY, HttpStatus.METHOD_NOT_ALLOWED, mock(WebRequest.class));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo(GeneralErrorCode.METHOD_NOT_ALLOWED.getCode());
+    }
+
+    @Test
+    void handleTypeMismatch은_MethodArgumentTypeMismatchException이면_BAD_REQUEST로_응답한다() {
+        MethodArgumentTypeMismatchException ex = mock(MethodArgumentTypeMismatchException.class);
+        when(ex.getValue()).thenReturn("abc");
+        when(ex.getName()).thenReturn("page");
+
+        ResponseEntity<Object> response = advice.handleTypeMismatch(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo(GeneralErrorCode.BAD_REQUEST.getCode());
+    }
+
+    @Test
+    void handleNoResourceFoundException은_NOT_FOUND로_응답한다() {
+        NoResourceFoundException ex = mock(NoResourceFoundException.class);
+        when(ex.getMessage()).thenReturn("No static resource no-such-path.");
+
+        ResponseEntity<Object> response = advice.handleNoResourceFoundException(
+                ex, HttpHeaders.EMPTY, HttpStatus.NOT_FOUND, mock(WebRequest.class));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo(GeneralErrorCode.NOT_FOUND.getCode());
     }
 }

--- a/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
+++ b/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
@@ -12,6 +12,7 @@ import jakarta.validation.Path;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.core.MethodParameter;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +31,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.lang.reflect.Method;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -242,5 +244,50 @@ class GeneralExceptionAdviceTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         ApiResponse<?> body = (ApiResponse<?>) response.getBody();
         assertThat(body.getCode()).isEqualTo(GeneralErrorCode.NOT_FOUND.getCode());
+    }
+
+    @Test
+    void handleDataIntegrityViolationException은_유니크_제약_위반시_CONFLICT로_응답하고_DB_상세정보를_노출하지_않는다() {
+        SQLException sqlException = new SQLException("Duplicate entry 'test@test.com' for key 'uk_email'", "23000", 1062);
+        DataIntegrityViolationException ex = new DataIntegrityViolationException("could not execute statement", sqlException);
+
+        ResponseEntity<Object> response = advice.handleDataIntegrityViolationException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(GeneralErrorCode.CONFLICT.getStatus());
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo(GeneralErrorCode.CONFLICT.getCode());
+        assertThat(body.getResult()).isNull();
+    }
+
+    @Test
+    void handleDataIntegrityViolationException은_원인이_없어도_CONFLICT로_응답한다() {
+        DataIntegrityViolationException ex = new DataIntegrityViolationException("제약 조건 위반");
+
+        ResponseEntity<Object> response = advice.handleDataIntegrityViolationException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(GeneralErrorCode.CONFLICT.getStatus());
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getResult()).isNull();
+    }
+
+    @Test
+    void handleExceptionInternal은_4xx여도_5xx여도_같은_UNHANDLED_포맷으로_응답한다() {
+        Exception ex4xx = new IllegalStateException("잘못된 요청 상태");
+        Exception ex5xx = new IllegalStateException("서버 처리 실패");
+
+        ResponseEntity<Object> response4xx = advice.handleExceptionInternal(
+                ex4xx, null, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class));
+        ResponseEntity<Object> response5xx = advice.handleExceptionInternal(
+                ex5xx, null, HttpHeaders.EMPTY, HttpStatus.INTERNAL_SERVER_ERROR, mock(WebRequest.class));
+
+        ApiResponse<?> body4xx = (ApiResponse<?>) response4xx.getBody();
+        ApiResponse<?> body5xx = (ApiResponse<?>) response5xx.getBody();
+
+        assertThat(response4xx.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response5xx.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(body4xx.getCode()).isEqualTo("UNHANDLED_IllegalStateException");
+        assertThat(body5xx.getCode()).isEqualTo("UNHANDLED_IllegalStateException");
+        assertThat(body4xx.getMessage()).isEqualTo("요청을 처리할 수 없습니다.");
+        assertThat(body5xx.getMessage()).isEqualTo("요청을 처리할 수 없습니다.");
     }
 }

--- a/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
+++ b/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
@@ -6,15 +6,37 @@ import com.umc.halo.global.ai.exception.code.AiErrorCode;
 import com.umc.halo.global.apiPayload.ApiResponse;
 import com.umc.halo.global.apiPayload.code.GeneralErrorCode;
 import com.umc.halo.global.apiPayload.exception.ProjectException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.method.ParameterValidationResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GeneralExceptionAdviceTest {
 
     private final GeneralExceptionAdvice advice = new GeneralExceptionAdvice();
+
+    private void dummyTarget(String title) {}
 
     @Test
     void handleProjectException은_AnniversaryErrorCode를_그대로_응답에_담는다() {
@@ -61,5 +83,79 @@ class GeneralExceptionAdviceTest {
         assertThat(body.getCode()).isEqualTo(GeneralErrorCode.INTERNAL_SERVER_ERROR.getCode());
         assertThat(body.getMessage()).isEqualTo("서버 내부 오류가 발생했습니다.");
         assertThat(body.getMessage()).doesNotContain("DB 연결 실패");
+    }
+
+    @Test
+    void handleConstraintViolationException은_필드명과_메시지를_추출해서_담는다() {
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        Path path = mock(Path.class);
+        when(path.toString()).thenReturn("getAnniversary.id");
+        when(violation.getPropertyPath()).thenReturn(path);
+        when(violation.getMessage()).thenReturn("양수여야 합니다.");
+
+        ConstraintViolationException ex = new ConstraintViolationException(Set.of(violation));
+
+        ResponseEntity<Object> response = advice.handleConstraintViolationException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        @SuppressWarnings("unchecked")
+        Map<String, String> errors = (Map<String, String>) body.getResult();
+        assertThat(errors).containsEntry("id", "양수여야 합니다.");
+    }
+
+    @Test
+    void handleBindException은_필드_에러를_추출해서_담는다() {
+        BindException ex = new BindException(new Object(), "anniversaryReq");
+        ex.getBindingResult().addError(new FieldError("anniversaryReq", "title", "제목은 필수입니다."));
+
+        ResponseEntity<Object> response = advice.handleBindException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        @SuppressWarnings("unchecked")
+        Map<String, String> errors = (Map<String, String>) body.getResult();
+        assertThat(errors).containsEntry("title", "제목은 필수입니다.");
+    }
+
+    @Test
+    void handleMethodArgumentNotValid는_필드_에러를_추출해서_담는다() throws NoSuchMethodException {
+        Method dummyMethod = GeneralExceptionAdviceTest.class.getDeclaredMethod("dummyTarget", String.class);
+        MethodParameter parameter = new MethodParameter(dummyMethod, 0);
+        BeanPropertyBindingResult bindingResult = new BeanPropertyBindingResult(new Object(), "request");
+        bindingResult.addError(new FieldError("request", "title", "제목은 필수입니다."));
+        MethodArgumentNotValidException ex = new MethodArgumentNotValidException(parameter, bindingResult);
+
+        ResponseEntity<Object> response = advice.handleMethodArgumentNotValid(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        @SuppressWarnings("unchecked")
+        Map<String, String> errors = (Map<String, String>) body.getResult();
+        assertThat(errors).containsEntry("title", "제목은 필수입니다.");
+    }
+
+    @Test
+    void handleHandlerMethodValidationException은_파라미터별_에러_메시지를_담는다() {
+        HandlerMethodValidationException ex = mock(HandlerMethodValidationException.class);
+        ParameterValidationResult result = mock(ParameterValidationResult.class);
+        MethodParameter parameter = mock(MethodParameter.class);
+
+        when(ex.getParameterValidationResults()).thenReturn(List.of(result));
+        when(result.getMethodParameter()).thenReturn(parameter);
+        when(parameter.getParameterName()).thenReturn("size");
+        when(result.getResolvableErrors()).thenReturn(List.of(
+                new DefaultMessageSourceResolvable(new String[]{"size"}, "size는 양수여야 합니다.")
+        ));
+
+        ResponseEntity<Object> response = advice.handleHandlerMethodValidationException(
+                ex, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, mock(WebRequest.class));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        @SuppressWarnings("unchecked")
+        Map<String, String> errors = (Map<String, String>) body.getResult();
+        assertThat(errors).containsEntry("size", "size는 양수여야 합니다.");
     }
 }

--- a/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
+++ b/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
@@ -91,6 +91,7 @@ class GeneralExceptionAdviceTest {
         assertThat(body.getCode()).isEqualTo(GeneralErrorCode.INTERNAL_SERVER_ERROR.getCode());
         assertThat(body.getMessage()).isEqualTo("서버 내부 오류가 발생했습니다.");
         assertThat(body.getMessage()).doesNotContain("DB 연결 실패");
+        assertThat(body.getResult()).isNull();
     }
 
     @Test
@@ -257,6 +258,7 @@ class GeneralExceptionAdviceTest {
         ApiResponse<?> body = (ApiResponse<?>) response.getBody();
         assertThat(body.getCode()).isEqualTo(GeneralErrorCode.CONFLICT.getCode());
         assertThat(body.getResult()).isNull();
+        assertThat(body.getMessage()).doesNotContain("test@test.com", "23000", "1062");
     }
 
     @Test
@@ -289,5 +291,7 @@ class GeneralExceptionAdviceTest {
         assertThat(body5xx.getCode()).isEqualTo("UNHANDLED_IllegalStateException");
         assertThat(body4xx.getMessage()).isEqualTo("요청을 처리할 수 없습니다.");
         assertThat(body5xx.getMessage()).isEqualTo("요청을 처리할 수 없습니다.");
+        assertThat(body4xx.getResult()).isNull();
+        assertThat(body5xx.getResult()).isNull();
     }
 }

--- a/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
+++ b/src/test/java/com/umc/halo/global/apiPayload/handler/GeneralExceptionAdviceTest.java
@@ -1,0 +1,65 @@
+package com.umc.halo.global.apiPayload.handler;
+
+import com.umc.halo.domain.notification.exception.code.AnniversaryErrorCode;
+import com.umc.halo.domain.setting.exception.code.SettingErrorCode;
+import com.umc.halo.global.ai.exception.code.AiErrorCode;
+import com.umc.halo.global.apiPayload.ApiResponse;
+import com.umc.halo.global.apiPayload.code.GeneralErrorCode;
+import com.umc.halo.global.apiPayload.exception.ProjectException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GeneralExceptionAdviceTest {
+
+    private final GeneralExceptionAdvice advice = new GeneralExceptionAdvice();
+
+    @Test
+    void handleProjectException은_AnniversaryErrorCode를_그대로_응답에_담는다() {
+        ProjectException ex = new ProjectException(AnniversaryErrorCode.ANNIVERSARY_NOT_FOUND);
+
+        ResponseEntity<ApiResponse<Void>> response = advice.handleProjectException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody().getCode()).isEqualTo("ANNIVERSARY404_1");
+        assertThat(response.getBody().getMessage()).isEqualTo("존재하지 않는 기념일입니다.");
+        assertThat(response.getBody().isSuccess()).isFalse();
+    }
+
+    @Test
+    void handleProjectException은_SettingErrorCode를_그대로_응답에_담는다() {
+        ProjectException ex = new ProjectException(SettingErrorCode.SETTING_NOT_FOUND);
+
+        ResponseEntity<ApiResponse<Void>> response = advice.handleProjectException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody().getCode()).isEqualTo("SETTING404_1");
+        assertThat(response.getBody().getMessage()).isEqualTo("설정을 찾을 수 없습니다.");
+    }
+
+    @Test
+    void handleProjectException은_AiErrorCode를_그대로_응답에_담는다() {
+        ProjectException ex = new ProjectException(AiErrorCode.AI_RATE_LIMIT_EXCEEDED);
+
+        ResponseEntity<ApiResponse<Void>> response = advice.handleProjectException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.getBody().getCode()).isEqualTo("AI429_1");
+        assertThat(response.getBody().getMessage()).isEqualTo("AI 요청 횟수를 초과했습니다. 한도 갱신 후 다시 시도해주세요.");
+    }
+
+    @Test
+    void handleUnexpectedException은_500과_원인_미노출_메시지로_응답한다() {
+        Exception ex = new RuntimeException("내부 DB 연결 실패 상세 정보");
+
+        ResponseEntity<Object> response = advice.handleUnexpectedException(ex);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        ApiResponse<?> body = (ApiResponse<?>) response.getBody();
+        assertThat(body.getCode()).isEqualTo(GeneralErrorCode.INTERNAL_SERVER_ERROR.getCode());
+        assertThat(body.getMessage()).isEqualTo("서버 내부 오류가 발생했습니다.");
+        assertThat(body.getMessage()).doesNotContain("DB 연결 실패");
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

GeneralExceptionAdvice에 대한 테스트가 하나도 없어서, 예외 종류별 상태코드/에러코드 매핑이 깨져도 잡아낼 방법이 없던 상태를 해결하기 위해 GeneralExceptionAdviceTest를 신규 작성했습니다.

---

## 🔧 변경 사항

- `GeneralExceptionAdviceTest` 신규 작성 (총 17개 테스트)
  - `handleProjectException` — AnniversaryErrorCode/SettingErrorCode/AiErrorCode 각각 상태코드/코드/메시지가 응답에 그대로 실리는지 검증
  - `handleUnexpectedException` — 미처리 Exception은 500 + 원인 미노출
  - `handleConstraintViolationException`, `handleBindException`, `handleMethodArgumentNotValid`, `handleHandlerMethodValidationException` — 필드별 에러 메시지가 올바른 키로 담기는지 검증
  - `handleHttpMessageNotReadable`, `handleMissingServletRequestParameter`, `handleHttpMediaTypeNotSupported`, `handleHttpRequestMethodNotSupported`, `handleTypeMismatch`, `handleNoResourceFoundException` — 각각 매핑된 상태코드로 응답하는지 검증
  - `handleDataIntegrityViolationException` — 유니크 제약 위반 시 409 + DB 상세정보 미노출
  - `handleExceptionInternal` — 4xx/5xx 로그레벨과 무관하게 응답 바디는 `UNHANDLED_*` 코드로 통일되는지 검증

---

## 🧪 테스트 결과

```
./gradlew test --tests "*.GeneralExceptionAdviceTest"
BUILD SUCCESSFUL
```

---

## ✅ 확인 사항

- [x] 서버 정상 기동 확인
- [x] 담당 기능(API) 정상 동작 확인
- [x] 테스트 코드 작성 및 통과 (해당하는 경우)
- [x] develop 최신화 후 충돌 없음 확인

---

## 🔗 관련 이슈

close #299

---

## 📌 참고 사항

- 대상 파일: `GeneralExceptionAdvice`, `ProjectException`, `BaseErrorCode`, `GeneralErrorCode`
- Advice와 같은 패키지에 테스트를 둬서 protected 오버라이드 메서드(`handleMethodArgumentNotValid` 등)를 리플렉션 없이 직접 호출
- 실제 HTTP 요청 없이 예외 객체를 직접 생성하거나, 생성이 까다로운 것들은 mock으로 필요한 메서드만 스텁해서 MockMvc 없이 순수 단위테스트로 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **테스트**
  - 예외 처리 시 HTTP 상태 코드, 오류 코드, 메시지 및 결과 형식을 검증하는 테스트를 추가했습니다.
  - 입력값 검증, 요청 형식 오류, 리소스 미발견, 데이터 무결성 위반 등 다양한 예외 상황을 확인합니다.
  - 예상치 못한 오류 및 데이터베이스 상세 정보가 사용자에게 노출되지 않는지 검증합니다.
  - 4xx·5xx 공통 오류 응답 형식과 필드별 검증 오류 추출을 확인합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->